### PR TITLE
Fix bug with DKIM and DMARC

### DIFF
--- a/Rego/EXOConfig.rego
+++ b/Rego/EXOConfig.rego
@@ -124,7 +124,8 @@ DomainsWithDkim[DkimConfig.Domain] {
     DkimConfig.Enabled == true
     DkimRecord := input.dkim_records[_]
     DkimRecord.domain == DkimConfig.Domain
-    startswith(DkimRecord.rdata, "v=DKIM1;")
+    ValidAnswers := [Answer | Answer := DkimRecord.rdata[_]; startswith(Answer, "v=DKIM1;")]
+    count(ValidAnswers) > 0
 }
 
 tests[{
@@ -151,7 +152,8 @@ tests[{
 #--
 DomainsWithoutDmarc[DmarcRecord.domain] {
     DmarcRecord := input.dmarc_records[_]
-    not startswith(DmarcRecord.rdata, "v=DMARC1;")
+    ValidAnswers := [Answer | Answer := DmarcRecord.rdata[_]; startswith(Answer, "v=DMARC1;")]
+    count(ValidAnswers) == 0
 }
 
 tests[{
@@ -173,7 +175,8 @@ tests[{
 #--
 DomainsWithoutPreject[DmarcRecord.domain] {
     DmarcRecord := input.dmarc_records[_]
-    not contains(DmarcRecord.rdata, "p=reject;")
+    ValidAnswers := [Answer | Answer := DmarcRecord.rdata[_]; contains(Answer, "p=reject;")]
+    count(ValidAnswers) == 0
 }
 
 tests[{
@@ -195,7 +198,8 @@ tests[{
 #--
 DomainsWithoutDHSContact[DmarcRecord.domain] {
     DmarcRecord := input.dmarc_records[_]
-    not contains(DmarcRecord.rdata, "mailto:reports@dmarc.cyber.dhs.gov")
+    ValidAnswers := [Answer | Answer := DmarcRecord.rdata[_]; contains(Answer, "mailto:reports@dmarc.cyber.dhs.gov")]
+    count(ValidAnswers) == 0
 }
 
 tests[{
@@ -217,7 +221,8 @@ tests[{
 #--
 DomainsWithoutAgencyContact[DmarcRecord.domain] {
     DmarcRecord := input.dmarc_records[_]
-    count(split(DmarcRecord.rdata, "@")) < 3
+    EnoughContacts := [Answer | Answer := DmarcRecord.rdata[_]; count(split(Answer, "@")) >= 3]
+    count(EnoughContacts) == 0
 }
 
 tests[{

--- a/Testing/Unit/Rego/EXO/EXOConfig2_03_test.rego
+++ b/Testing/Unit/Rego/EXO/EXOConfig2_03_test.rego
@@ -18,13 +18,13 @@ test_Enabled_Correct_V1 if {
         ],
         "dkim_records": [
             {
-                "rdata" : "v=DKIM1;", 
+                "rdata" : ["v=DKIM1;"], 
                 "domain" : "test.name"
             }
         ],
         "spf_records": [
             {
-                "rdata" : "spf1 ", 
+                "rdata" : ["spf1 "], 
                 "domain" : "test.name"
             }
         ]  
@@ -57,21 +57,21 @@ test_Enabled_Correct_V2 if {
         ],
         "dkim_records": [
             {
-                "rdata" : "v=DKIM1;", 
+                "rdata" : ["v=DKIM1;"], 
                 "domain" : "test.name"
             },
             {
-                "rdata" : "", 
+                "rdata" : [], 
                 "domain" : "example.onmicrosoft.com"
             }
         ],
         "spf_records": [
             {
-                "rdata" : "spf1 ", 
+                "rdata" : ["spf1 "], 
                 "domain" : "test.name"
             },
             {
-                "rdata" : "spf1 ", 
+                "rdata" : ["spf1 "], 
                 "domain" : "example.onmicrosoft.com"
             }
         ]  
@@ -102,21 +102,21 @@ test_Enabled_Correct_V3 if {
         ],
         "dkim_records": [
             {
-                "rdata" : "v=DKIM1;", 
+                "rdata" : ["v=DKIM1;"], 
                 "domain" : "test.name"
             },
             {
-                "rdata" : "v=DKIM1;", 
+                "rdata" : ["v=DKIM1;"], 
                 "domain" : "test2.name"
             }
         ],
         "spf_records": [
             {
-                "rdata" : "spf1 ", 
+                "rdata" : ["spf1 "], 
                 "domain" : "test.name"
             },
             {
-                "rdata" : "spf1 ", 
+                "rdata" : ["spf1 "], 
                 "domain" : "test2.name"
             }
         ]  
@@ -143,13 +143,13 @@ test_Enabled_Correct_V4 if {
         ],
         "dkim_records": [
             {
-                "rdata" : "v=DKIM1;", 
+                "rdata" : ["v=DKIM1;"], 
                 "domain" : "example.onmicrosoft.com"
             }
         ],
         "spf_records": [
             {
-                "rdata" : "spf1 ", 
+                "rdata" : ["spf1 "], 
                 "domain" : "example.onmicrosoft.com"
             }
         ]  
@@ -175,13 +175,13 @@ test_Enabled_Incorrect if {
         ],
         "dkim_records": [
             {
-                "rdata" : "v=DKIM1;", 
+                "rdata" : ["v=DKIM1;"], 
                 "domain" : "test.name"
             }
         ],
         "spf_records": [
             {
-                "rdata" : "spf1 ", 
+                "rdata" : ["spf1 "], 
                 "domain" : "test.name"
             }
         ]  
@@ -207,13 +207,13 @@ test_Rdata_Incorrect if {
         ],
         "dkim_records": [
             {
-                "rdata" : " ", 
+                "rdata" : [], 
                 "domain" : "test.name"
             }
         ],
         "spf_records": [
             {
-                "rdata" : "spf1 ", 
+                "rdata" : ["spf1 "], 
                 "domain" : "test.name"
             }
         ]  
@@ -239,13 +239,13 @@ test_Rdata_Incorrect_V2 if {
         ],
         "dkim_records": [
             {
-                "rdata" : "Hello World", 
+                "rdata" : ["Hello World"], 
                 "domain" : "test.name"
             }
         ],
         "spf_records": [
             {
-                "rdata" : "spf1 ", 
+                "rdata" : ["spf1 "], 
                 "domain" : "test.name"
             }
         ]  
@@ -275,21 +275,21 @@ test_Enabled_Correct_V2 if {
         ],
         "dkim_records": [
             {
-                "rdata" : "v=DKIM1;", 
+                "rdata" : ["v=DKIM1;"], 
                 "domain" : "test.name"
             },
             {
-                "rdata" : "v=DKIM1;", 
+                "rdata" : ["v=DKIM1;"], 
                 "domain" : "test2.name"
             }
         ],
         "spf_records": [
             {
-                "rdata" : "spf1 ", 
+                "rdata" : ["spf1 "], 
                 "domain" : "test.name"
             },
             {
-                "rdata" : "spf1 ", 
+                "rdata" : ["spf1 "], 
                 "domain" : "test2.name"
             }
         ]  
@@ -319,21 +319,21 @@ test_Enabled_Inorrect_V3 if {
         ],
         "dkim_records": [
             {
-                "rdata" : "v=DKIM1;", 
+                "rdata" : ["v=DKIM1;"], 
                 "domain" : "test.name"
             },
             {
-                "rdata" : "v=DKIM1;", 
+                "rdata" : ["v=DKIM1;"], 
                 "domain" : "test2.name"
             }
         ],
         "spf_records": [
             {
-                "rdata" : "spf1 ", 
+                "rdata" : ["spf1 "], 
                 "domain" : "test.name"
             },
             {
-                "rdata" : "spf1 ", 
+                "rdata" : ["spf1 "], 
                 "domain" : "test2.name"
             }
         ]  

--- a/Testing/Unit/Rego/EXO/EXOConfig2_04_test.rego
+++ b/Testing/Unit/Rego/EXO/EXOConfig2_04_test.rego
@@ -12,13 +12,13 @@ test_Rdata_Correct if {
     Output := tests with input as {
         "dmarc_records":[
             {
-                "rdata" : "v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov", 
+                "rdata" : ["v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov"], 
                 "domain" : "test.name"
             }
         ],
         "spf_records": [
             {
-                "rdata" : "spf1 ", 
+                "rdata" : ["spf1 "], 
                 "domain" : "test.name"
             }
         ]  
@@ -38,13 +38,13 @@ test_Rdata_Incorrect if {
     Output := tests with input as {
         "dmarc_records":[
             {
-                "rdata" : " ", 
+                "rdata" : [], 
                 "domain" : "test.name"
             }
         ],
         "spf_records": [
             {
-                "rdata" : "spf1 ", 
+                "rdata" : ["spf1 "], 
                 "domain" : "test.name"
             }
         ]  
@@ -64,13 +64,13 @@ test_Rdata_Incorrect_V2 if {
     Output := tests with input as {
         "dmarc_records":[  
             {
-                "rdata" : "v=DMARC1", 
+                "rdata" : ["v=DMARC1"], 
                 "domain" : "test.name"
             }
         ],
         "spf_records": [
             {
-                "rdata" : "spf1 ", 
+                "rdata" : ["spf1 "], 
                 "domain" : "test.name"
             }
         ]  
@@ -90,21 +90,21 @@ test_Rdata_Incorrect_V3 if {
     Output := tests with input as {
         "dmarc_records": [
             {
-                "rdata" : "v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov", 
+                "rdata" : ["v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov"], 
                 "domain" : "test.name"
             },
             {
-                "rdata" : "", 
+                "rdata" : [], 
                 "domain" : "bad.name"
             }
         ],
         "spf_records": [
             {
-                "rdata" : "spf1 ", 
+                "rdata" : ["spf1 "], 
                 "domain" : "test.name"
             },
             {
-                "rdata" : "spf1 ", 
+                "rdata" : ["spf1 "], 
                 "domain" : "bad.name"
             }
         ]  
@@ -127,13 +127,13 @@ test_Rdata_Correct_V2 if {
     Output := tests with input as {
         "dmarc_records": [
             {
-                "rdata" : "v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov", 
+                "rdata" : ["v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov"], 
                 "domain" : "test.name"
             }
         ],
         "spf_records": [
             {
-                "rdata" : "spf1 ", 
+                "rdata" : ["spf1 "], 
                 "domain" : "test.name"
             }
         ]  
@@ -153,13 +153,13 @@ test_Rdata_Incorrect_V4 if {
     Output := tests with input as {
         "dmarc_records": [
             {
-                "rdata" : "v=DMARC1; p=none; mailto:reports@dmarc.cyber.dhs.gov mailto:jsmith@dhs.gov mailto:jsomething@dhs.gov", 
+                "rdata" : ["v=DMARC1; p=none; mailto:reports@dmarc.cyber.dhs.gov mailto:jsmith@dhs.gov mailto:jsomething@dhs.gov"], 
                 "domain" : "test.name"
             }
         ],
         "spf_records": [
             {
-                "rdata" : "spf1 ", 
+                "rdata" : ["spf1 "], 
                 "domain" : "test.name"
             }
         ]  
@@ -179,13 +179,13 @@ test_Rdata_Incorrect_V5 if {
     Output := tests with input as {
         "dmarc_records": [
             {
-                "rdata" : "v=DMARC1; mailto:reports@dmarc.cyber.dhs.gov mailto:jsmith@dhs.gov mailto:jsomething@dhs.gov", 
+                "rdata" : ["v=DMARC1; mailto:reports@dmarc.cyber.dhs.gov mailto:jsmith@dhs.gov mailto:jsomething@dhs.gov"], 
                 "domain" : "test.name"
             }
         ],
         "spf_records": [
             {
-                "rdata" : "spf1 ", 
+                "rdata" : ["spf1 "], 
                 "domain" : "test.name"
             }
         ]  
@@ -208,13 +208,13 @@ test_Rdata_Correct_V3 if {
     Output := tests with input as {
         "dmarc_records": [
             {
-                "rdata" : "v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov", 
+                "rdata" : ["v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov"], 
                 "domain" : "test.name"
             }
         ],
         "spf_records": [
             {
-                "rdata" : "spf1 ", 
+                "rdata" : ["spf1 "], 
                 "domain" : "test.name"
             }
         ]  
@@ -234,13 +234,13 @@ test_Rdata_Incorrect_V6 if {
     Output := tests with input as {
         "dmarc_records": [
             {
-                "rdata" : "v=DMARC1; p=reject; pct=100;", 
+                "rdata" : ["v=DMARC1; p=reject; pct=100;"], 
                 "domain" : "test.name"
             }
         ],
         "spf_records": [
             {
-                "rdata" : "spf1 ", 
+                "rdata" : ["spf1 "], 
                 "domain" : "test.name"
             }
         ]  
@@ -260,13 +260,13 @@ test_Rdata_Incorrect_V7 if {
     Output := tests with input as {
         "dmarc_records": [
             {
-                "rdata" : "v=DMARC1; p=reject; pct=100; rua=mailto:reports@wrong.address", 
+                "rdata" : ["v=DMARC1; p=reject; pct=100; rua=mailto:reports@wrong.address"], 
                 "domain" : "test.name"
             }
         ],
         "spf_records": [
             {
-                "rdata" : "spf1 ", 
+                "rdata" : ["spf1 "], 
                 "domain" : "test.name"
             }
         ]  
@@ -289,13 +289,13 @@ test_Rdata_Incorrect_V4 if {
     Output := tests with input as {
         "dmarc_records": [
             {
-                "rdata" : "v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov", 
+                "rdata" : ["v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov"], 
                 "domain" : "test.name"
             }
         ],
         "spf_records": [
             {
-                "rdata" : "spf1 ", 
+                "rdata" : ["spf1 "], 
                 "domain" : "test.name"
             }
         ]  
@@ -315,13 +315,13 @@ test_Rdata_Incorrect_V8 if {
     Output := tests with input as {
         "dmarc_records": [
             {
-                "rdata" : "v=DMARC1; p=reject; pct=100; rua=mailto:reports@dmarc.cyber.dhs.gov", 
+                "rdata" : ["v=DMARC1; p=reject; pct=100; rua=mailto:reports@dmarc.cyber.dhs.gov"], 
                 "domain" : "test.name"
             }
         ],
         "spf_records": [
             {
-                "rdata" : "spf1 ", 
+                "rdata" : ["spf1 "], 
                 "domain" : "test.name"
             }
         ]  


### PR DESCRIPTION
## 🗣 Description ##
Adjusted the Rego tests for EXO 2.3 and 2.4 so that the DNS answers are expected as a list, rather than a single string.

## 💭 Motivation and context ##
Closes #214.

## 🧪 Testing ##
Tested on both G5 and E5 tenants. Manually inspected results for correctness as well as compared results with v0.2.0.
 
<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
