### PR TITLE
Constrict SetUp.ps1 to install maximum acceptable version

### DIFF
--- a/.github/workflows/run_opa_tests.yaml
+++ b/.github/workflows/run_opa_tests.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup OPA
       uses: open-policy-agent/setup-opa@v2
       with:
-        version: latest
+        version: <0.50
 
     - name: Run OPA Check
       run: opa check Rego Testing/Unit/Rego --strict

--- a/PowerShell/ScubaGear/Dependencies.ps1
+++ b/PowerShell/ScubaGear/Dependencies.ps1
@@ -32,7 +32,7 @@ foreach ($Module in $ModuleList) {
         throw [System.IO.FileNotFoundException] "No acceptable installed version found for module: $($Module.ModuleName)
         Required Min Version: $($Module.ModuleVersion) | Max Version: $($Module.MaximumVersion)
         Run Get-InstalledModule to see a list of currently installed modules
-        Run SetUp.ps1 or Install-Module $($Module.ModuleName) -force to install the latest version of $($Module.ModuleName)"
+        Run SetUp.ps1 or Install-Module $($Module.ModuleName) -force to install the latest acceptable version of $($Module.ModuleName)"
     }
 }
 

--- a/PowerShell/ScubaGear/Dependencies.ps1
+++ b/PowerShell/ScubaGear/Dependencies.ps1
@@ -32,7 +32,7 @@ foreach ($Module in $ModuleList) {
         throw [System.IO.FileNotFoundException] "No acceptable installed version found for module: $($Module.ModuleName)
         Required Min Version: $($Module.ModuleVersion) | Max Version: $($Module.MaximumVersion)
         Run Get-InstalledModule to see a list of currently installed modules
-        Run SetUp.ps1 or Install-Module $($Module.ModuleName) -force to install the latest acceptable version of $($Module.ModuleName)"
+        Run SetUp.ps1 or Install-Module $($Module.ModuleName) -Force -MaximumVersion $($Module.MaximumVersion) to install the latest acceptable version of $($Module.ModuleName)"
     }
 }
 

