### PR TITLE
Updated OneDrive 2.3 policy 

### DIFF
--- a/Rego/OneDriveConfig.rego
+++ b/Rego/OneDriveConfig.rego
@@ -117,6 +117,11 @@ ReportDetails2_3(Policy) = Description if {
 	Description := "Requirement not met: files are not limited to view for Anyone"
 }
 
+ReportDetails2_3(Policy) = Description if {
+    Policy.DefaultLinkPermission == 2
+	Description := "Requirement not met: link permission is not limited to view"
+}
+
 tests[{
     "Requirement" : "Anyone link permissions SHOULD be limited to View",
     "Control" : "OneDrive 2.3",

--- a/Rego/OneDriveConfig.rego
+++ b/Rego/OneDriveConfig.rego
@@ -92,7 +92,8 @@ tests[{
 DefaultLinkPermissionPolicy[Policy]{
     Policy := input.SPO_tenant_info[_]
     Policy.DefaultLinkPermission == 1
-    Policy.OneDriveSharingCapability == 1
+    Policy.FileAnonymousLinkType == 1
+    Policy.FolderAnonymousLinkType == 1
 }
 
 tests[{

--- a/Rego/OneDriveConfig.rego
+++ b/Rego/OneDriveConfig.rego
@@ -90,40 +90,44 @@ tests[{
 # Baseline 2.3: Policy 1
 #--
 ReportDetails2_3(Policy) = Description if {
+    Policy.DefaultLinkPermission == 1
     Policy.FileAnonymousLinkType == 1
     Policy.FolderAnonymousLinkType == 1
 	Description := "Requirement met"
 }
 
 ReportDetails2_3(Policy) = Description if {
+    Policy.DefaultLinkPermission == 1
     Policy.FileAnonymousLinkType == 2
     Policy.FolderAnonymousLinkType == 2
-	Description := "Requirement not met: both file and folder are not limited to view for Anyone"
+	Description := "Requirement not met: both files and folders are not limited to view for Anyone"
 }
 
 ReportDetails2_3(Policy) = Description if {
+    Policy.DefaultLinkPermission == 1
     Policy.FileAnonymousLinkType == 1
     Policy.FolderAnonymousLinkType == 2
-	Description := "Requirement not met: folder are not limited to view for Anyone"
+	Description := "Requirement not met: folders are not limited to view for Anyone"
 }
 
 ReportDetails2_3(Policy) = Description if {
+    Policy.DefaultLinkPermission == 1
     Policy.FileAnonymousLinkType == 2
     Policy.FolderAnonymousLinkType == 1
 	Description := "Requirement not met: files are not limited to view for Anyone"
 }
 
 tests[{
-    "Requirement" : "Anyone file and folder permissions SHOULD be limited to View",
+    "Requirement" : "Anyone link permissions SHOULD be limited to View",
     "Control" : "OneDrive 2.3",
     "Criticality" : "Should",
     "Commandlet" : ["Get-SPOTenant"],
-    "ActualValue" : [Policy.FileAnonymousLinkType, Policy.FolderAnonymousLinkType],
+    "ActualValue" : [Policy.DefaultLinkPermission, Policy.FileAnonymousLinkType, Policy.FolderAnonymousLinkType],
     "ReportDetails" : ReportDetails2_3(Policy),
     "RequirementMet" : Status
 }] {
     Policy := input.SPO_tenant_info[_]
-	Conditions := [Policy.FileAnonymousLinkType == 1, Policy.FolderAnonymousLinkType == 1]
+	Conditions := [Policy.DefaultLinkPermission == 1, Policy.FileAnonymousLinkType == 1, Policy.FolderAnonymousLinkType == 1]
     Status := count([Condition | Condition = Conditions[_]; Condition == false]) == 0
 }
 #--

--- a/Rego/OneDriveConfig.rego
+++ b/Rego/OneDriveConfig.rego
@@ -92,6 +92,7 @@ tests[{
 DefaultLinkPermissionPolicy[Policy]{
     Policy := input.SPO_tenant_info[_]
     Policy.DefaultLinkPermission == 1
+    Policy.OneDriveSharingCapability == 1
 }
 
 tests[{

--- a/Rego/OneDriveConfig.rego
+++ b/Rego/OneDriveConfig.rego
@@ -90,35 +90,35 @@ tests[{
 # Baseline 2.3: Policy 1
 #--
 ReportDetails2_3(Policy) = Description if {
-    Policy.DefaultLinkPermission == 1
+    Policy.DeafultSharingLinkType == 1
     Policy.FileAnonymousLinkType == 1
     Policy.FolderAnonymousLinkType == 1
 	Description := "Requirement met"
 }
 
 ReportDetails2_3(Policy) = Description if {
-    Policy.DefaultLinkPermission == 1
+    Policy.DeafultSharingLinkType == 1
     Policy.FileAnonymousLinkType == 2
     Policy.FolderAnonymousLinkType == 2
 	Description := "Requirement not met: both files and folders are not limited to view for Anyone"
 }
 
 ReportDetails2_3(Policy) = Description if {
-    Policy.DefaultLinkPermission == 1
+    Policy.DeafultSharingLinkType == 1
     Policy.FileAnonymousLinkType == 1
     Policy.FolderAnonymousLinkType == 2
 	Description := "Requirement not met: folders are not limited to view for Anyone"
 }
 
 ReportDetails2_3(Policy) = Description if {
-    Policy.DefaultLinkPermission == 1
+    Policy.DeafultSharingLinkType == 1
     Policy.FileAnonymousLinkType == 2
     Policy.FolderAnonymousLinkType == 1
 	Description := "Requirement not met: files are not limited to view for Anyone"
 }
 
 ReportDetails2_3(Policy) = Description if {
-    Policy.DefaultLinkPermission == 2
+    Policy.DeafultSharingLinkType == 2
 	Description := "Requirement not met: link permission is not limited to view"
 }
 
@@ -127,12 +127,12 @@ tests[{
     "Control" : "OneDrive 2.3",
     "Criticality" : "Should",
     "Commandlet" : ["Get-SPOTenant"],
-    "ActualValue" : [Policy.DefaultLinkPermission, Policy.FileAnonymousLinkType, Policy.FolderAnonymousLinkType],
+    "ActualValue" : [Policy.DeafultSharingLinkType, Policy.FileAnonymousLinkType, Policy.FolderAnonymousLinkType],
     "ReportDetails" : ReportDetails2_3(Policy),
     "RequirementMet" : Status
 }] {
     Policy := input.SPO_tenant_info[_]
-	Conditions := [Policy.DefaultLinkPermission == 1, Policy.FileAnonymousLinkType == 1, Policy.FolderAnonymousLinkType == 1]
+	Conditions := [Policy.DeafultSharingLinkType == 1, Policy.FileAnonymousLinkType == 1, Policy.FolderAnonymousLinkType == 1]
     Status := count([Condition | Condition = Conditions[_]; Condition == false]) == 0
 }
 #--

--- a/Rego/OneDriveConfig.rego
+++ b/Rego/OneDriveConfig.rego
@@ -119,7 +119,7 @@ ReportDetails2_3(Policy) = Description if {
 
 ReportDetails2_3(Policy) = Description if {
     Policy.DefaultSharingLinkType == 3
-	Description := "Requirement not met: link permission is not limited to view"
+	Description := "Requirement not met: default link sharing type is set to Anyone with link"
 }
 
 tests[{

--- a/Rego/OneDriveConfig.rego
+++ b/Rego/OneDriveConfig.rego
@@ -89,24 +89,42 @@ tests[{
 #
 # Baseline 2.3: Policy 1
 #--
-DefaultLinkPermissionPolicy[Policy]{
-    Policy := input.SPO_tenant_info[_]
-    Policy.DefaultLinkPermission == 1
+ReportDetails2_3(Policy) = Description if {
     Policy.FileAnonymousLinkType == 1
     Policy.FolderAnonymousLinkType == 1
+	Description := "Requirement met"
+}
+
+ReportDetails2_3(Policy) = Description if {
+    Policy.FileAnonymousLinkType == 2
+    Policy.FolderAnonymousLinkType == 2
+	Description := "Requirement not met: both file and folder are not limited to view for Anyone"
+}
+
+ReportDetails2_3(Policy) = Description if {
+    Policy.FileAnonymousLinkType == 1
+    Policy.FolderAnonymousLinkType == 2
+	Description := "Requirement not met: folder are not limited to view for Anyone"
+}
+
+ReportDetails2_3(Policy) = Description if {
+    Policy.FileAnonymousLinkType == 2
+    Policy.FolderAnonymousLinkType == 1
+	Description := "Requirement not met: files are not limited to view for Anyone"
 }
 
 tests[{
-    "Requirement" : "Anyone link permissions SHOULD be limited to View",
+    "Requirement" : "Anyone file and folder permissions SHOULD be limited to View",
     "Control" : "OneDrive 2.3",
     "Criticality" : "Should",
     "Commandlet" : ["Get-SPOTenant"],
-    "ActualValue" : Policies,
-    "ReportDetails" : ReportDetailsBoolean(Status),
+    "ActualValue" : [Policy.FileAnonymousLinkType, Policy.FolderAnonymousLinkType],
+    "ReportDetails" : ReportDetails2_3(Policy),
     "RequirementMet" : Status
 }] {
-    Policies := DefaultLinkPermissionPolicy
-    Status := count(Policies) == 1
+    Policy := input.SPO_tenant_info[_]
+	Conditions := [Policy.FileAnonymousLinkType == 1, Policy.FolderAnonymousLinkType == 1]
+    Status := count([Condition | Condition = Conditions[_]; Condition == false]) == 0
 }
 #--
 

--- a/Rego/OneDriveConfig.rego
+++ b/Rego/OneDriveConfig.rego
@@ -90,35 +90,35 @@ tests[{
 # Baseline 2.3: Policy 1
 #--
 ReportDetails2_3(Policy) = Description if {
-    Policy.DeafultSharingLinkType == 1
+    Policy.DefaultSharingLinkType != 3
     Policy.FileAnonymousLinkType == 1
     Policy.FolderAnonymousLinkType == 1
 	Description := "Requirement met"
 }
 
 ReportDetails2_3(Policy) = Description if {
-    Policy.DeafultSharingLinkType == 1
+    Policy.DefaultSharingLinkType != 3
     Policy.FileAnonymousLinkType == 2
     Policy.FolderAnonymousLinkType == 2
 	Description := "Requirement not met: both files and folders are not limited to view for Anyone"
 }
 
 ReportDetails2_3(Policy) = Description if {
-    Policy.DeafultSharingLinkType == 1
+    Policy.DefaultSharingLinkType != 3
     Policy.FileAnonymousLinkType == 1
     Policy.FolderAnonymousLinkType == 2
 	Description := "Requirement not met: folders are not limited to view for Anyone"
 }
 
 ReportDetails2_3(Policy) = Description if {
-    Policy.DeafultSharingLinkType == 1
+    Policy.DefaultSharingLinkType != 3
     Policy.FileAnonymousLinkType == 2
     Policy.FolderAnonymousLinkType == 1
 	Description := "Requirement not met: files are not limited to view for Anyone"
 }
 
 ReportDetails2_3(Policy) = Description if {
-    Policy.DeafultSharingLinkType == 2
+    Policy.DefaultSharingLinkType == 3
 	Description := "Requirement not met: link permission is not limited to view"
 }
 
@@ -127,12 +127,12 @@ tests[{
     "Control" : "OneDrive 2.3",
     "Criticality" : "Should",
     "Commandlet" : ["Get-SPOTenant"],
-    "ActualValue" : [Policy.DeafultSharingLinkType, Policy.FileAnonymousLinkType, Policy.FolderAnonymousLinkType],
+    "ActualValue" : [Policy.DefaultSharingLinkType, Policy.FileAnonymousLinkType, Policy.FolderAnonymousLinkType],
     "ReportDetails" : ReportDetails2_3(Policy),
     "RequirementMet" : Status
 }] {
     Policy := input.SPO_tenant_info[_]
-	Conditions := [Policy.DeafultSharingLinkType == 1, Policy.FileAnonymousLinkType == 1, Policy.FolderAnonymousLinkType == 1]
+	Conditions := [Policy.DefaultSharingLinkType != 3, Policy.FileAnonymousLinkType == 1, Policy.FolderAnonymousLinkType == 1]
     Status := count([Condition | Condition = Conditions[_]; Condition == false]) == 0
 }
 #--

--- a/Testing/Unit/Rego/OneDrive/OneDriveConfig2_03_test.rego
+++ b/Testing/Unit/Rego/OneDrive/OneDriveConfig2_03_test.rego
@@ -88,3 +88,24 @@ test_DefaultLinkPermission_Incorrect_V3 if {
     not RuleOutput[0].RequirementMet
     RuleOutput[0].ReportDetails == "Requirement not met: folders are not limited to view for Anyone"
 }
+
+test_DefaultLinkPermission_Incorrect_V4 if {
+    ControlNumber := "OneDrive 2.3"
+    Requirement := "Anyone link permissions SHOULD be limited to View"
+
+    Output := tests with input as {
+        "SPO_tenant_info": [
+            {
+                "DefaultLinkPermission" : 2,
+                "FileAnonymousLinkType" : 1,
+                "FolderAnonymousLinkType" : 1
+            }
+        ]
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement not met: link permission is not limited to view"
+}

--- a/Testing/Unit/Rego/OneDrive/OneDriveConfig2_03_test.rego
+++ b/Testing/Unit/Rego/OneDrive/OneDriveConfig2_03_test.rego
@@ -12,7 +12,7 @@ test_DefaultLinkPermission_Correct if {
     Output := tests with input as {
         "SPO_tenant_info": [
             {
-                "DefaultLinkPermission" : 1,
+                "DeafultSharingLinkType" : 1,
                 "FileAnonymousLinkType" : 1,
                 "FolderAnonymousLinkType" : 1
             }
@@ -33,7 +33,7 @@ test_DefaultLinkPermission_Incorrect if {
     Output := tests with input as {
         "SPO_tenant_info": [
             {
-                "DefaultLinkPermission" : 1,
+                "DeafultSharingLinkType" : 1,
                 "FileAnonymousLinkType" : 2,
                 "FolderAnonymousLinkType" : 2
             }
@@ -54,7 +54,7 @@ test_DefaultLinkPermission_Incorrect_V2 if {
     Output := tests with input as {
         "SPO_tenant_info": [
             {
-                "DefaultLinkPermission" : 1,
+                "DeafultSharingLinkType" : 1,
                 "FileAnonymousLinkType" : 2,
                 "FolderAnonymousLinkType" : 1
             }
@@ -75,7 +75,7 @@ test_DefaultLinkPermission_Incorrect_V3 if {
     Output := tests with input as {
         "SPO_tenant_info": [
             {
-                "DefaultLinkPermission" : 1,
+                "DeafultSharingLinkType" : 1,
                 "FileAnonymousLinkType" : 1,
                 "FolderAnonymousLinkType" : 2
             }
@@ -96,7 +96,7 @@ test_DefaultLinkPermission_Incorrect_V4 if {
     Output := tests with input as {
         "SPO_tenant_info": [
             {
-                "DefaultLinkPermission" : 2,
+                "DeafultSharingLinkType" : 2,
                 "FileAnonymousLinkType" : 1,
                 "FolderAnonymousLinkType" : 1
             }

--- a/Testing/Unit/Rego/OneDrive/OneDriveConfig2_03_test.rego
+++ b/Testing/Unit/Rego/OneDrive/OneDriveConfig2_03_test.rego
@@ -13,7 +13,8 @@ test_DefaultLinkPermission_Correct if {
         "SPO_tenant_info": [
             {
                 "DefaultLinkPermission" : 1,
-                "OneDriveSharingCapability":  1
+                "FileAnonymousLinkType" : 1,
+                "FolderAnonymousLinkType" : 1
             }
         ]
     }
@@ -33,7 +34,8 @@ test_DefaultLinkPermission_Incorrect if {
         "SPO_tenant_info": [
             {
                 "DefaultLinkPermission" : 2,
-                "OneDriveSharingCapability":  1
+                "FileAnonymousLinkType" : 1,
+                "FolderAnonymousLinkType" : 1
             }
         ]
     }
@@ -53,7 +55,8 @@ test_DefaultLinkPermission_Incorrect_V2 if {
         "SPO_tenant_info": [
             {
                 "DefaultLinkPermission" : 1,
-                "OneDriveSharingCapability":  2
+                "FileAnonymousLinkType" : 2,
+                "FolderAnonymousLinkType" : 2
             }
         ]
     }

--- a/Testing/Unit/Rego/OneDrive/OneDriveConfig2_03_test.rego
+++ b/Testing/Unit/Rego/OneDrive/OneDriveConfig2_03_test.rego
@@ -12,7 +12,7 @@ test_DefaultLinkPermission_Correct if {
     Output := tests with input as {
         "SPO_tenant_info": [
             {
-                "DeafultSharingLinkType" : 1,
+                "DefaultSharingLinkType" : 1,
                 "FileAnonymousLinkType" : 1,
                 "FolderAnonymousLinkType" : 1
             }
@@ -33,7 +33,7 @@ test_DefaultLinkPermission_Incorrect if {
     Output := tests with input as {
         "SPO_tenant_info": [
             {
-                "DeafultSharingLinkType" : 1,
+                "DefaultSharingLinkType" : 1,
                 "FileAnonymousLinkType" : 2,
                 "FolderAnonymousLinkType" : 2
             }
@@ -54,7 +54,7 @@ test_DefaultLinkPermission_Incorrect_V2 if {
     Output := tests with input as {
         "SPO_tenant_info": [
             {
-                "DeafultSharingLinkType" : 1,
+                "DefaultSharingLinkType" : 1,
                 "FileAnonymousLinkType" : 2,
                 "FolderAnonymousLinkType" : 1
             }
@@ -75,7 +75,7 @@ test_DefaultLinkPermission_Incorrect_V3 if {
     Output := tests with input as {
         "SPO_tenant_info": [
             {
-                "DeafultSharingLinkType" : 1,
+                "DefaultSharingLinkType" : 1,
                 "FileAnonymousLinkType" : 1,
                 "FolderAnonymousLinkType" : 2
             }
@@ -96,7 +96,7 @@ test_DefaultLinkPermission_Incorrect_V4 if {
     Output := tests with input as {
         "SPO_tenant_info": [
             {
-                "DeafultSharingLinkType" : 2,
+                "DefaultSharingLinkType" : 3,
                 "FileAnonymousLinkType" : 1,
                 "FolderAnonymousLinkType" : 1
             }

--- a/Testing/Unit/Rego/OneDrive/OneDriveConfig2_03_test.rego
+++ b/Testing/Unit/Rego/OneDrive/OneDriveConfig2_03_test.rego
@@ -13,6 +13,7 @@ test_DefaultLinkPermission_Correct if {
         "SPO_tenant_info": [
             {
                 "DefaultLinkPermission" : 1
+                "OneDriveSharingCapability":  1
             }
         ]
     }
@@ -31,7 +32,28 @@ test_DefaultLinkPermission_Incorrect if {
     Output := tests with input as {
         "SPO_tenant_info": [
             {
-                "DefaultLinkPermission" : 2
+                "DefaultLinkPermission" : 2,
+                "OneDriveSharingCapability":  1
+            }
+        ]
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement not met"
+}
+
+test_DefaultLinkPermission_Incorrect_V2 if {
+    ControlNumber := "OneDrive 2.3"
+    Requirement := "Anyone link permissions SHOULD be limited to View"
+
+    Output := tests with input as {
+        "SPO_tenant_info": [
+            {
+                "DefaultLinkPermission" : 1,
+                "OneDriveSharingCapability":  2
             }
         ]
     }

--- a/Testing/Unit/Rego/OneDrive/OneDriveConfig2_03_test.rego
+++ b/Testing/Unit/Rego/OneDrive/OneDriveConfig2_03_test.rego
@@ -12,7 +12,7 @@ test_DefaultLinkPermission_Correct if {
     Output := tests with input as {
         "SPO_tenant_info": [
             {
-                "DefaultLinkPermission" : 1
+                "DefaultLinkPermission" : 1,
                 "OneDriveSharingCapability":  1
             }
         ]

--- a/Testing/Unit/Rego/OneDrive/OneDriveConfig2_03_test.rego
+++ b/Testing/Unit/Rego/OneDrive/OneDriveConfig2_03_test.rego
@@ -107,5 +107,5 @@ test_DefaultLinkPermission_Incorrect_V4 if {
 
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
-    RuleOutput[0].ReportDetails == "Requirement not met: link permission is not limited to view"
+    RuleOutput[0].ReportDetails == "Requirement not met: default link sharing type is set to Anyone with link"
 }

--- a/Testing/Unit/Rego/OneDrive/OneDriveConfig2_03_test.rego
+++ b/Testing/Unit/Rego/OneDrive/OneDriveConfig2_03_test.rego
@@ -7,7 +7,7 @@ import future.keywords
 #--
 test_DefaultLinkPermission_Correct if {
     ControlNumber := "OneDrive 2.3"
-    Requirement := "Anyone link permissions SHOULD be limited to View"
+    Requirement := "Anyone file and folder permissions SHOULD be limited to View"
 
     Output := tests with input as {
         "SPO_tenant_info": [
@@ -27,7 +27,7 @@ test_DefaultLinkPermission_Correct if {
 
 test_DefaultLinkPermission_Incorrect if {
     ControlNumber := "OneDrive 2.3"
-    Requirement := "Anyone link permissions SHOULD be limited to View"
+    Requirement := "Anyone file and folder permissions SHOULD be limited to View"
 
     Output := tests with input as {
         "SPO_tenant_info": [
@@ -47,7 +47,7 @@ test_DefaultLinkPermission_Incorrect if {
 
 test_DefaultLinkPermission_Incorrect_V2 if {
     ControlNumber := "OneDrive 2.3"
-    Requirement := "Anyone link permissions SHOULD be limited to View"
+    Requirement := "Anyone file and folder permissions SHOULD be limited to View"
 
     Output := tests with input as {
         "SPO_tenant_info": [
@@ -67,7 +67,7 @@ test_DefaultLinkPermission_Incorrect_V2 if {
 
 test_DefaultLinkPermission_Incorrect_V3 if {
     ControlNumber := "OneDrive 2.3"
-    Requirement := "Anyone link permissions SHOULD be limited to View"
+    Requirement := "Anyone file and folder permissions SHOULD be limited to View"
 
     Output := tests with input as {
         "SPO_tenant_info": [

--- a/Testing/Unit/Rego/OneDrive/OneDriveConfig2_03_test.rego
+++ b/Testing/Unit/Rego/OneDrive/OneDriveConfig2_03_test.rego
@@ -12,7 +12,6 @@ test_DefaultLinkPermission_Correct if {
     Output := tests with input as {
         "SPO_tenant_info": [
             {
-                "DefaultLinkPermission" : 1,
                 "FileAnonymousLinkType" : 1,
                 "FolderAnonymousLinkType" : 1
             }
@@ -33,28 +32,6 @@ test_DefaultLinkPermission_Incorrect if {
     Output := tests with input as {
         "SPO_tenant_info": [
             {
-                "DefaultLinkPermission" : 2,
-                "FileAnonymousLinkType" : 1,
-                "FolderAnonymousLinkType" : 1
-            }
-        ]
-    }
-
-    RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
-
-    count(RuleOutput) == 1
-    not RuleOutput[0].RequirementMet
-    RuleOutput[0].ReportDetails == "Requirement not met"
-}
-
-test_DefaultLinkPermission_Incorrect_V2 if {
-    ControlNumber := "OneDrive 2.3"
-    Requirement := "Anyone link permissions SHOULD be limited to View"
-
-    Output := tests with input as {
-        "SPO_tenant_info": [
-            {
-                "DefaultLinkPermission" : 1,
                 "FileAnonymousLinkType" : 2,
                 "FolderAnonymousLinkType" : 2
             }
@@ -65,5 +42,45 @@ test_DefaultLinkPermission_Incorrect_V2 if {
 
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
-    RuleOutput[0].ReportDetails == "Requirement not met"
+    RuleOutput[0].ReportDetails == "Requirement not met: both file and folder are not limited to view for Anyone"
+}
+
+test_DefaultLinkPermission_Incorrect_V2 if {
+    ControlNumber := "OneDrive 2.3"
+    Requirement := "Anyone link permissions SHOULD be limited to View"
+
+    Output := tests with input as {
+        "SPO_tenant_info": [
+            {
+                "FileAnonymousLinkType" : 2,
+                "FolderAnonymousLinkType" : 1
+            }
+        ]
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement not met: files are not limited to view for Anyone"
+}
+
+test_DefaultLinkPermission_Incorrect_V3 if {
+    ControlNumber := "OneDrive 2.3"
+    Requirement := "Anyone link permissions SHOULD be limited to View"
+
+    Output := tests with input as {
+        "SPO_tenant_info": [
+            {
+                "FileAnonymousLinkType" : 1,
+                "FolderAnonymousLinkType" : 2
+            }
+        ]
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement not met: folder are not limited to view for Anyone"
 }

--- a/Testing/Unit/Rego/OneDrive/OneDriveConfig2_03_test.rego
+++ b/Testing/Unit/Rego/OneDrive/OneDriveConfig2_03_test.rego
@@ -7,11 +7,12 @@ import future.keywords
 #--
 test_DefaultLinkPermission_Correct if {
     ControlNumber := "OneDrive 2.3"
-    Requirement := "Anyone file and folder permissions SHOULD be limited to View"
+    Requirement := "Anyone link permissions SHOULD be limited to View"
 
     Output := tests with input as {
         "SPO_tenant_info": [
             {
+                "DefaultLinkPermission" : 1,
                 "FileAnonymousLinkType" : 1,
                 "FolderAnonymousLinkType" : 1
             }
@@ -27,11 +28,12 @@ test_DefaultLinkPermission_Correct if {
 
 test_DefaultLinkPermission_Incorrect if {
     ControlNumber := "OneDrive 2.3"
-    Requirement := "Anyone file and folder permissions SHOULD be limited to View"
+    Requirement := "Anyone link permissions SHOULD be limited to View"
 
     Output := tests with input as {
         "SPO_tenant_info": [
             {
+                "DefaultLinkPermission" : 1,
                 "FileAnonymousLinkType" : 2,
                 "FolderAnonymousLinkType" : 2
             }
@@ -42,16 +44,17 @@ test_DefaultLinkPermission_Incorrect if {
 
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
-    RuleOutput[0].ReportDetails == "Requirement not met: both file and folder are not limited to view for Anyone"
+    RuleOutput[0].ReportDetails == "Requirement not met: both files and folders are not limited to view for Anyone"
 }
 
 test_DefaultLinkPermission_Incorrect_V2 if {
     ControlNumber := "OneDrive 2.3"
-    Requirement := "Anyone file and folder permissions SHOULD be limited to View"
+    Requirement := "Anyone link permissions SHOULD be limited to View"
 
     Output := tests with input as {
         "SPO_tenant_info": [
             {
+                "DefaultLinkPermission" : 1,
                 "FileAnonymousLinkType" : 2,
                 "FolderAnonymousLinkType" : 1
             }
@@ -67,11 +70,12 @@ test_DefaultLinkPermission_Incorrect_V2 if {
 
 test_DefaultLinkPermission_Incorrect_V3 if {
     ControlNumber := "OneDrive 2.3"
-    Requirement := "Anyone file and folder permissions SHOULD be limited to View"
+    Requirement := "Anyone link permissions SHOULD be limited to View"
 
     Output := tests with input as {
         "SPO_tenant_info": [
             {
+                "DefaultLinkPermission" : 1,
                 "FileAnonymousLinkType" : 1,
                 "FolderAnonymousLinkType" : 2
             }
@@ -82,5 +86,5 @@ test_DefaultLinkPermission_Incorrect_V3 if {
 
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
-    RuleOutput[0].ReportDetails == "Requirement not met: folder are not limited to view for Anyone"
+    RuleOutput[0].ReportDetails == "Requirement not met: folders are not limited to view for Anyone"
 }


### PR DESCRIPTION
Removed checks for DefaultLinkPermission
Add check for DefaultSharingLinkType; FileAnonymousLinkType; FolderAnonymousLinkType to policy 2.3 
Adjusted the unit test cases
Reports now gives detailed description when requirement is not met

## 🗣 Description ##

OneDrive 2.3 policy
edited the policy to check user permission for view and edit for OneDrive
adjusted the unit test cases

## 💭 Motivation and context ##

closes #98 

## 🧪 Testing ##

1. Open the Sharepoint Admin Center
2. Navigate to Policies > Sharing
3. Set the External Sharing slider to Anyone (Need do it on Sharepoint first then OneDrive)
4. Scroll to the section "Choose expiration and permissions options for Anyone links."
5. Set the Files permission to View and Edit
6. Set the Folders permission to View, edit and upload
7. Run the tool

The result should reflect that both 2.1 and 2.3 did not meet the requirement
 
PS: Don't forget to revert the changes after testing

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

- [ ] Add a tag or create a release.
