### PR TITLE
Fix Defender 2.2 Policy 3 bug when DLP policy in test mode

### DIFF
--- a/Rego/DefenderConfig.rego
+++ b/Rego/DefenderConfig.rego
@@ -139,6 +139,10 @@ SensitiveRules[{
                     "U.S. Individual Taxpayer Identification Number (ITIN)" in ContentNames,
                     "Credit Card Number" in ContentNames]
     count([Condition | Condition = Conditions[_]; Condition == true]) > 0
+
+    Policy := input.dlp_compliance_policies[_]
+    Rules.ParentPolicyName == Policy.Name
+    Policy.Enabled == true
 }
 
 #
@@ -319,16 +323,19 @@ tests[{
 SensitiveRulesNotBlocking[Rule.Name] {
     Rule := SensitiveRules[_]
     not Rule.BlockAccess
+    Policy := input.dlp_compliance_policies[_]
+    Rule.ParentPolicyName == Policy.Name
+    Policy.Mode == "Enable"
 }
 
 # Covers rules set to block, but inside policies set to
-# "TestWithNotifications" that won't enforce the block
+# "TestWithNotifications" or "TestWithoutNotifications" that won't enforce the block
 SensitiveRulesNotBlocking[Rule.Name] {
     Rule := SensitiveRules[_]
     Policy := input.dlp_compliance_policies[_]
     Rule.ParentPolicyName == Policy.Name
     Rule.BlockAccess
-    Policy.Mode != "Enable"
+    startswith(Policy.Mode, "TestWith") == true
 }
 
 tests[{

--- a/Rego/DefenderConfig.rego
+++ b/Rego/DefenderConfig.rego
@@ -155,7 +155,7 @@ ITINRules[Rule.Name] {
     "U.S. Individual Taxpayer Identification Number (ITIN)" in Rule.ContentNames
 }
 
-CardRules[ Rule.Name] {
+CardRules[Rule.Name] {
     Rule := SensitiveRules[_]
     "Credit Card Number" in Rule.ContentNames
 }
@@ -321,6 +321,16 @@ SensitiveRulesNotBlocking[Rule.Name] {
     not Rule.BlockAccess
 }
 
+# Covers rules set to block, but inside policies set to
+# "TestWithNotifications" that won't enforce the block
+SensitiveRulesNotBlocking[Rule.Name] {
+    Rule := SensitiveRules[_]
+    Policy := input.dlp_compliance_policies[_]
+    Rule.ParentPolicyName == Policy.Name
+    Rule.BlockAccess
+    Policy.Mode != "Enable"
+}
+
 tests[{
     "Requirement" : "The action for the DLP policy SHOULD be set to block sharing sensitive information with everyone when DLP conditions are met",
     "Control" : "Defender 2.2",
@@ -331,7 +341,7 @@ tests[{
     "RequirementMet" : Status
 }] {
     Rules := SensitiveRulesNotBlocking
-    ErrorMessage := "rule(s) found that do(es) not block access:"
+    ErrorMessage := "rule(s) found that do(es) not block access or associated policy not set to enforce block action:"
 	Status := count(Rules) == 0
 }
 #--

--- a/Testing/Unit/Rego/Defender/DefenderConfig2_02_test.rego
+++ b/Testing/Unit/Rego/Defender/DefenderConfig2_02_test.rego
@@ -27,6 +27,13 @@ test_ContentContainsSensitiveInformation_Correct_V1 if {
                 ],
 	            "NotifyUserType":  "NotSet"
             }
+        ],
+        "dlp_compliance_policies": [
+            {
+                "Name": "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
+            }
         ]
     }
 
@@ -60,6 +67,13 @@ test_ContentContainsSensitiveInformation_Incorrect_V1 if {
                 ],
 	            "NotifyUserType":  "NotSet"
             }
+        ],
+        "dlp_compliance_policies": [
+            {
+                "Name": "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
+            }
         ]
     }
 
@@ -91,6 +105,13 @@ test_ContentContainsSensitiveInformation_Correct_V2 if {
                     "Owner"
                 ],
 	            "NotifyUserType":  "NotSet"
+            }
+        ],
+        "dlp_compliance_policies": [
+            {
+                "Name": "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
             }
         ]
     }
