### PR TITLE
Hotfix the fatal error caused by duplicate JSON keys being generated in the EXO Provider

### DIFF
--- a/PowerShell/ScubaGear/Modules/Providers/ExportEXOProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportEXOProvider.psm1
@@ -61,8 +61,8 @@ function Export-EXOProvider {
     <#
     2.13
     #>
-
-    $Config = ConvertTo-Json @($Tracker.TryCommand("Get-OrganizationConfig"))
+    $Config = $Tracker.TryCommand("Get-OrganizationConfig") | Select-Object Name, DisplayName, AuditDisabled
+    $Config = ConvertTo-Json @($Config)
 
 
     $SuccessfulCommands = ConvertTo-Json @($Tracker.GetSuccessfulCommands())
@@ -130,7 +130,7 @@ function Get-EXOTenantDetail {
             "DisplayName"= $OrgConfig.DisplayName;
             "DomainName" = $DomainName;
             "TenantId" = $TenantId;
-            "EXOAdditionalData" = $OrgConfig;
+            "EXOAdditionalData" = "Unable to safely retrieve due to EXO API changes";
         }
         $EXOTenantInfo = ConvertTo-Json @($EXOTenantInfo) -Depth 4
         $EXOTenantInfo


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->
- Updated `Get-EXOTenantDetail` to omit the "EXOAdditionalData" values returned from `Get-OrganizationConfig`
- Updated the Get-OrganizationConfig cmdlet call used in the EXO Provider to select only the fields we need for EXO 2.13
- Both changes above remove the offending duplicate key `RootPublicFolderMailbox.Type` field generated from ConvertTo-Json.
## 💭 Motivation and context ##
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->
Closes #132
TODO: address the root cause in the pull request that solves issue #139 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
- Confirmed on main branch that Test Tenant 1 (G5), Test Tenant 2 (G3), and now even Test Tenant 4 (E5) are erroring when running `Invoke-Scuba -ProductNames exo` 
 - Ran the updated code in this branch against Test Tenant 1 (G5) with no issues to EXO 2.13 and other providers with the following commands. `Invoke-Scuba -ProductNames exo` `Invoke-Scuba -ProductNames defender` `Invoke-Scuba -ProductNames exo, defender, teams `
 - Ran the updated code in this branch against Test Tenant 1 (G3) with no issues with the following commands. `Invoke-Scuba -ProductNames exo` `Invoke-Scuba -ProductNames defender` `Invoke-Scuba -ProductNames aad, exo, defender`
 - Ran the updated code in this branch against Test Tenant 4 (E5) with no issues with the following commands. `Invoke-Scuba -ProductNames exo` `Invoke-Scuba -ProductNames defender` `Invoke-Scuba -ProductNames exo, powerplatform, onedrive, teams`
- Ran the updated code in this branch against Test Tenant 1 (G5) and 2 (G3) with `Invoke-Scuba -ProductNames * -M365Enviroment gcc` with no issues.
- Ran the updated code in this branch against Test Tenant 4 (E5) with `Invoke-Scuba -ProductNames * -M365Enviroment commercial` with no issues and compared with previous reports. No regressions found.
<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] ~~I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.~~
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Add a tag or create a release.
