### PR TITLE
Add Service Principal authentication via CertificateThumprint parameters and correct erroneous GCC High/DOD Defender endpoints

### DIFF
--- a/PowerShell/ScubaGear/Modules/Connection/ConnectHelpers.psm1
+++ b/PowerShell/ScubaGear/Modules/Connection/ConnectHelpers.psm1
@@ -25,7 +25,7 @@ function Connect-EXOHelper {
             $EXOParams += @{'ExchangeEnvironmentName' = "O365USGovGCCHigh";}
         }
         "dod" {
-            $EXOParams += @{'ExchangeEnvironmentName' = "O365USGovDoD";} 
+            $EXOParams += @{'ExchangeEnvironmentName' = "O365USGovDoD";}
         }
     }
 

--- a/PowerShell/ScubaGear/Modules/Connection/ConnectHelpers.psm1
+++ b/PowerShell/ScubaGear/Modules/Connection/ConnectHelpers.psm1
@@ -28,6 +28,41 @@ function Connect-EXOHelper {
     }
 }
 
+function Connect-DefenderHelper {
+    <#
+    .Description
+    This function is used for assisting in connecting to different M365 Environments for EXO.
+    .Functionality
+    Internal
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("commercial", "gcc", "gcchigh", "dod", IgnoreCase = $false)]
+        [string]
+        $M365Environment
+    )
+    $IPPSParams = @{
+        'ErrorAction' = 'Stop';
+    }
+    switch ($M365Environment) {
+        {($_ -eq "commercial") -or ($_ -eq "gcc")} {
+            $IPPSParams = @{'ErrorAction' = 'Stop';} # sanity check
+        }
+        "gcchigh" {
+            $IPPSParams = $IPPSParams + @{'ConnectionUri' = "https://outlook.office365.us/powershell-liveID";}
+        }
+        "dod" {
+            $IPPSParams = $IPPSParams + @{'ConnectionUri' = "https://webmail.apps.mil/powershell-liveID";}
+        }
+        default {
+            throw -Message "Unsupported or invalid M365Environment argument"
+        }
+    }
+    Connect-IPPSSession @IPPSParams | Out-Null
+}
+
 Export-ModuleMember -Function @(
-    'Connect-EXOHelper'
+    'Connect-EXOHelper',
+    'Connect-DefenderHelper'
 )

--- a/PowerShell/ScubaGear/Modules/Connection/ConnectHelpers.psm1
+++ b/PowerShell/ScubaGear/Modules/Connection/ConnectHelpers.psm1
@@ -10,20 +10,29 @@ function Connect-EXOHelper {
         [Parameter(Mandatory = $true)]
         [ValidateSet("commercial", "gcc", "gcchigh", "dod", IgnoreCase = $false)]
         [string]
-        $M365Environment
+        $M365Environment,
+
+        [Parameter(Mandatory = $false)]
+        [hashtable]
+        $CertThumbprintParams
     )
+    $EXOParams = @{
+        ErrorAction = "Stop";
+        ShowBanner = $false;
+    }
     switch ($M365Environment) {
-        {($_ -eq "commercial") -or ($_ -eq "gcc")} {
-            Connect-ExchangeOnline -ShowBanner:$false -ErrorAction "Stop" | Out-Null
-        }
         "gcchigh" {
-            Connect-ExchangeOnline -ShowBanner:$false -ExchangeEnvironmentName "O365USGovGCCHigh" -ErrorAction "Stop" | Out-Null
+            $EXOParams += @{'ExchangeEnvironmentName' = "O365USGovGCCHigh";}
         }
         "dod" {
-            Connect-ExchangeOnline -ShowBanner:$false -ExchangeEnvironmentName "O365USGovDoD" -ErrorAction "Stop" | Out-Null
+            $EXOParams += @{'ExchangeEnvironmentName' = "O365USGovDoD";} 
         }
-
     }
+
+    if ($CertThumbprintParams) {
+        $EXOParams += $CertThumbprintParams
+    }
+    Connect-ExchangeOnline @EXOParams | Out-Null
 }
 
 function Connect-DefenderHelper {
@@ -38,18 +47,25 @@ function Connect-DefenderHelper {
         [Parameter(Mandatory = $true)]
         [ValidateSet("commercial", "gcc", "gcchigh", "dod", IgnoreCase = $false)]
         [string]
-        $M365Environment
+        $M365Environment,
+
+        [Parameter(Mandatory = $false)]
+        [hashtable]
+        $CertThumbprintParams
     )
     $IPPSParams = @{
         'ErrorAction' = 'Stop';
     }
     switch ($M365Environment) {
         "gcchigh" {
-            $IPPSParams = $IPPSParams + @{'ConnectionUri' = "https://outlook.office365.us/powershell-liveID";}
+            $IPPSParams += @{'ConnectionUri' = "https://outlook.office365.us/powershell-liveID";}
         }
         "dod" {
-            $IPPSParams = $IPPSParams + @{'ConnectionUri' = "https://webmail.apps.mil/powershell-liveID";}
+            $IPPSParams += @{'ConnectionUri' = "https://webmail.apps.mil/powershell-liveID";}
         }
+    }
+    if ($CertThumbprintParams) {
+        $IPPSParams += $CertThumbprintParams
     }
     Connect-IPPSSession @IPPSParams | Out-Null
 }

--- a/PowerShell/ScubaGear/Modules/Connection/ConnectHelpers.psm1
+++ b/PowerShell/ScubaGear/Modules/Connection/ConnectHelpers.psm1
@@ -22,9 +22,7 @@ function Connect-EXOHelper {
         "dod" {
             Connect-ExchangeOnline -ShowBanner:$false -ExchangeEnvironmentName "O365USGovDoD" -ErrorAction "Stop" | Out-Null
         }
-        default {
-            throw "Unsupported or invalid M365Environment argument"
-        }
+
     }
 }
 
