### PR TITLE
Implement code signing and basic pipeline to create draft releases.

### DIFF
--- a/.github/workflows/run_release.yaml
+++ b/.github/workflows/run_release.yaml
@@ -19,7 +19,6 @@ jobs:
     env:
       CODESIGN_PW: ${{ secrets.CODESIGN_PW }}
       CODESIGN_PFX: ${{ secrets.CODESIGN_PFX }}
-      CODESIGN_INT: ${{ secrets.CODESIGN_INT }}
     permissions:
       contents: write
     steps:
@@ -38,12 +37,11 @@ jobs:
         Set-Content -Path certificate\cert.txt -Value $env:CODESIGN_PFX
         certutil -decode certificate\cert.txt certificate\cert.pfx
 
-        Set-Content -Path certificate\int.txt -Value $env:CODESIGN_INT
-        certutil -decode certificate\int.txt certificate\int.cer
+        $cert = Get-PfxCertificate -FilePath certificate\cert.pfx -Password (ConvertTo-SecureString -String $env:WINDOWS_PFX_PASSWORD -Force -AsPlainText)
 
         Get-ChildItem -Recurse -Path repo -Include **.ps1,**.psm1 | ForEach-Object {
           $path = $_.FullName
-          & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' sign /tr "http://timestamp.sectigo.com/rfc3161" /fd SHA256 /p $env:CODESIGN_PW /f certificate\cert.pfx /td SHA256 /ac certificate\int.cer /r "DigiCert Trusted Root G4" $path
+          Set-AuthenticodeSignature -Certificate $cert -FilePath $path -TimestampServer "http://timestamp.sectigo.com/" -IncludeChain NotRoot
         }
 
         Remove-Item -Recurse -Force certificate

--- a/.github/workflows/run_release.yaml
+++ b/.github/workflows/run_release.yaml
@@ -45,7 +45,7 @@ jobs:
         $cert = Get-PfxCertificate -FilePath certificate\cert.pfx -Password (ConvertTo-SecureString -String $env:CODESIGN_PW -Force -AsPlainText)
 
         # Import Intermediate so it can be resolved
-        #Import-Certificate -FilePath certificate\int.cer 
+        Import-Certificate -FilePath certificate\int.cer -CertStoreLocation cert:\CurrentUser\My
 
         Get-ChildItem -Recurse -Path repo -Include **.ps1,**.psm1 | ForEach-Object {
           $path = $_.FullName

--- a/.github/workflows/run_release.yaml
+++ b/.github/workflows/run_release.yaml
@@ -50,6 +50,12 @@ jobs:
         Remove-Item -Recurse -Force repo -Include .git*
 
         Compress-Archive -Path repo\* -DestinationPath release.zip
+
+        # Verify certs
+        Get-ChildItem -Recurse -Path repo -Include **.ps1,**.psm1 | ForEach-Object {
+          $path = $_.FullName
+          & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' verify /pa /v $path
+        }
     - name: release
       uses: softprops/action-gh-release@v1
       id: create_release

--- a/.github/workflows/run_release.yaml
+++ b/.github/workflows/run_release.yaml
@@ -1,0 +1,59 @@
+on: 
+  workflow_dispatch:
+    inputs:
+      releaseName:
+        description: "Release Name"
+        required: true
+        type: string
+      version:
+        description: "Release Version"
+        required: true
+        type: string
+
+name: Build and Sign Release
+
+
+jobs:
+  build-and-deploy:
+    runs-on: windows-latest
+    env:
+      CODESIGN_PW: ${{ secrets.CODESIGN_PW }}
+      CODESIGN_BASE64: ${{ secrets.CODESIGN_BASE64 }}
+    permissions:
+      contents: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        path: repo
+    - name: Sign Scripts
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = "Stop"
+        $PSDefaultParameterValues['*:ErrorAction']='Stop'
+        Set-StrictMode -Version Latest
+
+        New-Item -ItemType directory -Path certificate
+        Set-Content -Path certificate\cert.txt -Value $env:CODESIGN_BASE64
+        certutil -decode certificate\cert.txt certificate\cert.pfx
+
+        Get-ChildItem -Recurse -Path repo -Include **.ps1,**.psm1 | ForEach-Object {
+          $path = $_.FullName
+          & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' sign /tr "http://timestamp.sectigo.com/rfc3161" /fd SHA256 /p $env:CODESIGN_PW /f certificate\cert.pfx /td SHA256 $path
+        }
+
+        Remove-Item -Recurse -Force certificate
+        Remove-Item -Recurse -Force repo -Include .git*
+
+        Compress-Archive -Path repo -DestinationPath release.zip
+    - name: release
+      uses: softprops/action-gh-release@v1
+      id: create_release
+      with:
+        draft: true
+        prerelease: false
+        name: ${{ inputs.releaseName }}
+        tag_name: ${{ inputs.version }}
+        files: release.zip
+        generate_release_notes: true
+        fail_on_unmatched_files: true

--- a/.github/workflows/run_release.yaml
+++ b/.github/workflows/run_release.yaml
@@ -43,7 +43,7 @@ jobs:
         }
 
         Remove-Item -Recurse -Force certificate
