### PR TITLE
Update MS.AAD.7.6v1 rego to only apply to global admin 

### DIFF
--- a/Rego/AADConfig.rego
+++ b/Rego/AADConfig.rego
@@ -790,11 +790,11 @@ tests[{
     "Criticality" : "Should",
     "Commandlet" : ["Get-MgSubscribedSku", "Get-PrivilegedRole"],
     "ActualValue" : RolesWithoutApprovalRequired,
-    "ReportDetails" : ReportDetailsArrayLicenseWarning(RolesWithoutApprovalRequired, DescriptionString),
+    "ReportDetails" : ReportDetailsBooleanLicenseWarning(Status),
     "RequirementMet" : Status
 }] {
-    DescriptionString := "role(s) that do not require approval to activate found"
-    Conditions := [count(RolesWithoutApprovalRequired) == 0, check_if_role_rules_exist]
+    ApprovalNotRequired := "Global Administrator" in RolesWithoutApprovalRequired
+    Conditions := [ApprovalNotRequired == false, check_if_role_rules_exist]
     Status := count([Condition | Condition = Conditions[_]; Condition == false]) == 0
 }
 #--

--- a/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
+++ b/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
@@ -418,7 +418,56 @@ test_AdditionalProperties_Correct_V2 if {
 
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
-    RuleOutput[0].ReportDetails == "0 role(s) that do not require approval to activate found"
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
+
+test_AdditionalProperties_Correct_V3 if {
+    PolicyId := "MS.AAD.7.6v1"
+
+    Output := tests with input as {
+        "privileged_roles" : [
+            {
+                "DisplayName" : "Global Administrator",
+                "Rules" : [
+                    {
+                        "Id" :  "Approval_EndUser_Assignment",
+                        "AdditionalProperties" :  {
+                            "setting" : {
+                                "isApprovalRequired" : true
+                            }
+                        }
+                    }
+                ]
+            },
+            {
+                "DisplayName" : "Groups Administrator",
+                "Rules" : [
+                    {
+                        "Id" :  "Approval_EndUser_Assignment",
+                        "AdditionalProperties" :  {
+                            "setting" : {
+                                "isApprovalRequired" : false # this shouldn't matter, only Global Admin matters for this control
+                            }
+                        }
+                    }
+                ]
+            }
+        ],
+        "service_plans" : [
+            { "ServicePlanName" : "EXCHANGE_S_FOUNDATION",
+                "ServicePlanId" : "31a0d5b2-13d0-494f-8e42-1e9c550a1b24"
+            },
+            { "ServicePlanName" : "AAD_PREMIUM_P2",
+                "ServicePlanId" : "c7d91867-e1ce-4402-8d4f-22188b44b6c2"
+            }
+        ]
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
 }
 
 test_AdditionalProperties_Incorrect_V3 if {
@@ -454,7 +503,7 @@ test_AdditionalProperties_Incorrect_V3 if {
 
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
-    RuleOutput[0].ReportDetails == "1 role(s) that do not require approval to activate found:<br/>Global Administrator"
+    RuleOutput[0].ReportDetails == "Requirement not met"
 }
 #--
 


### PR DESCRIPTION
## 🗣 Description ##
Update MS.AAD.7.6v1 rego to only apply to global admin per recent baseline change.

## 💭 Motivation and context ##
Closes #415. 

## 🧪 Testing ##
- Tested on G5 tenant. Passes as expected.
- Tested on E5 tenant. Toggled the feature, passes and fails as appropriate.
- Tested on G3 tenant. Failed and displays the license warning as expected.
- Tested on GCC high tenant. Toggled the feature, passes and fails as appropriate.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

NOTE: some teams Rego unit tests will fail until https://github.com/cisagov/ScubaGear/pull/426 is merged in. Failure is unrelated to changes made in this branch.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