@@ -46,17 +44,11 @@ function Connect-DefenderHelper {
         'ErrorAction' = 'Stop';
     }
     switch ($M365Environment) {
-        {($_ -eq "commercial") -or ($_ -eq "gcc")} {
-            $IPPSParams = @{'ErrorAction' = 'Stop';} # sanity check
-        }
         "gcchigh" {
             $IPPSParams = $IPPSParams + @{'ConnectionUri' = "https://outlook.office365.us/powershell-liveID";}
         }
         "dod" {
             $IPPSParams = $IPPSParams + @{'ConnectionUri' = "https://webmail.apps.mil/powershell-liveID";}
-        }
-        default {
-            throw -Message "Unsupported or invalid M365Environment argument"
         }
     }
     Connect-IPPSSession @IPPSParams | Out-Null

--- a/PowerShell/ScubaGear/Modules/Connection/ConnectHelpers.psm1
+++ b/PowerShell/ScubaGear/Modules/Connection/ConnectHelpers.psm1
@@ -58,10 +58,12 @@ function Connect-DefenderHelper {
     }
     switch ($M365Environment) {
         "gcchigh" {
-            $IPPSParams += @{'ConnectionUri' = "https://outlook.office365.us/powershell-liveID";}
+            $IPPSParams += @{'ConnectionUri' = "https://ps.compliance.protection.office365.us/powershell-liveid";}
+            $IPPSParams += @{'AzureADAuthorizationEndpointUri' = "https://login.microsoftonline.us/common";}
         }
         "dod" {
-            $IPPSParams += @{'ConnectionUri' = "https://webmail.apps.mil/powershell-liveID";}
+            $IPPSParams += @{'ConnectionUri' = "https://l5.ps.compliance.protection.office365.us/powershell-liveid";}
+            $IPPSParams += @{'AzureADAuthorizationEndpointUri' = "https://login.microsoftonline.us/common";}
         }
     }
     if ($ServicePrincipalParams.CertThumbprintParams) {

--- a/PowerShell/ScubaGear/Modules/Connection/ConnectHelpers.psm1
+++ b/PowerShell/ScubaGear/Modules/Connection/ConnectHelpers.psm1
@@ -14,7 +14,7 @@ function Connect-EXOHelper {
 
         [Parameter(Mandatory = $false)]
         [hashtable]
-        $CertThumbprintParams
+        $ServicePrincipalParams
     )
     $EXOParams = @{
         ErrorAction = "Stop";
@@ -29,8 +29,8 @@ function Connect-EXOHelper {
         }
     }
 
-    if ($CertThumbprintParams) {
-        $EXOParams += $CertThumbprintParams
+    if ($ServicePrincipalParams.CertThumbprintParams) {
+        $EXOParams += $ServicePrincipalParams.CertThumbprintParams
     }
     Connect-ExchangeOnline @EXOParams | Out-Null
 }
@@ -51,7 +51,7 @@ function Connect-DefenderHelper {
 
         [Parameter(Mandatory = $false)]
         [hashtable]
-        $CertThumbprintParams
+        $ServicePrincipalParams
     )
     $IPPSParams = @{
         'ErrorAction' = 'Stop';
@@ -64,8 +64,8 @@ function Connect-DefenderHelper {
             $IPPSParams += @{'ConnectionUri' = "https://webmail.apps.mil/powershell-liveID";}
         }
     }
-    if ($CertThumbprintParams) {
-        $IPPSParams += $CertThumbprintParams
+    if ($ServicePrincipalParams.CertThumbprintParams) {
+        $IPPSParams += $ServicePrincipalParams.CertThumbprintParams
     }
     Connect-IPPSSession @IPPSParams | Out-Null
 }

--- a/PowerShell/ScubaGear/Modules/Connection/Connection.psm1
+++ b/PowerShell/ScubaGear/Modules/Connection/Connection.psm1
@@ -27,8 +27,6 @@ function Connect-Tenant {
     )
     Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "ConnectHelpers.psm1")
 
-    # $a = $ServicePrincipalParams | Out-String
-    # Write-Host $a
     # Prevent duplicate sign ins
     $EXOAuthRequired = $true
     $SPOAuthRequired = $true

--- a/PowerShell/ScubaGear/Modules/Connection/Connection.psm1
+++ b/PowerShell/ScubaGear/Modules/Connection/Connection.psm1
@@ -82,7 +82,10 @@ function Connect-Tenant {
                         }
                     }
                     Connect-MgGraph @GraphParams | Out-Null
-                    Select-MgProfile -Name "Beta" -ErrorAction "Stop" | Out-Null
+                    $GraphProfile = (Get-MgProfile -ErrorAction "Stop").Name
+                    if ($GraphProfile.ToLower() -ne "beta") {
+                        Select-MgProfile -Name "Beta" -ErrorAction "Stop" | Out-Null
+                    }
                     $AADAuthRequired = $false
                 }
                 {($_ -eq "exo") -or ($_ -eq "defender")} {
@@ -146,7 +149,10 @@ function Connect-Tenant {
                             }
                         }
                         Connect-MgGraph @LimitedGraphParams | Out-Null
-                        Select-MgProfile -Name "Beta" -ErrorAction "Stop" | Out-Null
+                        $GraphProfile = (Get-MgProfile -ErrorAction "Stop").Name
+                        if ($GraphProfile.ToLower() -ne "beta") {
+                            Select-MgProfile -Name "Beta" -ErrorAction "Stop" | Out-Null
+                        }
                         $AADAuthRequired = $false
                     }
                     if ($SPOAuthRequired) {

--- a/PowerShell/ScubaGear/Modules/Connection/Connection.psm1
+++ b/PowerShell/ScubaGear/Modules/Connection/Connection.psm1
@@ -59,21 +59,11 @@ function Connect-Tenant {
                         'ErrorAction' = 'Stop';
                     }
                     switch ($M365Environment) {
-                        {($_ -eq "commercial") -or ($_ -eq "gcc")} {
-                            # Sanity check
-                            $GraphParams = @{
-                                'Scopes' = $GraphScopes;
-                                'ErrorAction' = 'Stop';
-                            }
-                        }
                         "gcchigh" {
                             $GraphParams = $GraphParams + @{'Environment' = "USGov";}
                         }
                         "dod" {
                             $GraphParams = $GraphParams + @{'Environment' = "USGovDoD";}
-                        }
-                        default {
-                            throw "Unsupported or invalid M365Environment argument"
                         }
                     }
                     Connect-MgGraph @GraphParams | Out-Null
@@ -105,9 +95,6 @@ function Connect-Tenant {
                         "dod" {
                             $AddPowerAppsParams = $AddPowerAppsParams + @{'Endpoint'='dod';}
                         }
-                        default {
-                            throw "Unsupported or invalid M365Environment argument"
-                        }
                     }
                     Add-PowerAppsAccount @AddPowerAppsParams | Out-Null
                 }