-        Remove-Item -Recurse -Force repo -Include .git*
+        Remove-Item -Recurse -Force repo\* -Include .git*
 
         Compress-Archive -Path repo -DestinationPath release.zip
     - name: release

--- a/.github/workflows/run_release.yaml
+++ b/.github/workflows/run_release.yaml
@@ -43,8 +43,7 @@ jobs:
 
         Get-ChildItem -Recurse -Path repo -Include **.ps1,**.psm1 | ForEach-Object {
           $path = $_.FullName
-          & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' sign /tr "http://timestamp.sectigo.com/rfc3161" /fd SHA256 /p $env:CODESIGN_PW /f certificate\cert.pfx /td SHA256 /ac certificate\int.cer /r "DigiCert Trusted Root G5" $path
-
+          & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' sign /tr "http://timestamp.sectigo.com/rfc3161" /fd SHA256 /p $env:CODESIGN_PW /f certificate\cert.pfx /td SHA256 /ac certificate\int.cer /r "DigiCert Trusted Root G4" $path
         }
 
         Remove-Item -Recurse -Force certificate

--- a/.github/workflows/run_release.yaml
+++ b/.github/workflows/run_release.yaml
@@ -37,7 +37,7 @@ jobs:
         Set-Content -Path certificate\cert.txt -Value $env:CODESIGN_PFX
         certutil -decode certificate\cert.txt certificate\cert.pfx
 
