### PR TITLE
Bug Fix: RegoCachedProviderTesting.ps1 file paths

### DIFF
--- a/Testing/Functional/RegoCachedProviderTesting.ps1
+++ b/Testing/Functional/RegoCachedProviderTesting.ps1
@@ -55,21 +55,7 @@ $RunCachedParams = @{
     'Quiet' = $Quiet;
 }
 
-function Get-Root {
-    param (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [String]$location
-    )
-
-    if($(Split-Path -Path $location | Split-Path -Leaf) -contains 'ScubaGear') {
-        return Split-Path -Path $location
-    }
-
-    return Get-Root $(Split-Path -Path $location)
-}
-
-Set-Location $(Get-Root  $PSScriptRoot)
+Set-Location $(Split-Path -Path $PSScriptRoot | Split-Path)
 $ManifestPath = Join-Path -Path "./PowerShell" -ChildPath "ScubaGear"
 Remove-Module "ScubaGear" -ErrorAction "SilentlyContinue" # For dev work
 #######

--- a/Testing/Functional/RegoCachedProviderTesting.ps1
+++ b/Testing/Functional/RegoCachedProviderTesting.ps1
@@ -55,8 +55,7 @@ $RunCachedParams = @{
     'Quiet' = $Quiet;
 }
 
-$Root = @((Get-ChildItem -Recurse -Filter CISA-SCuBA-M365-SCB -Directory -ErrorAction SilentlyContinue -Path $Home).FullName)
-Set-Location $Root[0]
+Set-Location $(Split-Path -Path $pwd)
 $ManifestPath = Join-Path -Path "./PowerShell" -ChildPath "ScubaGear"
 Remove-Module "ScubaGear" -ErrorAction "SilentlyContinue" # For dev work
 #######

--- a/Testing/Functional/RegoCachedProviderTesting.ps1
+++ b/Testing/Functional/RegoCachedProviderTesting.ps1
@@ -69,7 +69,7 @@ function Get-Root {
     return Get-Root $(Split-Path -Path $location)
 }
 
-Set-Location $(Get-Root $pwd)
+Set-Location $(Get-Root  $PSScriptRoot)
 $ManifestPath = Join-Path -Path "./PowerShell" -ChildPath "ScubaGear"
 Remove-Module "ScubaGear" -ErrorAction "SilentlyContinue" # For dev work
 #######

--- a/Testing/Functional/RegoCachedProviderTesting.ps1
+++ b/Testing/Functional/RegoCachedProviderTesting.ps1
@@ -55,7 +55,21 @@ $RunCachedParams = @{
     'Quiet' = $Quiet;
 }
 
-Set-Location $(Split-Path -Path $pwd)
+function Get-Root {
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String]$location
+    )
+
+    if($(Split-Path -Path $location | Split-Path -Leaf) -eq 'ScubaGear') {
+        return Split-Path -Path $location
+    }
+
+    return Get-Root $(Split-Path -Path $location)
+}
+
+Set-Location $(Get-Root $pwd)
 $ManifestPath = Join-Path -Path "./PowerShell" -ChildPath "ScubaGear"
 Remove-Module "ScubaGear" -ErrorAction "SilentlyContinue" # For dev work
 #######

--- a/Testing/Functional/RegoCachedProviderTesting.ps1
+++ b/Testing/Functional/RegoCachedProviderTesting.ps1
@@ -62,7 +62,7 @@ function Get-Root {
         [String]$location
     )
 
-    if($(Split-Path -Path $location | Split-Path -Leaf) -eq 'ScubaGear') {
+    if($(Split-Path -Path $location | Split-Path -Leaf) -contains 'ScubaGear') {
         return Split-Path -Path $location
     }
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

RegoCachedProviderTesting does not set location as expected when user has multiple instances of SCuBAGear.

## 💭 Motivation and context ##

The directory search function in line 58 was removed as it does not behave as expected when the user has multiple instances of SCuBAGear on their device. The set location was changed to only move up on folder with Split-Path to be in the correct file path for Invoke-SCuBA & still in the same instance.
Closing #106 

## 🧪 Testing ##

- `.\RunFunctionalTests.ps1 -p aad`
- Run above command when multiple instances of SCuBAGear & only 1 instance exists on device
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Add a tag or create a release.