@@ -125,6 +146,13 @@ test_ContentContainsSensitiveInformation_Incorrect_V2 if {
                 ],
 	            "NotifyUserType":  "NotSet"
             }
+        ],
+        "dlp_compliance_policies": [
+            {
+                "Name": "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
+            }
         ]
     }
 
@@ -156,6 +184,13 @@ test_ContentContainsSensitiveInformation_Correct_V3 if {
                     "Owner"
                 ],
 	            "NotifyUserType":  "NotSet"
+            }
+        ],
+        "dlp_compliance_policies": [
+            {
+                "Name": "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
             }
         ]
     }
@@ -189,6 +224,13 @@ test_ContentContainsSensitiveInformation_Incorrect_V3 if {
                     "Owner"
                 ],
 	            "NotifyUserType":  "NotSet"
+            }
+        ],
+        "dlp_compliance_policies": [
+            {
+                "Name": "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
             }
         ]
     }
@@ -232,7 +274,9 @@ test_Exchange_Correct if {
             {
                 "ExchangeLocation":  ["All"],
                 "Workload":  "Exchange",
-                "Name":  "Default Office 365 DLP policy"
+                "Name":  "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
             }
         ]
     }
@@ -273,7 +317,9 @@ test_ExchangeLocation_Incorrect if {
             {
                 "ExchangeLocation":  [""],
                 "Workload":  "Exchange",
-                "Name":  "Default Office 365 DLP policy"
+                "Name":  "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
             }
         ]
     }
@@ -314,7 +360,9 @@ test_Workload_Incorrect_V1 if {
             {
                 "ExchangeLocation":  ["All"],
                 "Workload":  "",
-                "Name":  "Default Office 365 DLP policy"
+                "Name":  "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
             }
         ]
     }
@@ -355,7 +403,9 @@ test_SharePoint_Correct if {
             {
                 "SharePointLocation":  ["All"],
                 "Workload":  "SharePoint",
-                "Name":  "Default Office 365 DLP policy"
+                "Name":  "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
             }
         ]
     }
@@ -396,7 +446,9 @@ test_SharePointLocation_Incorrect if {
             {
                 "SharePointLocation":  [""],
                 "Workload":  "SharePoint",
-                "Name":  "Default Office 365 DLP policy"
+                "Name":  "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
             }
         ]
     }
@@ -437,7 +489,9 @@ test_Workload_Incorrect_V2 if {
             {
                 "SharePointLocation":  ["All"],
                 "Workload":  "",
-                "Name":  "Default Office 365 DLP policy"
+                "Name":  "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
             }
         ]
     }
@@ -478,7 +532,9 @@ test_OneDrive_Correct if {
             {
                 "OneDriveLocation":  ["All"],
                 "Workload":  "OneDrivePoint",
-                "Name":  "Default Office 365 DLP policy"
+                "Name":  "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
             }
         ]
     }
@@ -519,7 +575,9 @@ test_OneDriveLocation_Incorrect if {
             {
                 "OneDriveLocation":  [""],
                 "Workload":  "OneDrivePoint",
-                "Name":  "Default Office 365 DLP policy"
+                "Name":  "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
             }
         ]
     }
@@ -560,7 +618,9 @@ test_Workload_Incorrect_V3 if {
             {
                 "OneDriveLocation":  ["All"],
                 "Workload":  "",
-                "Name":  "Default Office 365 DLP policy"
+                "Name":  "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
             }
         ]
     }
