### PR TITLE
Set encoding explictly

### DIFF
--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -252,6 +252,24 @@ $ProdToFullName = @{
     OneDrive = "OneDrive for Business";
 }
 
+function Get-FileEncoding{
+    <#
+    .Description
+    This function returns encoding type for setting content.
+    .Functionality
+    Internal
+    #>
+    $PSVersion = $PSVersionTable.PSVersion
+
+    $Encoding = 'utf8'
+
+    if ($PSVersion -ge '7.2.0'){
+        $Encoding = 'utf8NoBom'
+    }
+
+    return $Encoding
+}
+
 function Invoke-ProviderList {
     <#
     .Description
@@ -356,7 +374,7 @@ function Invoke-ProviderList {
         $BaselineSettingsExport = $BaselineSettingsExport.replace("\`"", "'")
         $BaselineSettingsExport = $BaselineSettingsExport.replace("\", "")
         $FinalPath = Join-Path -Path $OutFolderPath -ChildPath "$($OutProviderFileName).json"
-        $BaselineSettingsExport | Set-Content -Path $FinalPath
+        $BaselineSettingsExport | Set-Content -Path $FinalPath -Encoding $(Get-FileEncoding)
     }
 }
 
@@ -427,7 +445,7 @@ function Invoke-RunRego {
 
             $TestResultsJson = $TestResults | ConvertTo-Json -Depth 5
             $FileName = Join-Path -path $OutFolderPath "$($OutRegoFileName).json"
-            $TestResultsJson | Set-Content -Path $FileName
+            $TestResultsJson | Set-Content -Path $FileName -Encoding $(Get-FileEncoding)
 
             foreach ($Product in $TestResults) {
                 foreach ($Test in $Product) {
@@ -441,7 +459,7 @@ function Invoke-RunRego {
 
             $TestResultsCsv = $TestResults | ConvertTo-Csv -NoTypeInformation
             $CSVFileName = Join-Path -Path $OutFolderPath "$($OutRegoFileName).csv"
-            $TestResultsCsv | Set-Content -Path $CSVFileName
+            $TestResultsCsv | Set-Content -Path $CSVFileName -Encoding $(Get-FileEncoding)
         }
     }
 

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -263,7 +263,7 @@ function Get-FileEncoding{
 
     $Encoding = 'utf8'
 
-    if ($PSVersion -ge '7.2.0'){
+    if ($PSVersion -ge '6.0'){
         $Encoding = 'utf8NoBom'
     }
 


### PR DESCRIPTION
## 🗣 Description ##

Explicitly set encoding to UTF8 when Set-Content is invoked.

## 💭 Motivation and context ##

This standardizes encoding for files written to the file system. Primarily this is to ensure the OPA Agent is getting 
files encoded as UTF8. Closes issue [#20](https://github.com/cisagov/ScubaGear/issues/20)
  
## 🧪 Testing ##

Executed 'Invoke-SCuBA -ProductNames aad' in both PowerShell 5.1.19041.2364 and 7.3.0.  Verified ProviderSettingExport.json was utf8 encoded. 

## ✅ Pre-approval checklist ##
- [x ] This PR has an informative and human-readable title.
- [x ] Changes are limited to a single goal - *eschew scope creep!*
- [x ] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x ] All relevant type-of-change labels have been added.
- [x ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x ] Tests have been added and/or modified to cover the changes in this PR.
- [x ] All new and existing tests pass.

## ✅ Pre-merge checklist ##
- [ X] Revert dependencies to default branches.
- [X ] Finalize version.

## ✅ Post-merge checklist ##

- [ ] Add a tag or create a release.