@@ -117,19 +104,11 @@ function Connect-Tenant {
                             'ErrorAction' = 'Stop';
                         }
                         switch ($M365Environment) {
-                            {($_ -eq "commercial") -or ($_ -eq "gcc")} {
-                                $LimitedGraphParams = @{
-                                    'ErrorAction' = 'Stop';
-                                }
-                            }
                             "gcchigh" {
                                 $LimitedGraphParams = $LimitedGraphParams + @{'Environment' = "USGov";}
                             }
                             "dod" {
                                 $LimitedGraphParams = $LimitedGraphParams + @{'Environment' = "USGovDoD";}
-                            }
-                            default {
-                                throw "Unsupported or invalid M365Environment argument"
                             }
                         }
                         Connect-MgGraph @LimitedGraphParams | Out-Null
@@ -160,9 +139,6 @@ function Connect-Tenant {
                                     'Region' = "ITAR";
                                 }
                             }
-                            default {
-                                throw "Unsupported or invalid M365Environment argument"
-                            }
                         }
                         Connect-SPOService @SPOParams | Out-Null
                         $SPOAuthRequired = $false
@@ -171,23 +147,17 @@ function Connect-Tenant {
                 "teams" {
                     $TeamsParams = @{'ErrorAction'= 'Stop'}
                     switch ($M365Environment) {
-                        {($_ -eq "commercial") -or ($_ -eq "gcc")} {
-                            $TeamsParams = @{'ErrorAction'= 'Stop'} # sanity check
-                        }
                         "gcchigh" {
                             $TeamsParams = $TeamsParams + @{'TeamsEnvironmentName'= 'TeamsGCCH';}
                         }
                         "dod" {
                             $TeamsParams = $TeamsParams + @{'TeamsEnvironmentName'= 'TeamsDOD';}
                         }
-                        default {
-                            throw "Unsupported or invalid M365Environment argument"
-                        }
                     }
                     Connect-MicrosoftTeams @TeamsParams | Out-Null
                 }
                 default {
-                    Write-Error -Message "Invalid ProductName argument"
+                    throw "Invalid ProductName argument" 
                 }
             }
         }

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -40,6 +40,16 @@ function Invoke-SCuBA {
     Note: defender will ask for authentication even if this variable is set to `$false`
     .Parameter Version
     Will output the current ScubaGear version to the terminal without running this cmdlet.
+    .Parameter AppID
+    The application ID of the service principal that's used during certificate based
+    authentication. A valid value is the GUID of the application ID (service principal).
+    .Parameter CertificateThumbprint
+    The thumbprint value specifies the certificate that's used for certificate base authentication.
+    The underlying PowerShell modules retrieve the certificate from the user's certificate store.
+    As such, a copy of the certificate must be located there.
+    .Parameter Organization
+    Specify the organization that's used in certificate based authentication.
+    Use the tenant's tenantname.onmicrosoft.com domain for the parameter value.
     .Parameter OutPath
     The folder path where both the output JSON and the HTML report will be created.
     The folder will be created if it does not exist. Defaults to current directory.
@@ -77,6 +87,9 @@ function Invoke-SCuBA {
     Invoke-SCuBA -ProductNames aad,exo -M365Environment gcc -OPAPath . -OutPath . -DisconnectOnExit
     Run the tool against Azure Active Directory and Exchange Online security
     baselines, disconnecting connections for those products when complete.
+    .Example
+    Invoke-SCuBA -ProductNames * -CertificateThumbprint <insert-thumbprint> -AppID <insert-appid> -Organization "tenant.onmicrosoft.com"
+    This example will run the tool against all available security baselines while authenticating using a Service Principal with the CertificateThumprint bundle of parameters.
     .Functionality
     Public
     #>
@@ -912,7 +925,16 @@ function Invoke-RunCached {
     this variable to be `$false` to bypass the reauthenticating in the same session. Default is $true.
     .Parameter Version
     Will output the current ScubaGear version to the terminal without running this cmdlet.
-    .Parameter OutPath
+    .Parameter AppID
+    The application ID of the service principal that's used during certificate based
+    authentication. A valid value is the GUID of the application ID (service principal).
+    .Parameter CertificateThumbprint
+    The thumbprint value specifies the certificate that's used for certificate base authentication.
+    The underlying PowerShell modules retrieve the certificate from the user's certificate store.
+    As such, a copy of the certificate must be located there.
+    .Parameter Organization
+    Specify the organization that's used in certificate based authentication.
+    Use the tenant's tenantname.onmicrosoft.com domain for the parameter value.
     The folder path where both the output JSON and the HTML report will be created.
     The folder will be created if it does not exist. Defaults to current directory.
     .Parameter OutFolderName
@@ -943,6 +965,9 @@ function Invoke-RunCached {
     Invoke-RunCached -ProductNames * -M365Environment dod -OPAPath . -OutPath .
     This example will run the tool against all available security baselines with the
     'dod' teams endpoint.
+    .Example
+    Invoke-SCuBA -ProductNames * -CertificateThumbprint <insert-thumbprint> -AppID <insert-appid> -Organization "tenant.onmicrosoft.com"
+    This example will run the tool against all available security baselines while authenticating using a Service Principal with the CertificateThumprint bundle of parameters.
     .Functionality
     Public
     #>
@@ -978,6 +1003,18 @@ function Invoke-RunCached {
         [Parameter(ParameterSetName = 'Report')]
         [switch]
         $Version,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Report')]
+        [string]
+        $AppID,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Report')]
+        [string]
+        $CertificateThumbprint,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Report')]
+        [string]
+        $Organization,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Report')]
         [ValidateNotNullOrEmpty()]
@@ -1016,7 +1053,7 @@ function Invoke-RunCached {
             }
 
             if ($ProductNames -eq '*'){
-                $ProductNames = "teams", "exo", "defender", "aad", "sharepoint", "onedrive"
+                $ProductNames = "teams", "exo", "defender", "aad", "sharepoint", "onedrive", "powerplatform"
             }
 
             # The equivalent of ..\..
@@ -1063,6 +1100,7 @@ function Invoke-RunCached {
                     'ModuleVersion' = $ModuleVersion;
                     'OutFolderPath' = $OutFolderPath;
                     'OutProviderFileName' = $OutProviderFileName;
+                    'BoundParameters' = $PSBoundParameters;
                 }
                 Invoke-ProviderList @ProviderParams
             }

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -114,6 +114,18 @@ function Invoke-SCuBA {
         $Version,
 
         [Parameter(Mandatory = $false, ParameterSetName = 'Report')]
+        [string]
+        $AppId,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Report')]
+        [string]
+        $CertificateThumbprint,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Report')]
+        [string]
+        $Organization,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Report')]
         [ValidateNotNullOrEmpty()]
         [string]
         $OutPath = '.',
@@ -149,6 +161,15 @@ function Invoke-SCuBA {
 
         if ($ProductNames -eq '*'){
             $ProductNames = "teams", "exo", "defender", "aad", "sharepoint", "onedrive", "powerplatform"
+        }
+
+        $ServicePrincipal
+        if($AppId) {
+            $ServicePrincipal = [pscustomobject]@{
+                "AppId" = $AppId;
+                "CertificateThumbprint" = $CertificateThumbprint;
+                "CertificatePassword" = $CertificatePassword;
+            }
         }
 
         # The equivalent of ..\..

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -348,10 +348,13 @@ function Invoke-ProviderList {
         $SPOProviderParams = @{
             'M365Environment' = $M365Environment
         }
+
+        $PnPFlag = $false
         if ($BoundParameters.AppID) {
             $ServicePrincipalParams = Get-ServicePrincipalParams -BoundParameters $BoundParameters
             $ConnectTenantParams += @{ServicePrincipalParams = $ServicePrincipalParams;}
-            $SPOProviderParams += @{UsePnP = $true;}
+            $PnPFlag = $true
+            $SPOProviderParams += @{PnPFlag = $PnPFlag}
         }
 
         foreach ($Product in $ProductNames) {
@@ -381,7 +384,7 @@ function Invoke-ProviderList {
                     $RetVal = Export-PowerPlatformProvider -M365Environment $M365Environment | Select-Object -Last 1
                 }
                 "onedrive" {
-                    $RetVal = Export-OneDriveProvider @SPOProviderParams | Select-Object -Last 1
+                    $RetVal = Export-OneDriveProvider -PnPFlag:$PnPFlag | Select-Object -Last 1
                 }
                 "sharepoint" {
                     $RetVal = Export-SharePointProvider @SPOProviderParams | Select-Object -Last 1

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -332,9 +332,13 @@ function Invoke-ProviderList {
         $ConnectTenantParams = @{
             'M365Environment' = $M365Environment
         }
+        $SPOProviderParams = @{
+            'M365Environment' = $M365Environment
+        }
         if ($BoundParameters.AppID) {
             $ServicePrincipalParams = Get-ServicePrincipalParams -BoundParameters $BoundParameters
             $ConnectTenantParams += @{ServicePrincipalParams = $ServicePrincipalParams;}
+            $SPOProviderParams += @{UsePnP = $true;}
         }
 
         foreach ($Product in $ProductNames) {
@@ -364,10 +368,10 @@ function Invoke-ProviderList {
                     $RetVal = Export-PowerPlatformProvider -M365Environment $M365Environment | Select-Object -Last 1
                 }
                 "onedrive" {
-                    $RetVal = Export-OneDriveProvider -M365Environment $M365Environment | Select-Object -Last 1
+                    $RetVal = Export-OneDriveProvider @SPOProviderParams | Select-Object -Last 1
                 }
                 "sharepoint" {
-                    $RetVal = Export-SharePointProvider -M365Environment $M365Environment | Select-Object -Last 1
+                    $RetVal = Export-SharePointProvider @SPOProviderParams | Select-Object -Last 1
                 }
                 "teams" {
                     $RetVal = Export-TeamsProvider | Select-Object -Last 1

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -163,15 +163,6 @@ function Invoke-SCuBA {
             $ProductNames = "teams", "exo", "defender", "aad", "sharepoint", "onedrive", "powerplatform"
         }
 
-        $ServicePrincipal
-        if($AppId) {
-            $ServicePrincipal = [pscustomobject]@{
-                "AppId" = $AppId;
-                "CertificateThumbprint" = $CertificateThumbprint;
-                "CertificatePassword" = $CertificatePassword;
-            }
-        }
-
         # The equivalent of ..\..
         $ParentPath = Split-Path $(Split-Path $ParentPath -Parent) -Parent
 
@@ -194,6 +185,7 @@ function Invoke-SCuBA {
             'LogIn' = $LogIn;
             'ProductNames' = $ProductNames;
             'M365Environment' = $M365Environment;
+            'BoundParameters' = $PSBoundParameters;
         }
 
         $ProdAuthFailed = Invoke-Connection @ConnectionParams
@@ -740,15 +732,24 @@ function Invoke-Connection {
 
         [ValidateSet("commercial", "gcc", "gcchigh", "dod")]
         [string]
-        $M365Environment = "commercial"
+        $M365Environment = "commercial",
+
+        [Parameter(Mandatory=$true)]
+        [hashtable]
+        $BoundParameters
     )
 
     # Increase PowerShell Maximum Function Count to support version 5.1 limitation
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'MaximumFunctionCount')]
     $MaximumFunctionCount = 32000
 
+    $ConnectTenantParams = @{
+        'ProductNames' = $ProductNames;
+        'M365Environment' = $M365Environment
+    }
+
     if ($LogIn) {
-        $AnyFailedAuth = Connect-Tenant -ProductNames $ProductNames -M365Environment $M365Environment
+        $AnyFailedAuth = Connect-Tenant @ConnectTenantParams
         $AnyFailedAuth
     }
 }

--- a/PowerShell/ScubaGear/Modules/Providers/ExportDefenderProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportDefenderProvider.psm1
@@ -11,7 +11,11 @@ function Export-DefenderProvider {
         [Parameter(Mandatory = $true)]
         [ValidateSet("commercial", "gcc", "gcchigh", "dod", IgnoreCase = $false)]
         [string]
-        $M365Environment
+        $M365Environment,
+
+        [Parameter(Mandatory = $false)]
+        [hashtable]
+        $CertThumbprintParams
     )
     $ParentPath = Split-Path $PSScriptRoot -Parent
     $ConnectionFolderPath = Join-Path -Path $ParentPath -ChildPath "Connection"
@@ -29,7 +33,13 @@ function Export-DefenderProvider {
     $ExchangeConnected = Get-Command Get-OrganizationConfig -ErrorAction SilentlyContinue
     if(-not $ExchangeConnected) {
         try {
-            Connect-EXOHelper -M365Environment $M365Environment
+            $EXOHelperParams = @{
+                M365Environment = $M365Environment;
+            }
+            if ($CertThumbprintParams) {
+                $EXOHelperParams += @{CertThumbprintParams = $CertThumbprintParams}
+            }
+            Connect-EXOHelper @CertThumbprintParams;
         }
         catch {
             Write-Error "Error connecting to ExchangeOnline. $($_)"
@@ -86,7 +96,14 @@ function Export-DefenderProvider {
     # Connect to Security & Compliance
     $IPPSConnected = $false
     try {
-        Connect-DefenderHelper -M365Environment $M365Environment 
+        $DefenderHelperParams = @{
+            M365Environment = $M365Environment;
+        }
+
+        if ($CertThumbprintParams) {
+            $DefenderHelperParams += @{CertThumbprintParams = $CertThumbprintParams}
+        }
+        Connect-DefenderHelper @DefenderHelperParams
         $IPPSConnected = $true
     }
     catch {

--- a/PowerShell/ScubaGear/Modules/Providers/ExportDefenderProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportDefenderProvider.psm1
@@ -85,25 +85,8 @@ function Export-DefenderProvider {
 
     # Connect to Security & Compliance
     $IPPSConnected = $false
-    $IPPSParams = @{
-        'ErrorAction' = 'Stop';
-    }
     try {
-        switch ($M365Environment) {
-            {($_ -eq "commercial") -or ($_ -eq "gcc")} {
-                $IPPSParams = @{'ErrorAction' = 'Stop';} # sanity check
-            }
-            "gcchigh" {
-                $IPPSParams = $IPPSParams + @{'ConnectionUri' = "https://outlook.office365.us/powershell-liveID";}
-            }
-            "dod" {
-                $IPPSParams = $IPPSParams + @{'ConnectionUri' = "https://webmail.apps.mil/powershell-liveID";}
-            }
-            default {
-                throw -Message "Unsupported or invalid M365Environment argument"
-            }
-        }
-        Connect-IPPSSession @IPPSParams | Out-Null
+        Connect-DefenderHelper -M365Environment $M365Environment 
         $IPPSConnected = $true
     }
     catch {

--- a/PowerShell/ScubaGear/Modules/Providers/ExportDefenderProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportDefenderProvider.psm1
@@ -15,7 +15,7 @@ function Export-DefenderProvider {
 
         [Parameter(Mandatory = $false)]
         [hashtable]
-        $CertThumbprintParams
+        $ServicePrincipalParams
     )
     $ParentPath = Split-Path $PSScriptRoot -Parent
     $ConnectionFolderPath = Join-Path -Path $ParentPath -ChildPath "Connection"
@@ -36,10 +36,10 @@ function Export-DefenderProvider {
             $EXOHelperParams = @{
                 M365Environment = $M365Environment;
             }
-            if ($CertThumbprintParams) {
-                $EXOHelperParams += @{CertThumbprintParams = $CertThumbprintParams}
+            if ($ServicePrincipalParams) {
+                $EXOHelperParams += @{ServicePrincipalParams = $ServicePrincipalParams}
             }
-            Connect-EXOHelper @CertThumbprintParams;
+            Connect-EXOHelper @ServicePrincipalParams;
         }
         catch {
             Write-Error "Error connecting to ExchangeOnline. $($_)"
@@ -100,8 +100,8 @@ function Export-DefenderProvider {
             M365Environment = $M365Environment;
         }
 
-        if ($CertThumbprintParams) {
-            $DefenderHelperParams += @{CertThumbprintParams = $CertThumbprintParams}
+        if ($ServicePrincipalParams) {
+            $DefenderHelperParams += @{ServicePrincipalParams = $ServicePrincipalParams}
         }
         Connect-DefenderHelper @DefenderHelperParams
         $IPPSConnected = $true

--- a/PowerShell/ScubaGear/Modules/Providers/ExportOneDriveProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportOneDriveProvider.psm1
@@ -8,31 +8,18 @@ function Export-OneDriveProvider {
     #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
-        [ValidateSet("commercial", "gcc", "gcchigh", "dod", IgnoreCase = $false)]
-        [string]
-        $M365Environment,
-
         [Parameter(Mandatory = $false)]
         [switch]
-        $UsePnP
+        $PnPFlag
     )
     $HelperFolderPath = Join-Path -Path $PSScriptRoot -ChildPath "ProviderHelpers"
     Import-Module (Join-Path -Path $HelperFolderPath -ChildPath "CommandTracker.psm1")
-    Import-Module (Join-Path -Path $HelperFolderPath -ChildPath "SPOSiteHelper.psm1")
     $Tracker = Get-CommandTracker
-
-    #Get InitialDomainPrefix
-    $InitialDomain = ($Tracker.TryCommand("Get-MgOrganization")).VerifiedDomains | Where-Object {$_.isInitial}
-    $InitialDomainPrefix = $InitialDomain.Name.split(".")[0]
-
-    $SPOSiteIdentity = Get-SPOSiteHelper -M365Environment $M365Environment -InitialDomainPrefix $InitialDomainPrefix
-    Write-Verbose "This is the tenant's main sharepoint domain use this for -Identity calls: $($SPOSiteIdentity)"
 
     $SPOTenantInfo = ConvertTo-Json @()
     $TenantSyncInfo = ConvertTo-Json @()
     $UsedPnP = ConvertTo-Json $false
-    if ($UsePnP) {
+    if ($PnPFlag) {
         $SPOTenantInfo = ConvertTo-Json @($Tracker.TryCommand("Get-PnPTenant"))
         $TenantSyncInfo = ConvertTo-Json @($Tracker.TryCommand("Get-PnPTenantSyncClientRestriction"))
         $Tracker.AddSuccessfulCommand("Get-SPOTenant")
@@ -53,7 +40,7 @@ function Export-OneDriveProvider {
     $json = @"
     "SPO_tenant_info": $SPOTenantInfo,
     "Tenant_sync_info": $TenantSyncInfo,
-    "OD_used_PnP": $UsedPnp,
+    "OneDrive_PnP_Flag": $UsedPnp,
     "OneDrive_successful_commands": $SuccessfulCommands,
     "OneDrive_unsuccessful_commands": $UnSuccessfulCommands,
 "@

--- a/PowerShell/ScubaGear/Modules/Providers/ExportOneDriveProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportOneDriveProvider.psm1
@@ -27,7 +27,7 @@ function Export-OneDriveProvider {
     $InitialDomainPrefix = $InitialDomain.Name.split(".")[0]
 
     $SPOSiteIdentity = Get-SPOSiteHelper -M365Environment $M365Environment -InitialDomainPrefix $InitialDomainPrefix
-
+    Write-Verbose "This is the tenant's main sharepoint domain use this for -Identity calls: $($SPOSiteIdentity)"
 
     $SPOTenantInfo = ConvertTo-Json @()
     $TenantSyncInfo = ConvertTo-Json @()
@@ -35,11 +35,15 @@ function Export-OneDriveProvider {
     if ($UsePnP) {
         $SPOTenantInfo = ConvertTo-Json @($Tracker.TryCommand("Get-PnPTenant"))
         $TenantSyncInfo = ConvertTo-Json @($Tracker.TryCommand("Get-PnPTenantSyncClientRestriction"))
+        $Tracker.AddSuccessfulCommand("Get-SPOTenant")
+        $Tracker.AddSuccessfulCommand("Get-SPOTenantSyncClientRestriction")
         $UsedPnP = ConvertTo-Json $true
     }
     else {
         $SPOTenantInfo = ConvertTo-Json @($Tracker.TryCommand("Get-SPOTenant"))
         $TenantSyncInfo = ConvertTo-Json @($Tracker.TryCommand("Get-SPOTenantSyncClientRestriction"))
+        $Tracker.AddSuccessfulCommand("Get-PnPTenant")
+        $Tracker.AddSuccessfulCommand("Get-PnPTenantSyncClientRestriction")
     }
 
     $SuccessfulCommands = ConvertTo-Json @($Tracker.GetSuccessfulCommands())

--- a/PowerShell/ScubaGear/Modules/Providers/ExportSharePointProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportSharePointProvider.psm1
@@ -15,7 +15,7 @@ function Export-SharePointProvider {
 
         [Parameter(Mandatory = $false)]
         [switch]
-        $UsePnP
+        $PnPFlag
     )
     $HelperFolderPath = Join-Path -Path $PSScriptRoot -ChildPath "ProviderHelpers"
     Import-Module (Join-Path -Path $HelperFolderPath -ChildPath "CommandTracker.psm1")
@@ -32,7 +32,7 @@ function Export-SharePointProvider {
 
     $SPOTenant = ConvertTo-Json @()
     $SPOSite = ConvertTo-Json @()
-    if ($UsePnP) {
+    if ($PnPFlag) {
         $SPOTenant = ConvertTo-Json @($Tracker.TryCommand("Get-PnPTenant"))
         $SPOSite = ConvertTo-Json @($Tracker.TryCommand("Get-PnPTenantSite",@{"Identity"="$($SPOSiteIdentity)"; "Detailed"=$true}) | Select-Object -Property *)
         $Tracker.AddSuccessfulCommand("Get-SPOTenant")

--- a/PowerShell/ScubaGear/Modules/Providers/ExportSharePointProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportSharePointProvider.psm1
@@ -34,11 +34,15 @@ function Export-SharePointProvider {
     $SPOSite = ConvertTo-Json @()
     if ($UsePnP) {
         $SPOTenant = ConvertTo-Json @($Tracker.TryCommand("Get-PnPTenant"))
-        $SPOTenant = ConvertTo-Json @($Tracker.TryCommand("Get-PnPTenantSite", @{"Identity"="$($SPOSiteIdentity)"; "Detailed"=$true}) | Select-Object -Property *)
+        $SPOSite = ConvertTo-Json @($Tracker.TryCommand("Get-PnPTenantSite",@{"Identity"="$($SPOSiteIdentity)"; "Detailed"=$true}) | Select-Object -Property *)
+        $Tracker.AddSuccessfulCommand("Get-SPOTenant")
+        $Tracker.AddSuccessfulCommand("Get-SPOSite")
     }
     else {
         $SPOTenant = ConvertTo-Json @($Tracker.TryCommand("Get-SPOTenant"))
         $SPOSite = ConvertTo-Json @($Tracker.TryCommand("Get-SPOSite", @{"Identity"="$($SPOSiteIdentity)"; "Detailed"=$true}) | Select-Object -Property *)
+        $Tracker.AddSuccessfulCommand("Get-PnPTenant")
+        $Tracker.AddSuccessfulCommand("Get-PnPTenantSite")
     }
 
 

--- a/PowerShell/ScubaGear/RequiredVersions.ps1
+++ b/PowerShell/ScubaGear/RequiredVersions.ps1
@@ -16,6 +16,11 @@ $ModuleList = @(
         MaximumVersion = [version] '16.99.99999'
     },
     @{
+        ModuleName = 'PnP.PowerShell' # alternate for SharePoint PowerShell
+        ModuleVersion = [version] '1.12.0'
+        MaximumVersion = [version] '1.99.99999'
+    },
+    @{
         ModuleName = 'Microsoft.PowerApps.Administration.PowerShell'
         ModuleVersion = [version] '2.0.0'
         MaximumVersion = [version] '2.99.99999'

--- a/PowerShell/ScubaGear/RequiredVersions.ps1
+++ b/PowerShell/ScubaGear/RequiredVersions.ps1
@@ -2,12 +2,12 @@
 $ModuleList = @(
     @{
         ModuleName = 'MicrosoftTeams'
-        ModuleVersion = [version] '4.8.0'
+        ModuleVersion = [version] '4.9.3'
         MaximumVersion = [version] '4.99.99999'
     },
     @{
         ModuleName = 'ExchangeOnlineManagement' # includes Defender
-        ModuleVersion = [version] '3.0.0'
+        ModuleVersion = [version] '3.1.0'
         MaximumVersion = [version] '3.99.99999'
     },
     @{

--- a/Rego/OneDriveConfig.rego
+++ b/Rego/OneDriveConfig.rego
@@ -22,7 +22,7 @@ tests[{
     "Requirement" : "Anyone links SHOULD be disabled",
     "Control" : "OneDrive 2.1",
     "Criticality" : "Should",
-    "Commandlet" : ["Get-SPOTenant"],
+    "Commandlet" : ["Get-SPOTenant", "Get-PnPTenant"],
     "ActualValue" : Policies,
     "ReportDetails" : ReportDetailsBoolean(Status),
     "RequirementMet" : Status
@@ -49,7 +49,7 @@ tests[{
     "Requirement" : "An expiration date SHOULD be set for Anyone links",
     "Control" : "OneDrive 2.2",
     "Criticality" : "Should",
-    "Commandlet" : ["Get-SPOTenant"],
+    "Commandlet" : ["Get-SPOTenant", "Get-PnPTenant"],
     "ActualValue" : Policies,
     "ReportDetails" : ReportDetailsBoolean(Status),
     "RequirementMet" : Status
@@ -71,7 +71,7 @@ tests[{
     "Requirement" : "Expiration date SHOULD be set to thirty days",
     "Control" : "OneDrive 2.2",
     "Criticality" : "Should",
-    "Commandlet" : ["Get-SPOTenant"],
+    "Commandlet" : ["Get-SPOTenant", "Get-PnPTenant"],
     "ActualValue" : Policies,
     "ReportDetails" : ReportDetailsBoolean(Status),
     "RequirementMet" : Status
@@ -126,7 +126,7 @@ tests[{
     "Requirement" : "Anyone link permissions SHOULD be limited to View",
     "Control" : "OneDrive 2.3",
     "Criticality" : "Should",
-    "Commandlet" : ["Get-SPOTenant"],
+    "Commandlet" : ["Get-SPOTenant", "Get-PnPTenant"],
     "ActualValue" : [Policy.DefaultSharingLinkType, Policy.FileAnonymousLinkType, Policy.FolderAnonymousLinkType],
     "ReportDetails" : ReportDetails2_3(Policy),
     "RequirementMet" : Status
@@ -154,7 +154,7 @@ tests[{
     "Requirement" : "OneDrive Client for Windows SHALL be restricted to agency-Defined Domain(s)",
     "Control" : "OneDrive 2.4",
     "Criticality" : "Shall",
-    "Commandlet" : ["Get-SPOTenant"],
+    "Commandlet" : ["Get-SPOTenant", "Get-PnPTenant"],
     "ActualValue" : Policies,
     "ReportDetails" : ReportDetailsBoolean(Status),
     "RequirementMet" : Status
@@ -181,7 +181,7 @@ tests[{
     "Requirement" : "OneDrive Client Sync SHALL only be allowed only within the local domain",
     "Control" : "OneDrive 2.5",
     "Criticality" : "Shall",
-    "Commandlet" : ["Get-SPOTenantSyncClientRestriction"],
+    "Commandlet" : ["Get-SPOTenantSyncClientRestriction", "Get-PnPTenantSyncClientRestriction"],
     "ActualValue" : Policies,
     "ReportDetails" : ReportDetailsBoolean(Status),
     "RequirementMet" : Status

--- a/Rego/OneDriveConfig.rego
+++ b/Rego/OneDriveConfig.rego
@@ -27,7 +27,7 @@ tests[{
     "ReportDetails" : ReportDetailsBoolean(Status),
     "RequirementMet" : Status
 }] {
-    input.OD_used_PnP == false
+    input.OneDrive_PnP_Flag == false
     Policies := AnyoneLinksPolicy
     Status := count(Policies) == 1
 }
@@ -42,7 +42,7 @@ tests[{
     "ReportDetails" : "Currently cannot be checked automatically while using Service Principals. See Onedrive Secure Configuration Baseline policy 2.1 for instructions on manual check",
     "RequirementMet" : false
 }] {
-    input.OD_used_PnP
+    input.OneDrive_PnP_Flag
 }
 #--
 

--- a/Rego/OneDriveConfig.rego
+++ b/Rego/OneDriveConfig.rego
@@ -27,8 +27,22 @@ tests[{
     "ReportDetails" : ReportDetailsBoolean(Status),
     "RequirementMet" : Status
 }] {
+    input.OD_used_PnP == false
     Policies := AnyoneLinksPolicy
     Status := count(Policies) == 1
+}
+#--
+
+tests[{
+    "Requirement" : "Anyone links SHOULD be disabled",
+    "Control" : "OneDrive 2.1",
+    "Criticality" : "Should/Not-Implemented",
+    "Commandlet" : [],
+    "ActualValue" : [],
+    "ReportDetails" : "Currently cannot be checked automatically while using Service Principals. See Onedrive Secure Configuration Baseline policy 2.1 for instructions on manual check",
+    "RequirementMet" : false
+}] {
+    input.OD_used_PnP
 }
 #--
 

--- a/Rego/SharepointConfig.rego
+++ b/Rego/SharepointConfig.rego
@@ -22,7 +22,7 @@ tests[{
     "Requirement" : "File and folder links default sharing setting SHALL be set to \"Specific People (Only the People the User Specifies)\"",
     "Control" : "Sharepoint 2.1",
     "Criticality" : "Shall",
-    "Commandlet" : ["Get-SPOTenant"],
+    "Commandlet" : ["Get-SPOTenant", "Get-PnPTenant"],
     "ActualValue" : Policies,
     "ReportDetails" : ReportDetailsBoolean(Status),
     "RequirementMet" : Status
@@ -49,7 +49,7 @@ tests[{
     "Requirement" : "External sharing SHOULD be limited to approved domains and security groups per interagency collaboration needs",
     "Control" : "Sharepoint 2.2",
     "Criticality" : "Should",
-    "Commandlet" : ["Get-SPOTenant"],
+    "Commandlet" : ["Get-SPOTenant", "Get-PnPTenant"],
     "ActualValue" : Policies,
     "ReportDetails" : ReportDetailsBoolean(Status),
     "RequirementMet" : Status
@@ -98,7 +98,7 @@ tests[{
     "Requirement" : "Expiration timers for 'guest access to a site or OneDrive' and 'people who use a verification code' SHOULD be set",
     "Control" : "Sharepoint 2.4",
     "Criticality" : "Should",
-    "Commandlet" : ["Get-SPOTenant"],
+    "Commandlet" : ["Get-SPOTenant", "Get-PnPTenant"],
     "ActualValue" : Policies,
     "ReportDetails" : ReportDetailsBoolean(Status),
     "RequirementMet" : Status
@@ -120,7 +120,7 @@ tests[{
     "Requirement" : "Expiration timers SHOULD be set to 30 days",
     "Control" : "Sharepoint 2.4",
     "Criticality" : "Should",
-    "Commandlet" : ["Get-SPOTenant"],
+    "Commandlet" : ["Get-SPOTenant", "Get-PnPTenant"],
     "ActualValue" : Policies,
     "ReportDetails" : ReportDetailsBoolean(Status),
     "RequirementMet" : Status
@@ -167,7 +167,7 @@ tests[{
     "Requirement" : "Users SHALL be prevented from running custom scripts on self-service created sites",
     "Control" : "Sharepoint 2.5",
     "Criticality" : "Shall",
-    "Commandlet" : ["Get-SPOSite"],
+    "Commandlet" : ["Get-SPOSite", "Get-PnPTenantSite"],
     "ActualValue" : Policies,
     "ReportDetails" : ReportDetailsBoolean(Status),
     "RequirementMet" : Status

--- a/Testing/Unit/Rego/OneDrive/OneDriveConfig2_01_test.rego
+++ b/Testing/Unit/Rego/OneDrive/OneDriveConfig2_01_test.rego
@@ -15,7 +15,7 @@ test_OneDriveLoopSharingCapability_Correct if {
                 "OneDriveLoopSharingCapability" : 1
             }
         ],
-        "OD_used_PnP": false   
+        "OneDrive_PnP_Flag": false   
     }
 
     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
@@ -35,7 +35,7 @@ test_OneDriveLoopSharingCapability_Incorrect if {
                 "OneDriveLoopSharingCapability" : 2
             }
         ],
-        "OD_used_PnP": false
+        "OneDrive_PnP_Flag": false 
     }
 
     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]

--- a/Testing/Unit/Rego/OneDrive/OneDriveConfig2_01_test.rego
+++ b/Testing/Unit/Rego/OneDrive/OneDriveConfig2_01_test.rego
@@ -14,7 +14,8 @@ test_OneDriveLoopSharingCapability_Correct if {
             {
                 "OneDriveLoopSharingCapability" : 1
             }
-        ]        
+        ],
+        "OD_used_PnP": false   
     }
 
     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
@@ -33,7 +34,8 @@ test_OneDriveLoopSharingCapability_Incorrect if {
             {
                 "OneDriveLoopSharingCapability" : 2
             }
-        ]        
+        ],
+        "OD_used_PnP": false
     }
 
     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->
- Add Service Principal Authentication via CertficateThumbprint, AppID, and Organization (domain name).
- Set up `Connection.psm1` for other Service Principal authentication methods to be added in the future.
- Raise minimum versions for EXO and Teams PowerShell modules.
- Add PnP.PowerShell module dependency for Service Principal Authentication support for SPO and OneDrive.
- Handle OneDrive 2.1 which does not have the field we need to check when using PnP.PowerShell.
- Correct erroneous Defender GCCHigh and DOD endpoints.
- Speed up Graph Beta Profile selection for AAD.

## 💭 Motivation and context ##
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->
Closes #96
Closes #63
Closes #144
Future TODO: add other Service Principal Authentication methods.
Future TODO: create a function to register an Azure AD Application with the permissions needed.


## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

 - Ran the updated code in this branch against Test Tenant 4 (E5) with all products individually, mixed, and all products together (*) with no issues with the following command. `Invoke-SCuBA -ProductNames * -CertificateThumbprint $CertThumbprint -AppID $AppID -Organization "tenant4.onmicrosoft.com"`
 - Compared results of the tests above with copies run from interactive login via `Invoke-SCuBA -ProductNames *`. No regressions found for E5 tenants.
 - [See rough notes in this comment for how to create your own application for testing](https://github.com/cisagov/ScubaGear/issues/96#issuecomment-1413129118)
<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] ~~I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.~~
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

## ✅ Post-merge checklist ##