### PR TITLE
Support non-NA regions when running Power Platform

### DIFF
--- a/PowerShell/ScubaGear/Modules/Providers/ExportPowerPlatformProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportPowerPlatformProvider.psm1
@@ -75,7 +75,7 @@ function Export-PowerPlatformProvider {
 
             $CheckRScope = $true
             $CheckRSubScope = $true
-            if ($RegionScope -eq "NA" -or $RegionScope -eq "USGov") {
+            if ($RegionScope -eq "NA" -or $RegionScope -eq "USGov" -or $RegionScope -eq "USG") {
                 switch ($M365Environment) {
                     "commercial" {
                         $CheckRScope = $RegionScope -eq "NA"

--- a/PowerShell/ScubaGear/Modules/Providers/ExportPowerPlatformProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportPowerPlatformProvider.psm1
@@ -75,25 +75,27 @@ function Export-PowerPlatformProvider {
 
             $CheckRScope = $true
             $CheckRSubScope = $true
-            switch ($M365Environment) {
-                "commercial" {
-                    $CheckRScope = $RegionScope -eq "NA"
-                    $CheckRSubScope = $RegionSubScope -eq ""
-                }
-                "gcc" {
-                    $CheckRScope = $RegionScope -eq "NA"
-                    $CheckRSubScope = $RegionSubScope -eq "GCC"
-                }
-                "gcchigh" {
-                    $CheckRScope = $RegionScope -eq "USGov" -or $RegionScope -eq "USG"
-                    $CheckRSubScope = $RegionSubScope -eq "DODCON"
-                }
-                "dod" {
-                    $CheckRScope = $RegionScope -eq "USGov" -or $RegionScope -eq "USG"
-                    $CheckRSubScope = $RegionSubScope -eq "DOD"
-                }
-                default {
-                    throw "Unsupported or invalid M365Environment argument"
+            if ($RegionScope -eq "NA" -or $RegionScope -eq "USGov") {
+                switch ($M365Environment) {
+                    "commercial" {
+                        $CheckRScope = $RegionScope -eq "NA"
+                        $CheckRSubScope = $RegionSubScope -eq ""
+                    }
+                    "gcc" {
+                        $CheckRScope = $RegionScope -eq "NA"
+                        $CheckRSubScope = $RegionSubScope -eq "GCC"
+                    }
+                    "gcchigh" {
+                        $CheckRScope = $RegionScope -eq "USGov" -or $RegionScope -eq "USG"
+                        $CheckRSubScope = $RegionSubScope -eq "DODCON"
+                    }
+                    "dod" {
+                        $CheckRScope = $RegionScope -eq "USGov" -or $RegionScope -eq "USG"
+                        $CheckRSubScope = $RegionSubScope -eq "DOD"
+                    }
+                    default {
+                        throw "Unsupported or invalid M365Environment argument"
+                    }
                 }
             }
             # spacing is intentional

--- a/Testing/Unit/PowerShell/Providers/PowerPlatformProvider/Export-PowerPlatformProvider.Tests.ps1
+++ b/Testing/Unit/PowerShell/Providers/PowerPlatformProvider/Export-PowerPlatformProvider.Tests.ps1
@@ -148,17 +148,17 @@ InModuleScope -ModuleName ExportPowerPlatformProvider {
             $ValidJson = Test-SCuBAValidProviderJson -Json $Json | Select-Object -Last 1
             $ValidJson | Should -Be $true
         }
-    }
-}
-It "When called with -M365Environment 'commercial', from a non-NA tenant returns valid json" {
-    Mock -CommandName Invoke-WebRequest {
-        return [pscustomobject]@{
-            Content = '{"tenant_region_scope": "EU","tenant_region_sub_scope": ""}'
+        It "When called with -M365Environment 'commercial', from a non-NA tenant returns valid json" {
+            Mock -CommandName Invoke-WebRequest {
+                return [pscustomobject]@{
+                    Content = '{"tenant_region_scope": "EU","tenant_region_sub_scope": ""}'
+                }
+            }
+            $Json = Export-PowerPlatformProvider -M365Environment 'commercial'
+            $ValidJson = Test-SCuBAValidProviderJson -Json $Json | Select-Object -Last 1
+            $ValidJson | Should -Be $true
         }
     }
-    $Json = Export-PowerPlatformProvider -M365Environment 'commercial'
-    $ValidJson = Test-SCuBAValidProviderJson -Json $Json | Select-Object -Last 1
-    $ValidJson | Should -Be $true
 }
 AfterAll {
     Remove-Module ExportPowerPlatformProvider -Force -ErrorAction SilentlyContinue

--- a/Testing/Unit/PowerShell/Providers/PowerPlatformProvider/Export-PowerPlatformProvider.Tests.ps1
+++ b/Testing/Unit/PowerShell/Providers/PowerPlatformProvider/Export-PowerPlatformProvider.Tests.ps1
@@ -150,6 +150,16 @@ InModuleScope -ModuleName ExportPowerPlatformProvider {
         }
     }
 }
+It "When called with -M365Environment 'commercial', from a non-NA tenant returns valid json" {
+    Mock -CommandName Invoke-WebRequest {
+        return [pscustomobject]@{
+            Content = '{"tenant_region_scope": "EU","tenant_region_sub_scope": ""}'
+        }
+    }
+    $Json = Export-PowerPlatformProvider -M365Environment 'commercial'
+    $ValidJson = Test-SCuBAValidProviderJson -Json $Json | Select-Object -Last 1
+    $ValidJson | Should -Be $true
+}
 AfterAll {
     Remove-Module ExportPowerPlatformProvider -Force -ErrorAction SilentlyContinue
     Remove-Module CommandTracker -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
Fixes a bug where non-NA tenants would be unable to run Power Platform because an error would be thrown. 
This bug was added in because of a check that was added in #114 to determine if the user passed in the correct `$M365Environment` variable.

## 💭 Motivation and context ##

Closes #201 

## 🧪 Testing ##

Tested against the E5/G5 and GCC tenants.
Added unit test for testing Non-NA regions

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

