### PR TITLE
EXO 2.7 Rego Bug Fix | Only Enabled Correctly Configured Rules Pass

### DIFF
--- a/Rego/EXOConfig.rego
+++ b/Rego/EXOConfig.rego
@@ -330,7 +330,7 @@ tests[{
 }] {
     Rules := input.transport_rule
     ErrorMessage := "No transport rule found with that applies to emails received from outside the organization"
-    EnabledRules := [rule | rule = Rules[_]; rule.State == "Enabled"]
+    EnabledRules := [rule | rule = Rules[_]; rule.State == "Enabled"; rule.Mode == "Enforce"]
     Conditions := [IsCorrectScope | IsCorrectScope = EnabledRules[_].FromScope == "NotInOrganization"]
     Status := count([Condition | Condition = Conditions[_]; Condition == true]) > 0
 }

--- a/Rego/EXOConfig.rego
+++ b/Rego/EXOConfig.rego
@@ -316,7 +316,6 @@ tests[{
 ################
 # Baseline 2.7 #
 ################
-
 #
 # Baseline 2.7: Policy 1
 #--
@@ -331,7 +330,8 @@ tests[{
 }] {
     Rules := input.transport_rule
     ErrorMessage := "No transport rule found with that applies to emails received from outside the organization"
-    Conditions := [IsCorrectScope | IsCorrectScope = Rules[_].FromScope == "NotInOrganization"]
+    EnabledRules := [rule | rule = Rules[_]; rule.State == "Enabled"]
+    Conditions := [IsCorrectScope | IsCorrectScope = EnabledRules[_].FromScope == "NotInOrganization"]
     Status := count([Condition | Condition = Conditions[_]; Condition == true]) > 0
 }
 #--

--- a/Rego/EXOConfig.rego
+++ b/Rego/EXOConfig.rego
@@ -329,7 +329,7 @@ tests[{
     "RequirementMet" : Status
 }] {
     Rules := input.transport_rule
-    ErrorMessage := "No transport rule found with that applies to emails received from outside the organization"
+    ErrorMessage := "No transport rule found that applies warnings to emails received from outside the organization"
     EnabledRules := [rule | rule = Rules[_]; rule.State == "Enabled"; rule.Mode == "Enforce"]
     Conditions := [IsCorrectScope | IsCorrectScope = EnabledRules[_].FromScope == "NotInOrganization"]
     Status := count([Condition | Condition = Conditions[_]; Condition == true]) > 0

--- a/Testing/Unit/Rego/EXO/EXOConfig2_07_test.rego
+++ b/Testing/Unit/Rego/EXO/EXOConfig2_07_test.rego
@@ -12,7 +12,8 @@ test_FromScope_Correct if {
     Output := tests with input as {
         "transport_rule": [
             {
-                "FromScope" : "NotInOrganization"
+                "FromScope" : "NotInOrganization",
+                "State" : "Enabled"
             }
         ]    
     }
@@ -24,14 +25,35 @@ test_FromScope_Correct if {
     RuleOutput[0].ReportDetails == "Requirement met"
 }
 
-test_FromScope_Incorrect if {
+test_FromScope_Incorrect1 if {
     ControlNumber := "EXO 2.7"
     Requirement := "External sender warnings SHALL be implemented"
 
     Output := tests with input as {
         "transport_rule": [
             {
-                "FromScope" : ""
+                "FromScope" : "",
+                "State" : "Enabled"
+            }
+        ]    
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+ 
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "No transport rule found with that applies to emails received from outside the organization"
+}
+
+test_FromScope_Incorrect2 if {
+    ControlNumber := "EXO 2.7"
+    Requirement := "External sender warnings SHALL be implemented"
+
+    Output := tests with input as {
+        "transport_rule": [
+            {
+                "FromScope" : "NotInOrganization",
+                "State" : "Disabled"
             }
         ]    
     }
@@ -50,10 +72,16 @@ test_FromScope_Multiple_Correct if {
     Output := tests with input as {
         "transport_rule": [
             {
-                "FromScope" : ""
+                "FromScope" : "",
+                "State" : "Disabled"
             },
             {
-                "FromScope" : "NotInOrganization"
+                "FromScope" : "",
+                "State" : "Enabled"
+            },
+            {
+                "FromScope" : "NotInOrganization",
+                "State" : "Enabled"
             }
         ]    
     }
@@ -72,10 +100,20 @@ test_FromScope_Multiple_Incorrect if {
     Output := tests with input as {
         "transport_rule": [
             {
-                "FromScope" : ""
+                "FromScope" : "",
+                "State" : "Enabled"
             },
             {
-                "FromScope" : "Hello there"
+                "FromScope" : "Hello there",
+                "State" : "Enabled"
+            },
+            {
+                "FromScope" : "",
+                "State" : "Disabled"
+            },
+            {
+                "FromScope" : "Hello there",
+                "State" : "Enabled"
             }
         ]    
     }

--- a/Testing/Unit/Rego/EXO/EXOConfig2_07_test.rego
+++ b/Testing/Unit/Rego/EXO/EXOConfig2_07_test.rego
@@ -44,7 +44,7 @@ test_FromScope_IncorrectV1 if {
  
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
-    RuleOutput[0].ReportDetails == "No transport rule found with that applies to emails received from outside the organization"
+    RuleOutput[0].ReportDetails == "No transport rule found that applies warnings to emails received from outside the organization"
 }
 
 test_FromScope_IncorrectV2 if {
@@ -65,7 +65,7 @@ test_FromScope_IncorrectV2 if {
  
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
-    RuleOutput[0].ReportDetails == "No transport rule found with that applies to emails received from outside the organization"
+    RuleOutput[0].ReportDetails == "No transport rule found that applies warnings to emails received from outside the organization"
 }
 
 test_FromScope_IncorrectV3 if {
@@ -86,7 +86,7 @@ test_FromScope_IncorrectV3 if {
  
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
-    RuleOutput[0].ReportDetails == "No transport rule found with that applies to emails received from outside the organization"
+    RuleOutput[0].ReportDetails == "No transport rule found that applies warnings to emails received from outside the organization"
 }
 
 test_FromScope_IncorrectV4 if {
@@ -107,7 +107,7 @@ test_FromScope_IncorrectV4 if {
  
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
-    RuleOutput[0].ReportDetails == "No transport rule found with that applies to emails received from outside the organization"
+    RuleOutput[0].ReportDetails == "No transport rule found that applies warnings to emails received from outside the organization"
 }
 
 test_FromScope_Multiple_Correct if {
@@ -189,5 +189,5 @@ test_FromScope_Multiple_Incorrect if {
  
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
-    RuleOutput[0].ReportDetails == "No transport rule found with that applies to emails received from outside the organization"
+    RuleOutput[0].ReportDetails == "No transport rule found that applies warnings to emails received from outside the organization"
 }

--- a/Testing/Unit/Rego/EXO/EXOConfig2_07_test.rego
+++ b/Testing/Unit/Rego/EXO/EXOConfig2_07_test.rego
@@ -13,7 +13,8 @@ test_FromScope_Correct if {
         "transport_rule": [
             {
                 "FromScope" : "NotInOrganization",
-                "State" : "Enabled"
+                "State" : "Enabled",
+                "Mode" : "Enforce"
             }
         ]    
     }
@@ -25,7 +26,7 @@ test_FromScope_Correct if {
     RuleOutput[0].ReportDetails == "Requirement met"
 }
 
-test_FromScope_Incorrect1 if {
+test_FromScope_IncorrectV1 if {
     ControlNumber := "EXO 2.7"
     Requirement := "External sender warnings SHALL be implemented"
 
@@ -33,7 +34,8 @@ test_FromScope_Incorrect1 if {
         "transport_rule": [
             {
                 "FromScope" : "",
-                "State" : "Enabled"
+                "State" : "Enabled",
+                "Mode" : "Audit"
             }
         ]    
     }
@@ -45,7 +47,7 @@ test_FromScope_Incorrect1 if {
     RuleOutput[0].ReportDetails == "No transport rule found with that applies to emails received from outside the organization"
 }
 
-test_FromScope_Incorrect2 if {
+test_FromScope_IncorrectV2 if {
     ControlNumber := "EXO 2.7"
     Requirement := "External sender warnings SHALL be implemented"
 
@@ -53,7 +55,50 @@ test_FromScope_Incorrect2 if {
         "transport_rule": [
             {
                 "FromScope" : "NotInOrganization",
-                "State" : "Disabled"
+                "State" : "Disabled",
+                "Mode" : "Audit"
+            }
+        ]    
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+ 
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "No transport rule found with that applies to emails received from outside the organization"
+}
+
+test_FromScope_IncorrectV3 if {
+    ControlNumber := "EXO 2.7"
+    Requirement := "External sender warnings SHALL be implemented"
+
+    Output := tests with input as {
+        "transport_rule": [
+            {
+                "FromScope" : "",
+                "State" : "Enabled",
+                "Mode" : "AuditAndNotify"
+            }
+        ]    
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+ 
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "No transport rule found with that applies to emails received from outside the organization"
+}
+
+test_FromScope_IncorrectV4 if {
+    ControlNumber := "EXO 2.7"
+    Requirement := "External sender warnings SHALL be implemented"
+
+    Output := tests with input as {
+        "transport_rule": [
+            {
+                "FromScope" : "NotInOrganization",
+                "State" : "Disabled",
+                "Mode" : "AuditAndNotify"
             }
         ]    
     }
@@ -73,15 +118,23 @@ test_FromScope_Multiple_Correct if {
         "transport_rule": [
             {
                 "FromScope" : "",
-                "State" : "Disabled"
+                "State" : "Disabled",
+                "Mode" : "Enforce"
             },
             {
                 "FromScope" : "",
-                "State" : "Enabled"
+                "State" : "Enabled",
+                "Mode" : "Audit"
+            },
+            {
+                "FromScope" : "",
+                "State" : "Enabled",
+                "Mode" : "AuditAndNotify"
             },
             {
                 "FromScope" : "NotInOrganization",
-                "State" : "Enabled"
+                "State" : "Enabled",
+                "Mode" : "Enforce"
             }
         ]    
     }
@@ -101,19 +154,33 @@ test_FromScope_Multiple_Incorrect if {
         "transport_rule": [
             {
                 "FromScope" : "",
-                "State" : "Enabled"
+                "State" : "Enabled",
+                "Mode":"Enforce"
             },
             {
                 "FromScope" : "Hello there",
-                "State" : "Enabled"
-            },
-            {
-                "FromScope" : "",
-                "State" : "Disabled"
+                "State" : "Enabled",
+                "Mode":"Audit"
             },
             {
                 "FromScope" : "Hello there",
-                "State" : "Enabled"
+                "State" : "Enabled",
+                "Mode":"AuditAndNotify"
+            },
+            {
+                "FromScope" : "NotInOrganization",
+                "State" : "Enabled",
+                "Mode":"Audit"
+            },
+            {
+                "FromScope" : "NotInOrganization",
+                "State" : "Enabled",
+                "Mode":"AuditAndNotify"
+            },
+            {
+                "FromScope" : "NotInOrganization",
+                "State" : "Disabled",
+                "Mode":"Enforce"
             }
         ]    
     }


### PR DESCRIPTION
## 🗣 Description ##

- Adds extra line in EXO 2.7 rego that filters the rules analyzed in the code by whether the rules are enabled. 
- Writes unit testing for EXO 2.7 to accommodate for the new logic. 

## 💭 Motivation and context ##

- Before this pull request, EXO 2.7 will pass if the rule is correctly configured but disabled, defeating the purpose of the baseline control. The solution is to add a line of rego code before checking the rule to see if it is correctly configured that filters the rules down to only the enabled rules.
- This pull request closes issues 126 and 27. 

## 🧪 Testing ##

- I tested my changes on a test tenant by creating two rules: a correctly configured rule and an incorrectly configured rule. After making the change in the rego code, I confirmed that when the correctly configured rule is enabled that the test passes. I also tested if they were both disabled, both enabled, and if the incorrect rule is enabled and the correct is disabled. Each case passed or failed appropriately.
- I also ran the unit tests for Exchange Online and confirmed that all tests pass.  
- A reviewer should confirm that all unit tests pass and confirm that a correctly configured rule that is disabled fails the test and only a correctly configured rule that is enabled succeeds. 

---


## ✅ Pre-approval checklist ##

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

- [ ] Add a tag or create a release.