### PR TITLE
Sharepoint rego policies do not implement all the conditions in the baseline policy

### DIFF
--- a/Rego/SharepointConfig.rego
+++ b/Rego/SharepointConfig.rego
@@ -18,7 +18,7 @@ tests[{
     "Control" : "Sharepoint 2.1",
     "Criticality" : "Shall",
     "Commandlet" : ["Get-SPOTenant"],
-    "ActualValue" : Policy,
+    "ActualValue" : Policy.DefaultSharingLinkType,
     "ReportDetails" : ReportDetailsBoolean(Status),
     "RequirementMet" : Status
 }] {
@@ -64,7 +64,7 @@ tests[{
     "Control" : "Sharepoint 2.2",
     "Criticality" : "Should",
     "Commandlet" : ["Get-SPOTenant"],
-    "ActualValue" : Policy,
+    "ActualValue" : [Policy.SharingCapability, Policy.SharingDomainRestrictionMode],
     "ReportDetails" : ReportDetails2_2(Policy),
     "RequirementMet" : Status
 }] {
@@ -134,7 +134,7 @@ tests[{
     "Control" : "Sharepoint 2.4",
     "Criticality" : "Should",
     "Commandlet" : ["Get-SPOTenant"],
-    "ActualValue" : Policy,
+    "ActualValue" : [Policy.ExternalUserExpirationRequired, Policy.EmailAttestationRequired],
     "ReportDetails" : ReportDetails2_4_1(Policy),
     "RequirementMet" : Status
 }] {
@@ -176,7 +176,7 @@ tests[{
     "Control" : "Sharepoint 2.4",
     "Criticality" : "Should",
     "Commandlet" : ["Get-SPOTenant"],
-    "ActualValue" : Policy,
+    "ActualValue" : [Policy.ExternalUserExpireInDays, Policy.EmailAttestationReAuthDays],
     "ReportDetails" : ReportDetails2_4_2(Policy),
     "RequirementMet" : Status
 }] {
@@ -216,7 +216,7 @@ tests[{
     "Control" : "Sharepoint 2.5",
     "Criticality" : "Shall",
     "Commandlet" : ["Get-SPOSite"],
-    "ActualValue" : Policy,
+    "ActualValue" : Policy.DenyAddAndCustomizePages,
     "ReportDetails" : ReportDetailsBoolean(Status),
     "RequirementMet" : Status
 }] {

--- a/Rego/SharepointConfig.rego
+++ b/Rego/SharepointConfig.rego
@@ -18,7 +18,7 @@ tests[{
     "Control" : "Sharepoint 2.1",
     "Criticality" : "Shall",
     "Commandlet" : ["Get-SPOTenant"],
-    "ActualValue" : Policies,
+    "ActualValue" : Policy,
     "ReportDetails" : ReportDetailsBoolean(Status),
     "RequirementMet" : Status
 }] {
@@ -127,13 +127,14 @@ ReportDetails2_4_1(Policy) = Description if {
     Policy.ExternalUserExpirationRequired == false
     Policy.EmailAttestationRequired == false
 	Description := "Requirement not met"
+}
 
 tests[{
     "Requirement" : "Expiration timers for 'guest access to a site or OneDrive' and 'people who use a verification code' SHOULD be set",
     "Control" : "Sharepoint 2.4",
     "Criticality" : "Should",
     "Commandlet" : ["Get-SPOTenant"],
-    "ActualValue" : Policies,
+    "ActualValue" : Policy,
     "ReportDetails" : ReportDetails2_4_1(Policy),
     "RequirementMet" : Status
 }] {
@@ -175,7 +176,7 @@ tests[{
     "Control" : "Sharepoint 2.4",
     "Criticality" : "Should",
     "Commandlet" : ["Get-SPOTenant"],
-    "ActualValue" : Policies,
+    "ActualValue" : Policy,
     "ReportDetails" : ReportDetails2_4_2(Policy),
     "RequirementMet" : Status
 }] {
@@ -215,7 +216,7 @@ tests[{
     "Control" : "Sharepoint 2.5",
     "Criticality" : "Shall",
     "Commandlet" : ["Get-SPOSite"],
-    "ActualValue" : Policies,
+    "ActualValue" : Policy,
     "ReportDetails" : ReportDetailsBoolean(Status),
     "RequirementMet" : Status
 }] {

--- a/Rego/SharepointConfig.rego
+++ b/Rego/SharepointConfig.rego
@@ -70,7 +70,7 @@ tests[{
     "Criticality" : "Should",
     "Commandlet" : ["Get-SPOTenant"],
     "ActualValue" : Policy,
-    "ReportDetails" : ReportDetails2_2(Status),
+    "ReportDetails" : ReportDetails2_2(Policy),
     "RequirementMet" : Status
 }] {
     Policy := input.SPO_tenant[_]

--- a/Rego/SharepointConfig.rego
+++ b/Rego/SharepointConfig.rego
@@ -69,7 +69,7 @@ tests[{
     "Control" : "Sharepoint 2.2",
     "Criticality" : "Should",
     "Commandlet" : ["Get-SPOTenant"],
-    "ActualValue" : Policies,
+    "ActualValue" : Policy,
     "ReportDetails" : ReportDetails2_2(Status),
     "RequirementMet" : Status
 }] {

--- a/Testing/Unit/Rego/Sharepoint/SharepointConfig2_02_test.rego
+++ b/Testing/Unit/Rego/Sharepoint/SharepointConfig2_02_test.rego
@@ -12,7 +12,8 @@ test_SharingCapability_Correct if {
     Output := tests with input as {
         "SPO_tenant": [
             {
-                "SharingCapability" : 1
+                "SharingCapability" : 1,
+                "SharingDomainRestrictionMode" : 1
             }
         ]
     }
@@ -24,16 +25,57 @@ test_SharingCapability_Correct if {
     RuleOutput[0].ReportDetails == "Requirement met"
 }
 
-test_SharingCapability_Incorrect if {
+test_SharingCapability_Incorrect_V1 if {
     ControlNumber := "Sharepoint 2.2"
     Requirement := "External sharing SHOULD be limited to approved domains and security groups per interagency collaboration needs"
 
     Output := tests with input as {
         "SPO_tenant": [
             {
-                "SharingCapability" : 2
+                "SharingCapability" : 2,
+                "SharingDomainRestrictionMode" : 1
             }
-        ]        
+        ]
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement not met: Sharepoint sharing slider must be set to 'New and Existing Guests'"
+}
+
+test_SharingCapability_Incorrect_V2 if {
+    ControlNumber := "Sharepoint 2.2"
+    Requirement := "External sharing SHOULD be limited to approved domains and security groups per interagency collaboration needs"
+
+    Output := tests with input as {
+        "SPO_tenant": [
+            {
+                "SharingCapability" : 1,
+                "SharingDomainRestrictionMode" : 0
+            }
+        ]
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement not met: 'Limit external sharing by domain' must be enabled"
+}
+
+test_SharingCapability_Incorrect_V3 if {
+    ControlNumber := "Sharepoint 2.2"
+    Requirement := "External sharing SHOULD be limited to approved domains and security groups per interagency collaboration needs"
+
+    Output := tests with input as {
+        "SPO_tenant": [
+            {
+                "SharingCapability" : 2,
+                "SharingDomainRestrictionMode" : 0
+            }
+        ]
     }
 
     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]

--- a/Testing/Unit/Rego/Sharepoint/SharepointConfig2_04_test.rego
+++ b/Testing/Unit/Rego/Sharepoint/SharepointConfig2_04_test.rego
@@ -12,9 +12,10 @@ test_ExternalUserExpirationRequired_Correct if {
     Output := tests with input as {
         "SPO_tenant": [
             {
-                "ExternalUserExpirationRequired" : true
+                "ExternalUserExpirationRequired" : true,
+                "EmailAttestationRequired" : true
             }
-        ]        
+        ]
     }
 
     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
@@ -24,16 +25,57 @@ test_ExternalUserExpirationRequired_Correct if {
     RuleOutput[0].ReportDetails == "Requirement met"
 }
 
-test_ExternalUserExpirationRequired_Incorrect if {
+test_ExternalUserExpirationRequired_Incorrect_V1 if {
     ControlNumber := "Sharepoint 2.4"
     Requirement := "Expiration timers for 'guest access to a site or OneDrive' and 'people who use a verification code' SHOULD be set"
 
     Output := tests with input as {
         "SPO_tenant": [
             {
-                "ExternalUserExpirationRequired" : false
+                "ExternalUserExpirationRequired" : false,
+                "EmailAttestationRequired" : true
             }
-        ]        
+        ]
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement not met: 'Guest access to a site or OneDrive will expire automatically after this many days' must be enabled"
+}
+
+test_ExternalUserExpirationRequired_Incorrect_V2 if {
+    ControlNumber := "Sharepoint 2.4"
+    Requirement := "Expiration timers for 'guest access to a site or OneDrive' and 'people who use a verification code' SHOULD be set"
+
+    Output := tests with input as {
+        "SPO_tenant": [
+            {
+                "ExternalUserExpirationRequired" : true,
+                "EmailAttestationRequired" : false
+            }
+        ]
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement not met: 'People who use a verification code must reauthenticate after this many days' must be enabled"
+}
+
+test_ExternalUserExpirationRequired_Incorrect_V3 if {
+    ControlNumber := "Sharepoint 2.4"
+    Requirement := "Expiration timers for 'guest access to a site or OneDrive' and 'people who use a verification code' SHOULD be set"
+
+    Output := tests with input as {
+        "SPO_tenant": [
+            {
+                "ExternalUserExpirationRequired" : false,
+                "EmailAttestationRequired" : false
+            }
+        ]
     }
 
     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
@@ -53,9 +95,10 @@ test_ExternalUserExpireInDays_Correct if {
     Output := tests with input as {
         "SPO_tenant": [
             {
-                "ExternalUserExpireInDays" : 30
+                "ExternalUserExpireInDays" : 30,
+                "EmailAttestationReAuthDays" : 30
             }
-        ]        
+        ]
     }
 
     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
@@ -72,16 +115,17 @@ test_ExternalUserExpireInDays_Incorrect_V1 if {
     Output := tests with input as {
         "SPO_tenant": [
             {
-                "ExternalUserExpireInDays" : 29
+                "ExternalUserExpireInDays" : 29,
+                "EmailAttestationReAuthDays" : 30
             }
-        ]        
+        ]
     }
 
     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
 
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
-    RuleOutput[0].ReportDetails == "Requirement not met"
+    RuleOutput[0].ReportDetails == "Requirement not met: 'Guest access to a site or OneDrive will expire automatically after this many days' must be 30 days"
 }
 
 test_ExternalUserExpireInDays_Incorrect_V2 if {
@@ -91,9 +135,90 @@ test_ExternalUserExpireInDays_Incorrect_V2 if {
     Output := tests with input as {
         "SPO_tenant": [
             {
-                "ExternalUserExpireInDays" : 31
+                "ExternalUserExpireInDays" : 31,
+                "EmailAttestationReAuthDays" : 30
             }
-        ]        
+        ]
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement not met: 'Guest access to a site or OneDrive will expire automatically after this many days' must be 30 days"
+}
+
+test_EmailAttestationReAuthDays_Incorrect_V1 if {
+    ControlNumber := "Sharepoint 2.4"
+    Requirement := "Expiration timers SHOULD be set to 30 days"
+
+    Output := tests with input as {
+        "SPO_tenant": [
+            {
+                "ExternalUserExpireInDays" : 30,
+                "EmailAttestationReAuthDays" : 29
+            }
+        ]
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement not met: 'People who use a verification code must reauthenticate after this many days' must be 30 days"
+}
+
+test_EmailAttestationReAuthDays_Incorrect_V2 if {
+    ControlNumber := "Sharepoint 2.4"
+    Requirement := "Expiration timers SHOULD be set to 30 days"
+
+    Output := tests with input as {
+        "SPO_tenant": [
+            {
+                "ExternalUserExpireInDays" : 30,
+                "EmailAttestationReAuthDays" : 31
+            }
+        ]
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement not met: 'People who use a verification code must reauthenticate after this many days' must be 30 days"
+}
+
+test_Multi_Incorrect_V1 if {
+    ControlNumber := "Sharepoint 2.4"
+    Requirement := "Expiration timers SHOULD be set to 30 days"
+
+    Output := tests with input as {
+        "SPO_tenant": [
+            {
+                "ExternalUserExpireInDays" : 29,
+                "EmailAttestationReAuthDays" : 29
+            }
+        ]
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement not met"
+}
+
+test_Multi_Incorrect_V2 if {
+    ControlNumber := "Sharepoint 2.4"
+    Requirement := "Expiration timers SHOULD be set to 30 days"
+
+    Output := tests with input as {
+        "SPO_tenant": [
+            {
+                "ExternalUserExpireInDays" : 31,
+                "EmailAttestationReAuthDays" : 31
+            }
+        ]
     }
 
     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Update the Sharepoint Rego tests to match the current baseline.

## 💭 Motivation and context ##

2.2 & 2.4 did not check all the settings that the baseline covered. As such there were false positives. There is a setting that still needs to be found, so it is marked by TODO & a new issue was opened.

## 🧪 Testing ##
- Unit test cases
- Functional regression testing
- Ran against cisaent

## ✅ Pre-approval checklist ##
- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

- [ ] Add a tag or create a release.