-        $cert = Get-PfxCertificate -FilePath certificate\cert.pfx -Password (ConvertTo-SecureString -String $env:WINDOWS_PFX_PASSWORD -Force -AsPlainText)
+        $cert = Get-PfxCertificate -FilePath certificate\cert.pfx -Password (ConvertTo-SecureString -String $env:CODESIGN_PW -Force -AsPlainText)
 
         Get-ChildItem -Recurse -Path repo -Include **.ps1,**.psm1 | ForEach-Object {
           $path = $_.FullName

--- a/.github/workflows/run_release.yaml
+++ b/.github/workflows/run_release.yaml
@@ -19,6 +19,7 @@ jobs:
     env:
       CODESIGN_PW: ${{ secrets.CODESIGN_PW }}
       CODESIGN_PFX: ${{ secrets.CODESIGN_PFX }}
+      RELEASE_VERSION: ${{ inputs.vesion }}
     permissions:
       contents: write
     steps:
@@ -41,13 +42,15 @@ jobs:
 
         Get-ChildItem -Recurse -Path repo -Include **.ps1,**.psm1,**.psd1 | ForEach-Object {
           $path = $_.FullName
-          Set-AuthenticodeSignature -Certificate $cert -FilePath $path -TimestampServer "http://timestamp.sectigo.com/" -IncludeChain NotRoot
+          Set-AuthenticodeSignature -Certificate $cert -FilePath $path -TimestampServer "https://timestamp.sectigo.com/" -IncludeChain NotRoot -HashAlgorithm SHA256
+          # Delay for 15 seconds to please the timestamp server.
+          Start-Sleep -Seconds 15
         }
 
         Remove-Item -Recurse -Force certificate
         Remove-Item -Recurse -Force repo -Include .git*
 
-        Compress-Archive -Path repo\* -DestinationPath release.zip
+        Compress-Archive -Path repo\* -DestinationPath "ScubaGear-${env:RELEASE_VERSION}.zip"
     - name: release
       uses: softprops/action-gh-release@v1
       id: create_release
@@ -56,6 +59,6 @@ jobs:
         prerelease: false
         name: ${{ inputs.releaseName }}
         tag_name: ${{ inputs.version }}
-        files: release.zip
+        files: ScubaGear-${{ inputs.version}}.zip
         generate_release_notes: true
         fail_on_unmatched_files: true

--- a/.github/workflows/run_release.yaml
+++ b/.github/workflows/run_release.yaml
@@ -43,7 +43,7 @@ jobs:
 
         Get-ChildItem -Recurse -Path repo -Include **.ps1,**.psm1 | ForEach-Object {
           $path = $_.FullName
-          & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' sign /tr "http://timestamp.sectigo.com/rfc3161" /fd SHA256 /p $env:CODESIGN_PW /f certificate\cert.pfx /td SHA256 /ac certificate\int.cer $path
+          & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' sign /tr "http://timestamp.sectigo.com/rfc3161" /fd SHA256 /p $env:CODESIGN_PW /f certificate\cert.pfx /td SHA256 /ac certificate\int.cer /r "DigiCert Trusted Root G4" $path
 
         }
 

--- a/.github/workflows/run_release.yaml
+++ b/.github/workflows/run_release.yaml
@@ -45,7 +45,7 @@ jobs:
         $cert = Get-PfxCertificate -FilePath certificate\cert.pfx -Password (ConvertTo-SecureString -String $env:CODESIGN_PW -Force -AsPlainText)
 
         # Import Intermediate so it can be resolved
-        Import-Certificate -FilePath certificate\int.cer
+        #Import-Certificate -FilePath certificate\int.cer 
 
         Get-ChildItem -Recurse -Path repo -Include **.ps1,**.psm1 | ForEach-Object {
           $path = $_.FullName

--- a/.github/workflows/run_release.yaml
+++ b/.github/workflows/run_release.yaml
@@ -42,7 +42,7 @@ jobs:
         certutil -decode certificate\int.txt certificate\int.cer
 
         # Load CA and Key
-        $cert = Get-PfxCertificate -FilePath certificate\cert.pfx -Password (ConvertTo-SecureString -String $env:WINDOWS_PFX_PASSWORD -Force -AsPlainText)
+        $cert = Get-PfxCertificate -FilePath certificate\cert.pfx -Password (ConvertTo-SecureString -String $env:CODESIGN_PW -Force -AsPlainText)
 
         # Import Intermediate so it can be resolved
         Import-Certificate -FilePath certificate\int.cer

--- a/.github/workflows/run_release.yaml
+++ b/.github/workflows/run_release.yaml
@@ -41,15 +41,10 @@ jobs:
         Set-Content -Path certificate\int.txt -Value $env:CODESIGN_INT
         certutil -decode certificate\int.txt certificate\int.cer
 
-        # Load CA and Key
-        $cert = Get-PfxCertificate -FilePath certificate\cert.pfx -Password (ConvertTo-SecureString -String $env:CODESIGN_PW -Force -AsPlainText)
-
-        # Import Intermediate so it can be resolved
-        Import-Certificate -FilePath certificate\int.cer -CertStoreLocation cert:\CurrentUser\My
-
         Get-ChildItem -Recurse -Path repo -Include **.ps1,**.psm1 | ForEach-Object {
           $path = $_.FullName
-          Set-AuthenticodeSignature -Certificate $cert -FilePath $path -TimestampServer "http://timestamp.sectigo.com/" -IncludeChain NotRoot
+          & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' sign /tr "http://timestamp.sectigo.com/rfc3161" /fd SHA256 /p $env:CODESIGN_PW /f certificate\cert.pfx /td SHA256 /ac certificate\int.cer $path
+
         }
 
         Remove-Item -Recurse -Force certificate

--- a/.github/workflows/run_release.yaml
+++ b/.github/workflows/run_release.yaml
@@ -43,9 +43,9 @@ jobs:
         }
 
         Remove-Item -Recurse -Force certificate
-        Remove-Item -Recurse -Force repo\* -Include .git*
+        Remove-Item -Recurse -Force repo -Include .git*
 
-        Compress-Archive -Path repo -DestinationPath release.zip
+        Compress-Archive -Path repo\* -DestinationPath release.zip
     - name: release
       uses: softprops/action-gh-release@v1
       id: create_release

--- a/.github/workflows/run_release.yaml
+++ b/.github/workflows/run_release.yaml
@@ -1,6 +1,5 @@
 on: 
   # temporary to get to register.
-  pull_request:
   workflow_dispatch:
     inputs:
       releaseName:
@@ -20,7 +19,7 @@ jobs:
     runs-on: windows-latest
     env:
       CODESIGN_PW: ${{ secrets.CODESIGN_PW }}
-      CODESIGN_BASE64: ${{ secrets.CODESIGN_BASE64 }}
+      CODESIGN_PFX: ${{ secrets.CODESIGN_PFX }}
     permissions:
       contents: write
     steps:
@@ -36,7 +35,7 @@ jobs:
         Set-StrictMode -Version Latest
 
         New-Item -ItemType directory -Path certificate
-        Set-Content -Path certificate\cert.txt -Value $env:CODESIGN_BASE64
+        Set-Content -Path certificate\cert.txt -Value $env:CODESIGN_PFX
         certutil -decode certificate\cert.txt certificate\cert.pfx
 
         Get-ChildItem -Recurse -Path repo -Include **.ps1,**.psm1 | ForEach-Object {

--- a/.github/workflows/run_release.yaml
+++ b/.github/workflows/run_release.yaml
@@ -1,4 +1,6 @@
 on: 
+  # temporary to get to register.
+  pull_request:
   workflow_dispatch:
     inputs:
       releaseName:

--- a/.github/workflows/run_release.yaml
+++ b/.github/workflows/run_release.yaml
@@ -42,7 +42,7 @@ jobs:
 
         Get-ChildItem -Recurse -Path repo -Include **.ps1,**.psm1,**.psd1 | ForEach-Object {
           $path = $_.FullName
-          Set-AuthenticodeSignature -Certificate $cert -FilePath $path -TimestampServer "https://timestamp.sectigo.com/" -IncludeChain NotRoot -HashAlgorithm SHA256
+          Set-AuthenticodeSignature -Certificate $cert -FilePath $path -TimestampServer "http://timestamp.sectigo.com/" -IncludeChain NotRoot -HashAlgorithm SHA256
           # Delay for 15 seconds to please the timestamp server.
           Start-Sleep -Seconds 15
         }

--- a/.github/workflows/run_release.yaml
+++ b/.github/workflows/run_release.yaml
@@ -19,6 +19,7 @@ jobs:
     env:
       CODESIGN_PW: ${{ secrets.CODESIGN_PW }}
       CODESIGN_PFX: ${{ secrets.CODESIGN_PFX }}
+      CODESIGN_INT: ${{ secrets.CODESIGN_INT }}
     permissions:
       contents: write
     steps:
@@ -37,9 +38,18 @@ jobs:
         Set-Content -Path certificate\cert.txt -Value $env:CODESIGN_PFX
         certutil -decode certificate\cert.txt certificate\cert.pfx
 
+        Set-Content -Path certificate\int.txt -Value $env:CODESIGN_INT
+        certutil -decode certificate\int.txt certificate\int.cer
+
+        # Load CA and Key
+        $cert = Get-PfxCertificate -FilePath certificate\cert.pfx -Password (ConvertTo-SecureString -String $env:WINDOWS_PFX_PASSWORD -Force -AsPlainText)
+
+        # Import Intermediate so it can be resolved
+        Import-Certificate -FilePath certificate\int.cer
+
         Get-ChildItem -Recurse -Path repo -Include **.ps1,**.psm1 | ForEach-Object {
           $path = $_.FullName
-          & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' sign /tr "http://timestamp.sectigo.com/rfc3161" /fd SHA256 /p $env:CODESIGN_PW /f certificate\cert.pfx /td SHA256 $path
+          Set-AuthenticodeSignature -Certificate $cert -FilePath $path -TimestampServer "http://timestamp.sectigo.com/" -IncludeChain NotRoot
         }
 
         Remove-Item -Recurse -Force certificate

--- a/.github/workflows/run_release.yaml
+++ b/.github/workflows/run_release.yaml
@@ -39,7 +39,7 @@ jobs:
 
         $cert = Get-PfxCertificate -FilePath certificate\cert.pfx -Password (ConvertTo-SecureString -String $env:CODESIGN_PW -Force -AsPlainText)
 
-        Get-ChildItem -Recurse -Path repo -Include **.ps1,**.psm1 | ForEach-Object {
+        Get-ChildItem -Recurse -Path repo -Include **.ps1,**.psm1,**.psd1 | ForEach-Object {
           $path = $_.FullName
           Set-AuthenticodeSignature -Certificate $cert -FilePath $path -TimestampServer "http://timestamp.sectigo.com/" -IncludeChain NotRoot
         }
@@ -48,12 +48,6 @@ jobs:
         Remove-Item -Recurse -Force repo -Include .git*
 
         Compress-Archive -Path repo\* -DestinationPath release.zip
-
-        # Verify certs
-        Get-ChildItem -Recurse -Path repo -Include **.ps1,**.psm1 | ForEach-Object {
-          $path = $_.FullName
-          & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' verify /pa /v $path
-        }
     - name: release
       uses: softprops/action-gh-release@v1
       id: create_release

--- a/.github/workflows/run_release.yaml
+++ b/.github/workflows/run_release.yaml
@@ -1,5 +1,4 @@
 on: 
-  # temporary to get to register.
   workflow_dispatch:
     inputs:
       releaseName:

--- a/.github/workflows/run_release.yaml
+++ b/.github/workflows/run_release.yaml
@@ -42,9 +42,9 @@ jobs:
 
         Get-ChildItem -Recurse -Path repo -Include **.ps1,**.psm1,**.psd1 | ForEach-Object {
           $path = $_.FullName
-          Set-AuthenticodeSignature -Certificate $cert -FilePath $path -TimestampServer "http://timestamp.sectigo.com/" -IncludeChain NotRoot -HashAlgorithm SHA256
-          # Delay for 15 seconds to please the timestamp server.
-          Start-Sleep -Seconds 15
+          Set-AuthenticodeSignature -Certificate $cert -FilePath $path -TimestampServer "http://timestamp.digicert.com/" -IncludeChain NotRoot -HashAlgorithm SHA256
+          # Delay for 4 seconds to avoid exceeding rate limits (1000 / 5 minutes, 100 / 5 seconds)
+          Start-Sleep -Seconds 4
         }
 
         Remove-Item -Recurse -Force certificate

--- a/.github/workflows/run_release.yaml
+++ b/.github/workflows/run_release.yaml
@@ -19,7 +19,7 @@ jobs:
     env:
       CODESIGN_PW: ${{ secrets.CODESIGN_PW }}
       CODESIGN_PFX: ${{ secrets.CODESIGN_PFX }}
-      RELEASE_VERSION: ${{ inputs.vesion }}
+      RELEASE_VERSION: ${{ inputs.version }}
     permissions:
       contents: write
     steps:

--- a/.github/workflows/run_release.yaml
+++ b/.github/workflows/run_release.yaml
@@ -51,6 +51,8 @@ jobs:
         Remove-Item -Recurse -Force repo -Include .git*
 
         Compress-Archive -Path repo\* -DestinationPath "ScubaGear-${env:RELEASE_VERSION}.zip"
+
+        Get-ChildItem -Path . | Write-Output
     - name: release
       uses: softprops/action-gh-release@v1
       id: create_release
@@ -59,6 +61,6 @@ jobs:
         prerelease: false
         name: ${{ inputs.releaseName }}
         tag_name: ${{ inputs.version }}
-        files: ScubaGear-${{ inputs.version}}.zip
+        files: ScubaGear-${{ inputs.version }}.zip
         generate_release_notes: true
         fail_on_unmatched_files: true

--- a/.github/workflows/run_release.yaml
+++ b/.github/workflows/run_release.yaml
@@ -43,7 +43,7 @@ jobs:
 
         Get-ChildItem -Recurse -Path repo -Include **.ps1,**.psm1 | ForEach-Object {
           $path = $_.FullName
-          & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' sign /tr "http://timestamp.sectigo.com/rfc3161" /fd SHA256 /p $env:CODESIGN_PW /f certificate\cert.pfx /td SHA256 /ac certificate\int.cer /r "DigiCert Trusted Root G4" $path
+          & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' sign /tr "http://timestamp.sectigo.com/rfc3161" /fd SHA256 /p $env:CODESIGN_PW /f certificate\cert.pfx /td SHA256 /ac certificate\int.cer /r "DigiCert Trusted Root G5" $path
 
         }
 


### PR DESCRIPTION
# Implements code signing and basic pipeline to create draft releases #

## 🗣 Description ##

* Adds a github action that will create draft releases artifacts in zip format with signed powershell code
* Can be extended in future with other steps (testing, packaging, etc) and refined as appropriate
* Uses draft releases so that release notes can be manually refined as necessary.

## 💭 Motivation and context ##

This closes issue #95.  It enables us to release signed code that will run on windows without unblock-file. 

## 🧪 Testing ##

Initial testing was completed in a forked branch with an untrusted CA.   PR has been tested by running action from dev branch using real certificate.  Release artifacts run successfully without unblock-file in an environment that enforces signing for MOTW scripts.


## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.


