### PR TITLE
Scuba release should be in root folder

### DIFF
--- a/.github/workflows/run_release.yaml
+++ b/.github/workflows/run_release.yaml
@@ -8,10 +8,7 @@ on:
       version:
         description: "Release Version"
         required: true
-        type: string
-  push:
-    branches:
-      - '219-scuba-release-should-be-in-root-folder'      
+        type: string     
 
 name: Build and Sign Release
 

--- a/.github/workflows/run_release.yaml
+++ b/.github/workflows/run_release.yaml
@@ -8,7 +8,7 @@ on:
       version:
         description: "Release Version"
         required: true
-        type: string     
+        type: string
 
 name: Build and Sign Release
 

--- a/.github/workflows/run_release.yaml
+++ b/.github/workflows/run_release.yaml
@@ -9,9 +9,11 @@ on:
         description: "Release Version"
         required: true
         type: string
+  push:
+    branches:
+      - '219-scuba-release-should-be-in-root-folder'      
 
 name: Build and Sign Release
-
 
 jobs:
   build-and-deploy:
@@ -50,7 +52,8 @@ jobs:
         Remove-Item -Recurse -Force certificate
         Remove-Item -Recurse -Force repo -Include .git*
 
-        Compress-Archive -Path repo\* -DestinationPath "ScubaGear-${env:RELEASE_VERSION}.zip"
+        Move-Item  -Path repo -Destination "ScubaGear-${env:RELEASE_VERSION}" -Force
+        Compress-Archive -Path "ScubaGear-${env:RELEASE_VERSION}" -DestinationPath "ScubaGear-${env:RELEASE_VERSION}.zip"
 
         Get-ChildItem -Path . | Write-Output
     - name: release


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Placed release into root folder with version in zip file 

## 💭 Motivation and context ##

Adhere to standard release practices.

## 🧪 Testing ##

Manually triggered Build & Release action on branch to actuate a release.  
Verified release zip content is under root folder

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