@@ -601,7 +661,9 @@ test_Teams_Correct if {
             {
                 "TeamsLocation":  ["All"],
                 "Workload":  "Teams",
-                "Name":  "Default Office 365 DLP policy"
+                "Name":  "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
             }
         ]
     }
@@ -642,7 +704,9 @@ test_TeamsLocation_Incorrect if {
             {
                 "TeamsLocation":  [""],
                 "Workload":  "Teams",
-                "Name":  "Default Office 365 DLP policy"
+                "Name":  "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
             }
         ]
     }
@@ -683,7 +747,9 @@ test_Workload_Incorrect_V4 if {
             {
                 "TeamsLocation":  ["All"],
                 "Workload":  "",
-                "Name":  "Default Office 365 DLP policy"
+                "Name":  "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
             }
         ]
     }
@@ -724,7 +790,8 @@ test_BlockAccess_Correct if {
         "dlp_compliance_policies": [
             {
                 "Name": "Default Office 365 DLP policy",
-                "Mode": "Enable"
+                "Mode": "Enable",
+                "Enabled": true
             }
         ]
     }
@@ -762,7 +829,8 @@ test_BlockAccess_IncorrectV1 if {
         "dlp_compliance_policies": [
             {
                 "Name": "Default Office 365 DLP policy",
-                "Mode": "Enable"
+                "Mode": "Enable",
+                "Enabled": true
             }
         ]
     }
@@ -800,7 +868,8 @@ test_BlockAccess_IncorrectV2 if {
         "dlp_compliance_policies": [
             {
                 "Name": "Default Office 365 DLP policy",
-                "Mode": "TestWithNotifications"
+                "Mode": "TestWithNotifications",
+                "Enabled": true
             }
         ]
     }
@@ -835,6 +904,13 @@ test_NotifyUser_Correct_V1 if {
                 ],
 	            "NotifyUserType":  "NotSet"
             }
+        ],
+        "dlp_compliance_policies": [
+            {
+                "Name": "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
+            }
         ]
     }
 
@@ -867,6 +943,13 @@ test_NotifyUser_Correct_V2 if {
                 ],
 	            "NotifyUserType":  "NotSet"
             }
+        ],
+        "dlp_compliance_policies": [
+            {
+                "Name": "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
+            }
         ]
     }
 
@@ -894,6 +977,13 @@ test_NotifyUser_Incorrect if {
                 "BlockAccessScope":  "All",
 	            "NotifyUser":  [ ],
 	            "NotifyUserType":  "NotSet"
+            }
+        ],
+        "dlp_compliance_policies": [
+            {
+                "Name": "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
             }
         ]
     }

--- a/Testing/Unit/Rego/Defender/DefenderConfig2_02_test.rego
+++ b/Testing/Unit/Rego/Defender/DefenderConfig2_02_test.rego
@@ -720,6 +720,12 @@ test_BlockAccess_Correct if {
                 ],
 	            "NotifyUserType":  "NotSet"
             }
+        ],
+        "dlp_compliance_policies": [
+            {
+                "Name": "Default Office 365 DLP policy",
+                "Mode": "Enable"
+            }
         ]
     }
 
@@ -730,7 +736,7 @@ test_BlockAccess_Correct if {
     RuleOutput[0].ReportDetails == "Requirement met"
 }
 
-test_BlockAccess_Incorrect if {
+test_BlockAccess_IncorrectV1 if {
     ControlNumber := "Defender 2.2"
     Requirement := "The action for the DLP policy SHOULD be set to block sharing sensitive information with everyone when DLP conditions are met"
 
@@ -752,6 +758,12 @@ test_BlockAccess_Incorrect if {
                 ],
 	            "NotifyUserType":  "NotSet"
             }
+        ],
+        "dlp_compliance_policies": [
+            {
+                "Name": "Default Office 365 DLP policy",
+                "Mode": "Enable"
+            }
         ]
     }
 