--- a/PowerShell/ScubaGear/RequiredVersions.ps1
+++ b/PowerShell/ScubaGear/RequiredVersions.ps1
@@ -3,7 +3,7 @@ $ModuleList = @(
     @{
         ModuleName = 'MicrosoftTeams'
         ModuleVersion = [version] '4.9.3'
-        MaximumVersion = [version] '4.99.99999'
+        MaximumVersion = [version] '5.99.99999'
     },
     @{
         ModuleName = 'ExchangeOnlineManagement' # includes Defender

--- a/SetUp.ps1
+++ b/SetUp.ps1
@@ -30,7 +30,7 @@ param(
     $DoNotAutoTrustRepository
 )
 
-# Set prefernces for writing messages
+# Set preferences for writing messages
 $DebugPreference = "Continue"
 $InformationPreference = "Continue"
 
@@ -113,3 +113,5 @@ foreach ($Module in $ModuleList) {
 $Stopwatch.stop()
 
 Write-Debug "ScubaGear setup time elapsed:  $([math]::Round($stopwatch.Elapsed.TotalSeconds,0)) seconds."
+$DebugPreference = "SilentlyContinue"
+$InformationPreference = "SilentlyContinue"

--- a/SetUp.ps1
+++ b/SetUp.ps1
@@ -34,10 +34,10 @@ param(
 $DebugPreference = "Continue"
 $InformationPreference = "Continue"
 
-if (-not $DoNotAutoTrustRepository){
+if (-not $DoNotAutoTrustRepository) {
     $Policy = Get-PSRepository -Name "PSGallery" | Select-Object -Property -InstallationPolicy
 
-    if ($($Policy.InstallationPolicy) -ne "Trusted"){
+    if ($($Policy.InstallationPolicy) -ne "Trusted") {
         Set-PSRepository -Name "PSGallery" -InstallationPolicy Trusted
         Write-Information -MessageData "Setting PSGallery repository to trusted."
     }
@@ -47,11 +47,11 @@ if (-not $DoNotAutoTrustRepository){
 $Stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
 $RequiredModulesPath = Join-Path -Path $PSScriptRoot -ChildPath "PowerShell\ScubaGear\RequiredVersions.ps1"
-if (Test-Path -Path $RequiredModulesPath){
+if (Test-Path -Path $RequiredModulesPath) {
   . $RequiredModulesPath
 }
 
-if ($ModuleList){
+if ($ModuleList) {
     # Add PowerShellGet to beginning of ModuleList for installing required modules.
     $ModuleList = ,@{
         ModuleName = 'PowerShellGet'
@@ -81,10 +81,10 @@ foreach ($Module in $ModuleList) {
                     -AllowClobber `
                     -Scope CurrentUser `
                     -MaximumVersion $Module.MaximumVersion
-                Write-Information -MessageData "Re-installing module: ${ModuleName}"
+                Write-Information -MessageData "Re-installing module to latest acceptable version: ${ModuleName}"
             }
-        } else {
-
+        }
+        else {
             if ($SkipUpdate -eq $true) {
                 Write-Debug "Skipping update for ${ModuleName}:${HighestInstalledVersion} to newer version ${LatestVersion}."
             }
@@ -94,15 +94,17 @@ foreach ($Module in $ModuleList) {
                     -AllowClobber `
                     -Scope CurrentUser `
                     -MaximumVersion $Module.MaximumVersion
-                Write-Information -MessageData " ${ModuleName}:${HighestInstalledVersion} updated to version ${LatestVersion}."
+                $MaxInstalledVersion = (Get-Module -ListAvailable -Name $ModuleName | Sort-Object Version -Descending | Select-Object Version -First 1).Version
+                Write-Information -MessageData " ${ModuleName}:${HighestInstalledVersion} updated to version ${MaxInstalledVersion}."
             }
         }
-    } else {
+    }
+    else {
         Install-Module -Name $ModuleName `
             -AllowClobber `
             -Scope CurrentUser `
             -MaximumVersion $Module.MaximumVersion
-        Write-Information -MessageData "Installed latest version of $ModuleName"
+        Write-Information -MessageData "Installed the latest acceptable version of $ModuleName"
     }
 }
 

--- a/SetUp.ps1
+++ b/SetUp.ps1
@@ -79,7 +79,8 @@ foreach ($Module in $ModuleList) {
                 Install-Module -Name $ModuleName `
                     -Force `
                     -AllowClobber `
-                    -Scope CurrentUser
+                    -Scope CurrentUser `
+                    -MaximumVersion $Module.MaximumVersion
                 Write-Information -MessageData "Re-installing module: ${ModuleName}"
             }
         } else {
@@ -91,14 +92,16 @@ foreach ($Module in $ModuleList) {
                 Install-Module -Name $ModuleName `
                     -Force `
                     -AllowClobber `
-                    -Scope CurrentUser
+                    -Scope CurrentUser `
+                    -MaximumVersion $Module.MaximumVersion
                 Write-Information -MessageData " ${ModuleName}:${HighestInstalledVersion} updated to version ${LatestVersion}."
             }
         }
     } else {
         Install-Module -Name $ModuleName `
             -AllowClobber `
-            -Scope CurrentUser
+            -Scope CurrentUser `
+            -MaximumVersion $Module.MaximumVersion
         Write-Information -MessageData "Installed latest version of $ModuleName"
     }
 }
@@ -107,4 +110,3 @@ foreach ($Module in $ModuleList) {
 $Stopwatch.stop()
 
 Write-Debug "ScubaGear setup time elapsed:  $([math]::Round($stopwatch.Elapsed.TotalSeconds,0)) seconds."
-

--- a/SetUp.ps1
+++ b/SetUp.ps1
@@ -104,7 +104,8 @@ foreach ($Module in $ModuleList) {
             -AllowClobber `
             -Scope CurrentUser `
             -MaximumVersion $Module.MaximumVersion
-        Write-Information -MessageData "Installed the latest acceptable version of $ModuleName"
+            $MaxInstalledVersion = (Get-Module -ListAvailable -Name $ModuleName | Sort-Object Version -Descending | Select-Object Version -First 1).Version
+        Write-Information -MessageData "Installed the latest acceptable version of ${ModuleName} version ${MaxInstalledVersion}"
     }
 }
 


### PR DESCRIPTION

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

- Changes `SetUp.ps1` to add `-MaximumVersion` parameter to `Install-Module` calls. 
`Install-Module -MaximumVersion {Maximum version listed in RequiredVersions.ps1}`
- Additional text to `Write-Information` calls to reflect the changes made above.
- Updates MicrosoftTeams PowerShell module Maximum version to `5.99.99999`

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->
Closes #176 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

- Tested on Test Tenant 1 (G5), Test Tenant 2 (G3), Test Tenant 4 (E5), and Test Tenant 6 (GCC High) for regressions. None found.
- Tested new `SetUp.ps1` changes on 2 different client machines. When limited to MicrosoftTeams `MaximumVersion = 4.99...` `MicrosoftTeams 4.9.3` was installed successfully and `Invoke-SCuBA` ran smoothly. After updating the MicrosoftTeams PowerShell `MaximumVersion = 5.99...`,   `MicrosoftTeams 5.0` was installed successfully and Invoke-SCuBA ran smoothly.
- No regressions observed from updating to`MicrosoftTeams PowerShell module version 5.0
<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] ~I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.~
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->


## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
