### PR TITLE
Implements a workaround for issue number 134

### DIFF
--- a/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
+++ b/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
@@ -43,6 +43,12 @@ $AllTitles =  Get-Content $FileName | ConvertFrom-Json
 $Titles = $AllTitles.$BaselineName
 
 $FileName = Join-Path -Path $OutPath -ChildPath "$($OutProviderFileName).json"
+
+# This implements a fix for issue 134.
+if ($BaselineName -eq "aad") {
+    ((Get-Content -Path $FileName -Raw) -Replace '"conditional_access_policies": ,','"conditional_access_policies": {},') | Set-Content -Path $FileName
+}
+
 $SettingsExport =  Get-Content $FileName | ConvertFrom-Json
 
 $FileName = Join-Path -Path $OutPath -ChildPath "$($OutRegoFileName).json"


### PR DESCRIPTION
Implements a workaround for issue 134 [https://github.com/cisagov/ScubaGear/issues/134](https://github.com/cisagov/ScubaGear/issues/134).

## 🗣 Description ##

Issue 134 details a problem creating a report for AAD. The root cause of the problem is invalid JSON data contained in ProviderSettingsExport.json.

Specifically, the below line contained in ProviderSettingsExport.json does not properly validate:

```json
"conditional_access_policies": ,
```

## 💭 Motivation and context ##

Due to the JSON validation error, neither AADReport.html nor BaselineReports.html were generated when I ran the command below:

```powershell
Invoke-Scuba -ProductNames aad
```
Since the root cause of issue number 134 is related to running ```Invoke-Scuba -ProductNames aad``` for a tenant that does not have any Conditional Access Policies, the only ProductName which encountered issue number 134 was aad. I tested this using sharepoint, onedrive, exo, teams, and defender. I confirmed no other ProductNames encountered this issue.

I confirmed there was valid data contained in ProviderSettingsExport.json. I confirmed there was valid data contained in TestResults.json.

Tested and confirmed that replacing the following:

```json
"conditional_access_policies": ,
```

with the following:

```json
"conditional_access_policies": {},
```

resolved issue number 134.

As the issue appeared to be limited to creating the reports related to aad, I decided to update CreateReport.psm1 to replace:

```json
"conditional_access_policies": ,
```

with:

```json
"conditional_access_policies": {},
```

I tested adding the following code between lines 45 and 46 in CreateReport.psm1:

```powershell
# This implements a fix for issue 134.
if ($BaselineName -eq "aad") {
    ((Get-Content -Path $FileName -Raw) -Replace '"conditional_access_policies": ,','"conditional_access_policies": {},') | Set-Content -Path $FileName
}
```

I ran ```Invoke-Scuba -ProductNames aad```. No errors were returned. Both BaselineReports.html and AADReport.html were created successfully.



<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Add a tag or create a release.