@@ -759,7 +771,45 @@ test_BlockAccess_Incorrect if {
 
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
-    RuleOutput[0].ReportDetails == "1 rule(s) found that do(es) not block access: Baseline Rule"
+    RuleOutput[0].ReportDetails == "1 rule(s) found that do(es) not block access or associated policy not set to enforce block action: Baseline Rule"
+}
+
+test_BlockAccess_IncorrectV2 if {
+    ControlNumber := "Defender 2.2"
+    Requirement := "The action for the DLP policy SHOULD be set to block sharing sensitive information with everyone when DLP conditions are met"
+
+    Output := tests with input as {
+        "dlp_compliance_rules": [
+            {
+                "ContentContainsSensitiveInformation":  [
+                    {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"}
+                ],
+                "Name":  "Baseline Rule",
+	            "Disabled" : false,
+                "ParentPolicyName":  "Default Office 365 DLP policy",
+	            "BlockAccess":  true,
+                "BlockAccessScope":  "All",
+	            "NotifyUser":  [
+                    "SiteAdmin",
+                    "LastModifier",
+                    "Owner"
+                ],
+	            "NotifyUserType":  "NotSet"
+            }
+        ],
+        "dlp_compliance_policies": [
+            {
+                "Name": "Default Office 365 DLP policy",
+                "Mode": "TestWithNotifications"
+            }
+        ]
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "1 rule(s) found that do(es) not block access or associated policy not set to enforce block action: Baseline Rule"
 }
 
 #


### PR DESCRIPTION
#Fix Defender 2.2 Policy 3 bug when DLP policy in test mode#

## 🗣 Description ##

- Adds a new test for Defender 2.2 policy item 3 to include rules when the enclosing policy is set to test mode even if the rule itself is set to block
- Updates wording in the report details to note that it may be the policy, not the rule, causing the warning
- Adds a new unit test to validate the new use case is captured

Closes #42

## 💭 Motivation and context ##

Defender baseline 2.2 policy 3 states that:
* The action for the DLP policy SHOULD be set to block sharing sensitive information with everyone when DLP conditions are met.

The assessment report, however, was reporting PASS for some rules even though the associated policy does not enforce the block when set in Test mode rather than On.  This is inconsistent with the intent of the baseline policy to ensure that sharing of sensitive information is blocked by the Defender DLP component.

The fix detects rules that are set to block but contained within a policy that does not enforce blocking actions and flags these in addition to rules that do not block.  The report details were also adjusted to note the possibility that it is the policy mode, not the rule action, that is causing the warning.

The fix addresses the original bug, but updates to the associated baseline policy may also help clarify to the reader what is intended without changing the overall meaning.  Baseline changes are outside the scope of this PR.

## 🧪 Testing ##

Changes were tested on the associated bug fix branch.  To test these changes, a user would go to a M365 tenant's compliance center admin console

1. Sign in to the [Microsoft 365 compliance](https://compliance.microsoft.com/) admin center.
2. Under Solutions, select Data loss prevention.
3. Select Policies from the top of the page.
4. Select Default Office 365 DLP policy (or named policy containing sensitive information rules)
5. Select Edit policy.
6. Make sure a rule or rules exist with sensitive information content blocking enabled
7. Select Next until the "Test or Turn it On" page and select the Test option
8. Select Next and then Submit the changes

After the submitted changes are saved, run a new Defender report with ScubaGear.

```Invoke-SCuBA -p defender```

Check the resulting Defender assessment report and validate that the rules inside the policy you set to Test show up in the report details for Defender 2.2 policy item 3.
![Screenshot 2023-01-19 at 9 44 25 AM](https://user-images.githubusercontent.com/108814318/213487388-0a51b15c-2034-423d-8f4d-ba2c8eb232f6.png)

Now go back and edit the same policy, but change its mode to `Turn it on` instead of Test and save it.  Re-run the report and the warning should now be a pass assuming no other non-compliant rules or policies are present.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.
