### PR TITLE
Update DLP Custom Policy locations

### DIFF
--- a/baselines/defender.md
+++ b/baselines/defender.md
@@ -227,7 +227,7 @@ blocked.
 - _Last modified:_ June 2023
 
 #### MS.DEFENDER.4.2v1
-The custom policy SHOULD be applied in Exchange, OneDrive, Teams Chat,
+The custom policy SHOULD be applied in Exchange, OneDrive, SharePoint, Teams chat,
 and Devices.
 - _Rationale:_ Unauthorized disclosures may happen through Microsoft 365
                services or endpoint devices.  Data loss prevention
@@ -369,8 +369,8 @@ MS.DEFENDER.4.2v1 implementation:
    Locations page.
 
 6. Under **Choose locations to apply the policy**, ensure **Status** is set
-   to **On** for at least the Exchange email, OneDrive accounts, Teams chat
-   and channel messages, and Devices.
+   to **On** for at least the Exchange email, OneDrive accounts, SharePoint
+   sites, Teams chat and channel messages, and Devices.
 
 7. Click **Next** on each page until reaching the
    **Review your policy and create it** page.


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This change updates the Defender secure configuration baseline markdown document, specifically MS.DEFENDER.4.2v1, to include SharePoint sites in custom DLP policies.

## 💭 Motivation and context ##

Ensures proper coverage of DLP actions across different M365 services by adding SharePoint sites to the set of services scanned for sensitive information by the custom policy. 

closes #278

## 🧪 Testing ##

Follow the implementation guidance for MS.DEFENDER.4.2v1 to create a custom policy that includes the SharePoint sites location.  This was tested in the G5 test tenant to confirm the setting works as intended.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] ~~Tests have been added and/or modified to cover the changes in this PR.~~
- [x] ~~All new and existing tests pass.~~

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] ~~Revert dependencies to default branches.~~
- [x] ~~Finalize version.~~

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] ~~Create a release.~~
