### PR TITLE
Update MS.AAD.3.2v1 & MS.AAD.3.6v1 to Check Authentication Strength for Phishing Resistance MFA

### DIFF
--- a/Rego/AADConfig.rego
+++ b/Rego/AADConfig.rego
@@ -371,7 +371,7 @@ tests[{
     "RequirementMet" : false
 }] {
     PolicyId := "MS.AAD.3.3v1"
-    count(MS_AAD_3_1v1_CAP) = 0
+    count(MS_AAD_3_1v1_CAP) == 0
 }
 #--
 

--- a/Rego/AADConfig.rego
+++ b/Rego/AADConfig.rego
@@ -93,8 +93,8 @@ ReportDetailsBooleanLicenseWarning(_) = Description if {
 # User/Group Exclusion support functions #
 ##########################################
 
-default UserExclusionsFullyExempt(_, _) = false
-UserExclusionsFullyExempt(Policy, PolicyID) = true if {
+default UserExclusionsFullyExempt(_, _) := false
+UserExclusionsFullyExempt(Policy, PolicyID) := true if {
     # Returns true when all user exclusions present in the conditional
     # access policy are exempted in matching config variable for the
     # baseline policy item.  Undefined if no exclusions AND no exemptions.
@@ -104,14 +104,14 @@ UserExclusionsFullyExempt(Policy, PolicyID) = true if {
     count(ExcludedUsers - AllowedExcludedUsers) == 0
 }
 
-UserExclusionsFullyExempt(Policy, PolicyID) = true if {
+UserExclusionsFullyExempt(Policy, PolicyID) := true if {
     # Returns true when user inputs are not defined or user exclusion lists are empty
     count({ x | x := Policy.Conditions.Users.ExcludeUsers[_] }) == 0
     count({ y | y := input.scuba_config.Aad[PolicyID].CapExclusions.Users }) == 0
 }
 
-default GroupExclusionsFullyExempt(_, _) = false
-GroupExclusionsFullyExempt(Policy, PolicyID) = true if {
+default GroupExclusionsFullyExempt(_, _) := false
+GroupExclusionsFullyExempt(Policy, PolicyID) := true if {
     # Returns true when all group exclusions present in the conditional
     # access policy are exempted in matching config variable for the
     # baseline policy item.  Undefined if no exclusions AND no exemptions.
@@ -121,7 +121,7 @@ GroupExclusionsFullyExempt(Policy, PolicyID) = true if {
     count(ExcludedGroups - AllowedExcludedGroups) == 0
 }
 
-GroupExclusionsFullyExempt(Policy, PolicyID) = true if {
+GroupExclusionsFullyExempt(Policy, PolicyID) := true if {
     # Returns true when user inputs are not defined or group exclusion lists are empty
     count({ x | x := Policy.Conditions.Users.ExcludeGroups[_] }) == 0
     count({ y | y := input.scuba_config.Aad[PolicyID].CapExclusions.Groups }) == 0
@@ -134,8 +134,8 @@ GroupExclusionsFullyExempt(Policy, PolicyID) = true if {
 #
 # MS.AAD.1.1v1
 #--
-default LegacyAuthenticationConditionsMatch(_) = false
-LegacyAuthenticationConditionsMatch(Policy) = true if {
+default LegacyAuthenticationConditionsMatch(_) := false
+LegacyAuthenticationConditionsMatch(Policy) := true if {
     "All" in Policy.Conditions.Users.IncludeUsers
     "All" in Policy.Conditions.Applications.IncludeApplications
     "other" in Policy.Conditions.ClientAppTypes
@@ -176,8 +176,8 @@ tests[{
 #
 # MS.AAD.2.1v1
 #--
-default BlockHighRiskConditionsMatch(_) = false
-BlockHighRiskConditionsMatch(Policy) = true if {
+default BlockHighRiskConditionsMatch(_) := false
+BlockHighRiskConditionsMatch(Policy) := true if {
     "All" in Policy.Conditions.Users.IncludeUsers
     "All" in Policy.Conditions.Applications.IncludeApplications
     "high" in Policy.Conditions.UserRiskLevels
@@ -230,8 +230,8 @@ tests[{
 #
 # MS.AAD.2.3v1
 #--
-default SignInBlockedConditionsMatch(_) = false
-SignInBlockedConditionsMatch(Policy) = true if {
+default SignInBlockedConditionsMatch(_) := false
+SignInBlockedConditionsMatch(Policy) := true if {
     "All" in Policy.Conditions.Users.IncludeUsers
     "All" in Policy.Conditions.Applications.IncludeApplications
     "high" in Policy.Conditions.SignInRiskLevels
@@ -306,8 +306,8 @@ tests[{
 #
 # MS.AAD.3.2v1
 #--
-default AlternativeMFAConditionsMatch(_) = false
-AlternativeMFAConditionsMatch(Policy) = true if {
+default AlternativeMFAConditionsMatch(_) := false
+AlternativeMFAConditionsMatch(Policy) := true if {
     "All" in Policy.Conditions.Users.IncludeUsers
     "All" in Policy.Conditions.Applications.IncludeApplications
     "mfa" in Policy.GrantControls.BuiltInControls
@@ -701,7 +701,7 @@ DoPIMRoleRulesExist {
     _ = input.privileged_roles[_]["Rules"]
 }
 
-default check_if_role_rules_exist = false
+default check_if_role_rules_exist := false
 check_if_role_rules_exist := DoPIMRoleRulesExist
 
 #
@@ -773,8 +773,8 @@ tests[{
 #
 # MS.AAD.7.4v1
 #--
-default PrivilegedRoleExclusions(_, _) = false
-PrivilegedRoleExclusions(PrivilegedRole, PolicyID) = true if {
+default PrivilegedRoleExclusions(_, _) := false
+PrivilegedRoleExclusions(PrivilegedRole, PolicyID) := true if {
     PrivilegedRoleAssignedPrincipals := { x.PrincipalId | some x in PrivilegedRole.Assignments; x.EndDateTime == null }
 
     AllowedPrivilegedRoleUsers := { y | some y in input.scuba_config.Aad[PolicyID].RoleExclusions.Users; y != null }
@@ -785,7 +785,7 @@ PrivilegedRoleExclusions(PrivilegedRole, PolicyID) = true if {
     count(PrivilegedRoleAssignedPrincipals - AllowedPrivilegedRole) != 0
 }
 
-PrivilegedRoleExclusions(PrivilegedRole, PolicyID) = true if {
+PrivilegedRoleExclusions(PrivilegedRole, PolicyID) := true if {
     count({ x.PrincipalId | some x in PrivilegedRole.Assignments; x.EndDateTime == null }) > 0
     count({ y | some y in input.scuba_config.Aad[PolicyID].RoleExclusions.Users; y != null }) == 0
     count({ y | some y in input.scuba_config.Aad[PolicyID].RoleExclusions.Groups; y != null }) == 0
@@ -950,10 +950,10 @@ tests[{
 #--
 # must hardcode the ID. See
 # https://docs.microsoft.com/en-us/azure/active-directory/enterprise-users/users-restrict-guest-permissions
-LevelAsString(Id) = "Restricted access" if {Id == "2af84b1e-32c8-42b7-82bc-daa82404023b"}
-LevelAsString(Id) = "Limited access" if {Id == "10dae51f-b6af-4016-8d66-8c2a99b929b3"}
-LevelAsString(Id) = "Same as member users" if {Id == "a0b1b346-4d3e-4e8b-98f8-753987be4970"}
-LevelAsString(Id) = "Unknown" if {not Id in ["2af84b1e-32c8-42b7-82bc-daa82404023b", "10dae51f-b6af-4016-8d66-8c2a99b929b3", "a0b1b346-4d3e-4e8b-98f8-753987be4970"]}
+LevelAsString(Id) := "Restricted access" if {Id == "2af84b1e-32c8-42b7-82bc-daa82404023b"}
+LevelAsString(Id) := "Limited access" if {Id == "10dae51f-b6af-4016-8d66-8c2a99b929b3"}
+LevelAsString(Id) := "Same as member users" if {Id == "a0b1b346-4d3e-4e8b-98f8-753987be4970"}
+LevelAsString(Id) := "Unknown" if {not Id in ["2af84b1e-32c8-42b7-82bc-daa82404023b", "10dae51f-b6af-4016-8d66-8c2a99b929b3", "a0b1b346-4d3e-4e8b-98f8-753987be4970"]}
 
 AuthPoliciesBadRoleId[Policy.Id] {
     Policy = input.authorization_policies[_]

--- a/Rego/AADConfig.rego
+++ b/Rego/AADConfig.rego
@@ -93,8 +93,8 @@ ReportDetailsBooleanLicenseWarning(_) = Description if {
 # User/Group Exclusion support functions #
 ##########################################
 
-default UserExclusionsFullyExempt(_, _) := false
-UserExclusionsFullyExempt(Policy, PolicyID) := true if {
+default UserExclusionsFullyExempt(_, _) = false
+UserExclusionsFullyExempt(Policy, PolicyID) = true if {
     # Returns true when all user exclusions present in the conditional
     # access policy are exempted in matching config variable for the
     # baseline policy item.  Undefined if no exclusions AND no exemptions.
@@ -104,14 +104,14 @@ UserExclusionsFullyExempt(Policy, PolicyID) := true if {
     count(ExcludedUsers - AllowedExcludedUsers) == 0
 }
 
-UserExclusionsFullyExempt(Policy, PolicyID) := true if {
+UserExclusionsFullyExempt(Policy, PolicyID) = true if {
     # Returns true when user inputs are not defined or user exclusion lists are empty
     count({ x | x := Policy.Conditions.Users.ExcludeUsers[_] }) == 0
     count({ y | y := input.scuba_config.Aad[PolicyID].CapExclusions.Users }) == 0
 }
 
-default GroupExclusionsFullyExempt(_, _) := false
-GroupExclusionsFullyExempt(Policy, PolicyID) := true if {
+default GroupExclusionsFullyExempt(_, _) = false
+GroupExclusionsFullyExempt(Policy, PolicyID) = true if {
     # Returns true when all group exclusions present in the conditional
     # access policy are exempted in matching config variable for the
     # baseline policy item.  Undefined if no exclusions AND no exemptions.
@@ -121,7 +121,7 @@ GroupExclusionsFullyExempt(Policy, PolicyID) := true if {
     count(ExcludedGroups - AllowedExcludedGroups) == 0
 }
 
-GroupExclusionsFullyExempt(Policy, PolicyID) := true if {
+GroupExclusionsFullyExempt(Policy, PolicyID) = true if {
     # Returns true when user inputs are not defined or group exclusion lists are empty
     count({ x | x := Policy.Conditions.Users.ExcludeGroups[_] }) == 0
     count({ y | y := input.scuba_config.Aad[PolicyID].CapExclusions.Groups }) == 0
@@ -134,8 +134,8 @@ GroupExclusionsFullyExempt(Policy, PolicyID) := true if {
 #
 # MS.AAD.1.1v1
 #--
-default LegacyAuthenticationConditionsMatch(_) := false
-LegacyAuthenticationConditionsMatch(Policy) := true if {
+default LegacyAuthenticationConditionsMatch(_) = false
+LegacyAuthenticationConditionsMatch(Policy) = true if {
     "All" in Policy.Conditions.Users.IncludeUsers
     "All" in Policy.Conditions.Applications.IncludeApplications
     "other" in Policy.Conditions.ClientAppTypes
@@ -176,8 +176,8 @@ tests[{
 #
 # MS.AAD.2.1v1
 #--
-default BlockHighRiskConditionsMatch(_) := false
-BlockHighRiskConditionsMatch(Policy) := true if {
+default BlockHighRiskConditionsMatch(_) = false
+BlockHighRiskConditionsMatch(Policy) = true if {
     "All" in Policy.Conditions.Users.IncludeUsers
     "All" in Policy.Conditions.Applications.IncludeApplications
     "high" in Policy.Conditions.UserRiskLevels
@@ -230,8 +230,8 @@ tests[{
 #
 # MS.AAD.2.3v1
 #--
-default SignInBlockedConditionsMatch(_) := false
-SignInBlockedConditionsMatch(Policy) := true if {
+default SignInBlockedConditionsMatch(_) = false
+SignInBlockedConditionsMatch(Policy) = true if {
     "All" in Policy.Conditions.Users.IncludeUsers
     "All" in Policy.Conditions.Applications.IncludeApplications
     "high" in Policy.Conditions.SignInRiskLevels
@@ -306,8 +306,8 @@ tests[{
 #
 # MS.AAD.3.2v1
 #--
-default AlternativeMFAConditionsMatch(_) := false
-AlternativeMFAConditionsMatch(Policy) := true if {
+default AlternativeMFAConditionsMatch(_) = false
+AlternativeMFAConditionsMatch(Policy) = true if {
     "All" in Policy.Conditions.Users.IncludeUsers
     "All" in Policy.Conditions.Applications.IncludeApplications
     "mfa" in Policy.GrantControls.BuiltInControls
@@ -347,16 +347,31 @@ tests[{
 # MS.AAD.3.3v1
 #--
 # At this time we are unable to test for X because of NEW POLICY
+# If we have acceptable MFA then policy passes otherwise MS Authenticator need to be 
+# enabled to pass. However, we can not currently check if MS Authenticator enabled
+tests[{
+    "PolicyId" : "MS.AAD.3.3v1",
+    "Criticality" : "Shall",
+    "Commandlet" : ["Get-MgIdentityConditionalAccessPolicy"],
+    "ActualValue" : MS_AAD_3_1v1_CAP,
+    "ReportDetails" : concat(". ", [ReportFullDetailsArray(MS_AAD_3_1v1_CAP, DescriptionString), CapLink]),
+    "RequirementMet" : Status
+}]{
+    DescriptionString := "conditional access policy(s) found that meet(s) all requirements"
+    Status := count(MS_AAD_3_1v1_CAP) > 0
+    count(MS_AAD_3_1v1_CAP) > 0
+}   
+
 tests[{
     "PolicyId": PolicyId,
-    "Criticality" : "Should/Not-Implemented",
+    "Criticality" : "Shall/Not-Implemented",
     "Commandlet" : [],
     "ActualValue" : [],
     "ReportDetails" : NotCheckedDetails(PolicyId),
     "RequirementMet" : false
 }] {
     PolicyId := "MS.AAD.3.3v1"
-    true
+    count(MS_AAD_3_1v1_CAP) = 0
 }
 #--
 
@@ -401,7 +416,6 @@ tests[{
 PhishingResistantMFA[Cap.DisplayName] {
     Cap := input.conditional_access_policies[_]
     Cap.State == "enabled"
-    count(MS_AAD_3_1v1_CAP) > 0
     PrivRolesSet := { Role.RoleTemplateId | Role = input.privileged_roles[_] }
     CondIncludedRolesSet := { Y | Y = Cap.Conditions.Users.IncludeRoles[_] }
     MissingRoles := PrivRolesSet - CondIncludedRolesSet
@@ -687,7 +701,7 @@ DoPIMRoleRulesExist {
     _ = input.privileged_roles[_]["Rules"]
 }
 
-default check_if_role_rules_exist := false
+default check_if_role_rules_exist = false
 check_if_role_rules_exist := DoPIMRoleRulesExist
 
 #
@@ -759,8 +773,8 @@ tests[{
 #
 # MS.AAD.7.4v1
 #--
-default PrivilegedRoleExclusions(_, _) := false
-PrivilegedRoleExclusions(PrivilegedRole, PolicyID) := true if {
+default PrivilegedRoleExclusions(_, _) = false
+PrivilegedRoleExclusions(PrivilegedRole, PolicyID) = true if {
     PrivilegedRoleAssignedPrincipals := { x.PrincipalId | some x in PrivilegedRole.Assignments; x.EndDateTime == null }
 
     AllowedPrivilegedRoleUsers := { y | some y in input.scuba_config.Aad[PolicyID].RoleExclusions.Users; y != null }
@@ -771,7 +785,7 @@ PrivilegedRoleExclusions(PrivilegedRole, PolicyID) := true if {
     count(PrivilegedRoleAssignedPrincipals - AllowedPrivilegedRole) != 0
 }
 
-PrivilegedRoleExclusions(PrivilegedRole, PolicyID) := true if {
+PrivilegedRoleExclusions(PrivilegedRole, PolicyID) = true if {
     count({ x.PrincipalId | some x in PrivilegedRole.Assignments; x.EndDateTime == null }) > 0
     count({ y | some y in input.scuba_config.Aad[PolicyID].RoleExclusions.Users; y != null }) == 0
     count({ y | some y in input.scuba_config.Aad[PolicyID].RoleExclusions.Groups; y != null }) == 0
@@ -936,10 +950,10 @@ tests[{
 #--
 # must hardcode the ID. See
 # https://docs.microsoft.com/en-us/azure/active-directory/enterprise-users/users-restrict-guest-permissions
-LevelAsString(Id) := "Restricted access" if {Id == "2af84b1e-32c8-42b7-82bc-daa82404023b"}
-LevelAsString(Id) := "Limited access" if {Id == "10dae51f-b6af-4016-8d66-8c2a99b929b3"}
-LevelAsString(Id) := "Same as member users" if {Id == "a0b1b346-4d3e-4e8b-98f8-753987be4970"}
-LevelAsString(Id) := "Unknown" if {not Id in ["2af84b1e-32c8-42b7-82bc-daa82404023b", "10dae51f-b6af-4016-8d66-8c2a99b929b3", "a0b1b346-4d3e-4e8b-98f8-753987be4970"]}
+LevelAsString(Id) = "Restricted access" if {Id == "2af84b1e-32c8-42b7-82bc-daa82404023b"}
+LevelAsString(Id) = "Limited access" if {Id == "10dae51f-b6af-4016-8d66-8c2a99b929b3"}
+LevelAsString(Id) = "Same as member users" if {Id == "a0b1b346-4d3e-4e8b-98f8-753987be4970"}
+LevelAsString(Id) = "Unknown" if {not Id in ["2af84b1e-32c8-42b7-82bc-daa82404023b", "10dae51f-b6af-4016-8d66-8c2a99b929b3", "a0b1b346-4d3e-4e8b-98f8-753987be4970"]}
 
 AuthPoliciesBadRoleId[Policy.Id] {
     Policy = input.authorization_policies[_]

--- a/Rego/AADConfig.rego
+++ b/Rego/AADConfig.rego
@@ -317,6 +317,10 @@ AlternativeMFAConditionsMatch(Policy) := true if {
 
 AlternativeMFA[Cap.DisplayName] {
     Cap := input.conditional_access_policies[_]
+    Count(MS_AAD_3_1v1_CAP) > 0
+}
+AlternativeMFA[Cap.DisplayName] {
+    Cap := input.conditional_access_policies[_]
 
     # Match all simple conditions
     AlternativeMFAConditionsMatch(Cap)
@@ -396,6 +400,8 @@ tests[{
 #--
 PhishingResistantMFA[Cap.DisplayName] {
     Cap := input.conditional_access_policies[_]
+    Cap.State == "enabled"
+    count(MS_AAD_3_1v1_CAP) > 0
     PrivRolesSet := { Role.RoleTemplateId | Role = input.privileged_roles[_] }
     CondIncludedRolesSet := { Y | Y = Cap.Conditions.Users.IncludeRoles[_] }
     MissingRoles := PrivRolesSet - CondIncludedRolesSet
@@ -408,7 +414,9 @@ PhishingResistantMFA[Cap.DisplayName] {
     count(MatchingExcludeRoles) == 0
     "All" in Cap.Conditions.Applications.IncludeApplications
     "mfa" in Cap.GrantControls.BuiltInControls
-    Cap.State == "enabled"
+
+    GroupExclusionsFullyExempt(Cap, "MS.AAD.3.6v1") == true
+    UserExclusionsFullyExempt(Cap, "MS.AAD.3.6v1") == true
 }
 
 tests[{

--- a/Testing/Unit/Rego/AAD/AADConfig_03_test.rego
+++ b/Testing/Unit/Rego/AAD/AADConfig_03_test.rego
@@ -1387,10 +1387,79 @@ test_State_Incorrect_V1 if {
 #
 # MS.AAD.3.3v1
 #--
+test_3_1_passes_and_satisfies_3_3 if{
+    PolicyId := "MS.AAD.3.3v1"
+
+    Output := tests with input as {
+        "conditional_access_policies" : [
+            {
+                "Conditions" : {
+                    "Applications" : {
+                        "IncludeApplications" : ["All"],
+                        "ExcludeApplications" : []
+                    },
+                    "Users" : {
+                        "IncludeUsers" : ["All"],
+                        "ExcludeUsers" : [],
+                        "ExcludeGroups" : [],
+                        "ExcludeRoles" : []
+                    }
+                },
+                "GrantControls" : {
+                    "AuthenticationStrength" : {
+                        "AllowedCombinations":  [
+                            "windowsHelloForBusiness",
+                            "fido2",
+                            "x509CertificateMultiFactor"
+                        ]
+                    }
+                },
+                "State" : "enabled",
+                "DisplayName" : "Test Policy"
+            }
+        ]
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "1 conditional access policy(s) found that meet(s) all requirements:<br/>Test Policy. <a href='#caps'>View all CA policies</a>."
+
+}
+
 test_NotImplemented_Correct_V2 if {
     PolicyId := "MS.AAD.3.3v1"
 
-    Output := tests with input as { }
+    Output := tests with input as {
+        "conditional_access_policies" : [
+            {
+                "Conditions" : {
+                    "Applications" : {
+                        "IncludeApplications" : ["All"],
+                        "ExcludeApplications" : []
+                    },
+                    "Users" : {
+                        "IncludeUsers" : ["All"],
+                        "ExcludeUsers" : [],
+                        "ExcludeGroups" : [],
+                        "ExcludeRoles" : []
+                    }
+                },
+                "GrantControls" : {
+                    "AuthenticationStrength" : {
+                        "AllowedCombinations":  [
+                            "windowsHelloForBusiness",
+                            "fido2",
+                            "Super strength"
+                        ]
+                    }
+                },
+                "State" : "enabled",
+                "DisplayName" : "Test Policy"
+            }
+        ]
+    }
 
     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
 
@@ -1467,31 +1536,6 @@ test_ConditionalAccessPolicies_Correct_V2 if {
             {
                 "Conditions" : {
                     "Applications" : {
-                        "IncludeApplications" : ["All"],
-                        "ExcludeApplications" : []
-                    },
-                    "Users" : {
-                        "IncludeUsers" : ["All"],
-                        "ExcludeUsers" : [],
-                        "ExcludeGroups" : [],
-                        "ExcludeRoles" : []
-                    }
-                },
-                "GrantControls" : {
-                    "AuthenticationStrength" : {
-                        "AllowedCombinations":  [
-                            "windowsHelloForBusiness",
-                            "fido2",
-                            "x509CertificateMultiFactor"
-                        ]
-                    }
-                },
-                "State" : "enabled",
-                "DisplayName" : "Test name"
-            },
-            {
-                "Conditions" : {
-                    "Applications" : {
                         "IncludeApplications" : ["All"]
                     },
                     "Users" : {
@@ -1523,72 +1567,6 @@ test_ConditionalAccessPolicies_Correct_V2 if {
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     RuleOutput[0].ReportDetails == "1 conditional access policy(s) found that meet(s) all requirements:<br/>MFA required for all highly Privileged Roles Policy. <a href='#caps'>View all CA policies</a>."
-}
-
-test_GoodStrengthBadMFA if {
-    PolicyId := "MS.AAD.3.6v1"
-
-    Output := tests with input as {
-        "conditional_access_policies" : [
-            {
-                "Conditions" : {
-                    "Applications" : {
-                        "IncludeApplications" : ["All"],
-                        "ExcludeApplications" : []
-                    },
-                    "Users" : {
-                        "IncludeUsers" : ["All"],
-                        "ExcludeUsers" : [],
-                        "ExcludeGroups" : [],
-                        "ExcludeRoles" : []
-                    }
-                },
-                "GrantControls" : {
-                    "AuthenticationStrength" : {
-                        "AllowedCombinations":  [
-                            "windowsHelloForBusiness",
-                            "fido2",
-                            "x509CertificateMultiFactor"
-                        ]
-                    }
-                },
-                "State" : "enabled",
-                "DisplayName" : "Test name"
-            },
-            {
-                "Conditions" : {
-                    "Applications" : {
-                        "IncludeApplications" : ["All"]
-                    },
-                    "Users" : {
-                        "IncludeRoles" : ["Role1", "Role2" ],
-                        "ExcludeRoles" : []
-                    }
-                },
-                "GrantControls" : {
-                    "BuiltInControls" : []
-                },
-                "State" : "enabled",
-                "DisplayName" : "MFA required for all highly Privileged Roles Policy"
-            }
-        ],
-        "privileged_roles" : [
-            {
-                "RoleTemplateId" : "Role1",
-                "DisplayName" : "Global Administrator"
-            },
-            {
-                "RoleTemplateId" : "Role2",
-                "DisplayName" : "Privileged Role Administrator"
-            }
-        ]
-    }
-
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
-
-    count(RuleOutput) == 1
-    not RuleOutput[0].RequirementMet
-    RuleOutput[0].ReportDetails == "0 conditional access policy(s) found that meet(s) all requirements. <a href='#caps'>View all CA policies</a>."
 }
 
 test_IncludeApplications_Incorrect_V2 if {

--- a/Testing/Unit/Rego/AAD/AADConfig_03_test.rego
+++ b/Testing/Unit/Rego/AAD/AADConfig_03_test.rego
@@ -317,6 +317,123 @@ test_NoExclusionsConditions_Correct if {
     RuleOutput[0].ReportDetails == "1 conditional access policy(s) found that meet(s) all requirements:<br/>Test name. <a href='#caps'>View all CA policies</a>."
 }
 
+test_3_1_Passes_3_2_Fails_Correct if {
+    PolicyId := "MS.AAD.3.2v1"
+
+    Output := tests with input as {
+        "conditional_access_policies" : [
+            {
+                "Conditions" : {
+                    "Applications" : {
+                        "IncludeApplications" : ["All"],
+                        "ExcludeApplications" : []
+                    },
+                    "Users" : {
+                        "IncludeUsers" : ["All"],
+                        "ExcludeUsers" : [],
+                        "ExcludeGroups" : [],
+                        "ExcludeRoles" : []
+                    }
+                },
+                "GrantControls" : {
+                    "AuthenticationStrength" : {
+                        "AllowedCombinations":  [
+                            "windowsHelloForBusiness",
+                            "fido2",
+                            "x509CertificateMultiFactor"
+                        ]
+                    }
+                },
+                "State" : "enabled",
+                "DisplayName" : "Test name"
+            },
+            {
+                "Conditions" : {
+                    "Applications" : {
+                        "IncludeApplications" : ["All"]
+                    },
+                    "Users" : {
+                        "IncludeUsers" : ["All"],
+                        "ExcludeUsers" : [],
+                        "ExcludeGroups" : [],
+                        "ExcludeRoles" : []
+                    }
+                },
+                "GrantControls" : {
+                    "BuiltInControls" : [""]
+                },
+                "State" : "enabled",
+                "DisplayName" : "Test name"
+            }
+        ]
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "1 conditional access policy(s) found that meet(s) all requirements:<br/>Test name. <a href='#caps'>View all CA policies</a>."
+}
+
+test_3_1_Fails_3_2_Passes_Correct if {
+    PolicyId := "MS.AAD.3.2v1"
+
+    Output := tests with input as {
+        "conditional_access_policies" : [
+            {
+                "Conditions" : {
+                    "Applications" : {
+                        "IncludeApplications" : ["All"],
+                        "ExcludeApplications" : []
+                    },
+                    "Users" : {
+                        "IncludeUsers" : ["All"],
+                        "ExcludeUsers" : [],
+                        "ExcludeGroups" : [],
+                        "ExcludeRoles" : []
+                    }
+                },
+                "GrantControls" : {
+                    "AuthenticationStrength" : {
+                        "AllowedCombinations":  [
+                            "windowsHelloForBusiness",
+                            "fido2",
+                            "x509CertificateMultiFactor",
+                            "SuperStrength"
+                        ]
+                    }
+                },
+                "State" : "enabled",
+                "DisplayName" : "Test name"
+            },
+            {
+                "Conditions" : {
+                    "Applications" : {
+                        "IncludeApplications" : ["All"]
+                    },
+                    "Users" : {
+                        "IncludeUsers" : ["All"],
+                        "ExcludeUsers" : [],
+                        "ExcludeGroups" : [],
+                        "ExcludeRoles" : []
+                    }
+                },
+                "GrantControls" : {
+                    "BuiltInControls" : ["mfa"]
+                },
+                "State" : "enabled",
+                "DisplayName" : "Test name"
+            }
+        ]
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "1 conditional access policy(s) found that meet(s) all requirements:<br/>Test name. <a href='#caps'>View all CA policies</a>."
+}
+
 test_NoExclusionsExemptUsers_Correct if {
     PolicyId := "MS.AAD.3.2v1"
 
@@ -1350,6 +1467,31 @@ test_ConditionalAccessPolicies_Correct_V2 if {
             {
                 "Conditions" : {
                     "Applications" : {
+                        "IncludeApplications" : ["All"],
+                        "ExcludeApplications" : []
+                    },
+                    "Users" : {
+                        "IncludeUsers" : ["All"],
+                        "ExcludeUsers" : [],
+                        "ExcludeGroups" : [],
+                        "ExcludeRoles" : []
+                    }
+                },
+                "GrantControls" : {
+                    "AuthenticationStrength" : {
+                        "AllowedCombinations":  [
+                            "windowsHelloForBusiness",
+                            "fido2",
+                            "x509CertificateMultiFactor"
+                        ]
+                    }
+                },
+                "State" : "enabled",
+                "DisplayName" : "Test name"
+            },
+            {
+                "Conditions" : {
+                    "Applications" : {
                         "IncludeApplications" : ["All"]
                     },
                     "Users" : {
@@ -1381,6 +1523,72 @@ test_ConditionalAccessPolicies_Correct_V2 if {
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     RuleOutput[0].ReportDetails == "1 conditional access policy(s) found that meet(s) all requirements:<br/>MFA required for all highly Privileged Roles Policy. <a href='#caps'>View all CA policies</a>."
+}
+
+test_GoodStrengthBadMFA if {
+    PolicyId := "MS.AAD.3.6v1"
+
+    Output := tests with input as {
+        "conditional_access_policies" : [
+            {
+                "Conditions" : {
+                    "Applications" : {
+                        "IncludeApplications" : ["All"],
+                        "ExcludeApplications" : []
+                    },
+                    "Users" : {
+                        "IncludeUsers" : ["All"],
+                        "ExcludeUsers" : [],
+                        "ExcludeGroups" : [],
+                        "ExcludeRoles" : []
+                    }
+                },
+                "GrantControls" : {
+                    "AuthenticationStrength" : {
+                        "AllowedCombinations":  [
+                            "windowsHelloForBusiness",
+                            "fido2",
+                            "x509CertificateMultiFactor"
+                        ]
+                    }
+                },
+                "State" : "enabled",
+                "DisplayName" : "Test name"
+            },
+            {
+                "Conditions" : {
+                    "Applications" : {
+                        "IncludeApplications" : ["All"]
+                    },
+                    "Users" : {
+                        "IncludeRoles" : ["Role1", "Role2" ],
+                        "ExcludeRoles" : []
+                    }
+                },
+                "GrantControls" : {
+                    "BuiltInControls" : []
+                },
+                "State" : "enabled",
+                "DisplayName" : "MFA required for all highly Privileged Roles Policy"
+            }
+        ],
+        "privileged_roles" : [
+            {
+                "RoleTemplateId" : "Role1",
+                "DisplayName" : "Global Administrator"
+            },
+            {
+                "RoleTemplateId" : "Role2",
+                "DisplayName" : "Privileged Role Administrator"
+            }
+        ]
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "0 conditional access policy(s) found that meet(s) all requirements. <a href='#caps'>View all CA policies</a>."
 }
 
 test_IncludeApplications_Incorrect_V2 if {


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Check Authentication Strength for Phishing Resistance MFA.
Make both MS.AAD.3.2v1 and MS.AAD.3.6v1 depend/use MS.AAD.3.1.1v1 Authentication Strength checks.  

closes #409 
closes #413

## 💭 Motivation and context ##

Phisting resistant MFA is required in new secure baseline for MS.AAD.3.2v1 and MS.AAD.3.6v1

## 🧪 Testing ##

Added additional unit tests for MS.AAD.3.2v1 and MS.AAD.3.6v1.  
Ran InvokeScuba against all tenants. 

## 📷 Screenshots (if appropriate) ##
![image](https://github.com/cisagov/ScubaGear/assets/7025068/8633815d-26bc-423e-a444-cdf8b149b9a5)

![image](https://github.com/cisagov/ScubaGear/assets/7025068/7630fc59-9bae-4b07-9bbe-bcc4160ff67e)



## ✅ Pre-approval checklist ##

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [X] All relevant type-of-change labels have been added.
- [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [X] Tests have been added and/or modified to cover the changes in this PR.
- [X] All new and existing tests pass (except with open issues).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
