### PR TITLE
Update MS.DEFENDER.1.5v1 ATP rules check for sensitive users

### DIFF
--- a/Rego/DefenderConfig.rego
+++ b/Rego/DefenderConfig.rego
@@ -251,23 +251,23 @@ tests[{
 # MS.DEFENDER.1.5v1
 #--
 
-# TODO: look at config file to get list of sensitive users. Current
-# implementation just asserts that the strict policy applies to at
-# least one person.
+ATPPolicyForSensitiveIDs[Policies] {
+    Policies := input.atp_policy_rules
+    AccountsSetting := SensitiveAccountsSetting(Policies)
+    AccountsConfig := SensitiveAccountsConfig("MS.DEFENDER.1.5v1")
+
+    SensitiveAccounts(AccountsSetting, AccountsConfig) == true
+}
 
 tests[{
     "PolicyId" : "MS.DEFENDER.1.5v1",
     "Criticality" : "Shall",
     "Commandlet" : ["Get-ATPProtectionPolicyRule"],
-    "ActualValue" : {"ATPProtectionPolicies": Policies},
+    "ActualValue" : {"ATPProtectionPolicies": Status},
     "ReportDetails" : ApplyLicenseWarning(ReportDetailsBoolean(Status)),
     "RequirementMet" : Status
 }] {
-    Policies := input.atp_policy_rules
-    # If no one has been assigned to the strict policy, it won't even
-    # be included in the output of Get-ATPProtectionPolicyRule
-    Status := count([Policy | Policy = Policies[_];
-        Policy.Identity == "Strict Preset Security Policy"]) > 0
+    Status := count(ATPPolicyForSensitiveIDs) == 1
 }
 #--
 

--- a/Testing/Unit/Rego/Defender/DefenderConfig_01_test.rego
+++ b/Testing/Unit/Rego/Defender/DefenderConfig_01_test.rego
@@ -1822,15 +1822,38 @@ test_SensitiveEOP_Incorrect_V5 if {
 #
 # Policy 5
 #--
-test_SensitiveAtp_Correct_V1 if {
+test_SensitiveATP_Correct_V1 if {
     PolicyId := "MS.DEFENDER.1.5v1"
 
     Output := tests with input as {
         "atp_policy_rules" : [
             {
-                "Identity" : "Strict Preset Security Policy"
+                "Identity" : "Strict Preset Security Policy",
+                "SentTo": null,
+                "SentToMemberOf": null,
+                "RecipientDomainIs": null,
+                "ExceptIfSentTo": null,
+                "ExceptIfSentToMemberOf": null,
+                "ExceptIfRecipientDomainIs": null,
+                "Conditions":  null,
+                "Exceptions":  null,
+                "State":  "Enabled"
             }
         ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {
+                        "IncludedUsers" : [],
+                        "IncludedGroups" : [],
+                        "IncludedDomains" : [],
+                        "ExcludedUsers" : [],
+                        "ExcludedGroups" : [],
+                        "ExcludedDomains" : []
+                    }
+                }
+            }
+        },
         "defender_license": true
     }
 
@@ -1841,11 +1864,1146 @@ test_SensitiveAtp_Correct_V1 if {
     RuleOutput[0].ReportDetails == "Requirement met"
 }
 
-test_SensitiveAtp_Incorrect_V1 if {
+test_SensitiveATP_Correct_V2 if {
     PolicyId := "MS.DEFENDER.1.5v1"
 
     Output := tests with input as {
-        "atp_policy_rules" : [],
+        "atp_policy_rules" : [
+            {
+                "Identity" : "Strict Preset Security Policy",
+                "SentTo": null,
+                "SentToMemberOf": null,
+                "RecipientDomainIs": null,
+                "ExceptIfSentTo": null,
+                "ExceptIfSentToMemberOf": null,
+                "ExceptIfRecipientDomainIs": null,
+                "Conditions":  null,
+                "Exceptions":  null,
+                "State":  "Enabled"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {
+                    }
+                }
+            }
+        },
+        "defender_license": true
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
+
+test_SensitiveATP_Correct_V3 if {
+    PolicyId := "MS.DEFENDER.1.5v1"
+
+    Output := tests with input as {
+        "atp_policy_rules" : [
+            {
+                "Identity" : "Strict Preset Security Policy",
+                "SentTo": [
+                    "johndoe@random.example.com"
+                ],
+                "SentToMemberOf": null,
+                "RecipientDomainIs": null,
+                "ExceptIfSentTo": null,
+                "ExceptIfSentToMemberOf": null,
+                "ExceptIfRecipientDomainIs": null,
+                "Conditions":  [
+                    "Rules.Tasks"
+                ],
+                "Exceptions":  null,
+                "State":  "Enabled"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {
+                        "IncludedUsers" : [
+                            "johndoe@random.example.com"
+                        ]
+                    }
+                }
+            }
+        },
+        "defender_license": true
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
+
+test_SensitiveATP_Correct_V4 if {
+    PolicyId := "MS.DEFENDER.1.5v1"
+
+    Output := tests with input as {
+        "atp_policy_rules" : [
+            {
+                "Identity" : "Strict Preset Security Policy",
+                "SentTo": [
+                    "johndoe@random.example.com",
+                    "janedoe@random.example.com"
+                ],
+                "SentToMemberOf": null,
+                "RecipientDomainIs": null,
+                "ExceptIfSentTo": null,
+                "ExceptIfSentToMemberOf": null,
+                "ExceptIfRecipientDomainIs": null,
+                "Conditions":  [
+                    "Rules.Tasks"
+                ],
+                "Exceptions":  null,
+                "State":  "Enabled"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {
+                        "IncludedUsers" : [
+                            "johndoe@random.example.com",
+                            "janedoe@random.example.com"
+                        ]
+                    }
+                }
+            }
+        },
+        "defender_license": true
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
+
+test_SensitiveATP_Correct_V5 if {
+    PolicyId := "MS.DEFENDER.1.5v1"
+
+    Output := tests with input as {
+        "atp_policy_rules" : [
+            {
+                "Identity" : "Strict Preset Security Policy",
+                "SentTo": null,
+                "SentToMemberOf": null,
+                "RecipientDomainIs": null,
+                "ExceptIfSentTo": [
+                    "johndoe@random.example.com"
+                ],
+                "ExceptIfSentToMemberOf": null,
+                "ExceptIfRecipientDomainIs": null,
+                "Conditions":  null,
+                "Exceptions":  [
+                    "Rules.Tasks"
+                ],
+                "State":  "Enabled"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {
+                        "ExcludedUsers" : [
+                            "johndoe@random.example.com"
+                        ]
+                    }
+                }
+            }
+        },
+        "defender_license": true
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
+
+test_SensitiveATP_Correct_V6 if {
+    PolicyId := "MS.DEFENDER.1.5v1"
+
+    Output := tests with input as {
+        "atp_policy_rules" : [
+            {
+                "Identity" : "Strict Preset Security Policy",
+                "SentTo": null,
+                "SentToMemberOf": null,
+                "RecipientDomainIs": null,
+                "ExceptIfSentTo": [
+                    "johndoe@random.example.com",
+                    "janedoe@random.example.com"
+                ],
+                "ExceptIfSentToMemberOf": null,
+                "ExceptIfRecipientDomainIs": null,
+                "Conditions":  null,
+                "Exceptions":  [
+                    "Rules.Tasks"
+                ],
+                "State":  "Enabled"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {
+                        "ExcludedUsers" : [
+                            "johndoe@random.example.com",
+                            "janedoe@random.example.com"
+                        ]
+                    }
+                }
+            }
+        },
+        "defender_license": true
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
+
+test_SensitiveATP_Correct_V7 if {
+    PolicyId := "MS.DEFENDER.1.5v1"
+
+    Output := tests with input as {
+        "atp_policy_rules" : [
+            {
+                "Identity" : "Strict Preset Security Policy",
+                "SentTo": null,
+                "SentToMemberOf": [
+                    "Dune"
+                ],
+                "RecipientDomainIs": null,
+                "ExceptIfSentTo": null,
+                "ExceptIfSentToMemberOf": null,
+                "ExceptIfRecipientDomainIs": null,
+                "Conditions":  [
+                    "Rules.Tasks"
+                ],
+                "Exceptions":  null,
+                "State":  "Enabled"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {
+                        "IncludedGroups" : [
+                            "Dune"
+                        ]
+                    }
+                }
+            }
+        },
+        "defender_license": true
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
+
+test_SensitiveATP_Correct_V8 if {
+    PolicyId := "MS.DEFENDER.1.5v1"
+
+    Output := tests with input as {
+        "atp_policy_rules" : [
+            {
+                "Identity" : "Strict Preset Security Policy",
+                "SentTo": null,
+                "SentToMemberOf": [
+                    "Dune",
+                    "Dune12"
+                ],
+                "RecipientDomainIs": null,
+                "ExceptIfSentTo": null,
+                "ExceptIfSentToMemberOf": null,
+                "ExceptIfRecipientDomainIs": null,
+                "Conditions":  [
+                    "Rules.Tasks"
+                ],
+                "Exceptions":  null,
+                "State":  "Enabled"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {
+                        "IncludedGroups" : [
+                            "Dune",
+                            "Dune12"
+                        ]
+                    }
+                }
+            }
+        },
+        "defender_license": true
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
+
+test_SensitiveATP_Correct_V9 if {
+    PolicyId := "MS.DEFENDER.1.5v1"
+
+    Output := tests with input as {
+        "atp_policy_rules" : [
+            {
+                "Identity" : "Strict Preset Security Policy",
+                "SentTo": null,
+                "SentToMemberOf": null,
+                "RecipientDomainIs": null,
+                "ExceptIfSentTo": null,
+                "ExceptIfSentToMemberOf": [
+                    "Dune"
+                ],
+                "ExceptIfRecipientDomainIs": null,
+                "Conditions":  null,
+                "Exceptions":  [
+                    "Rules.Tasks"
+                ],
+                "State":  "Enabled"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {
+                        "ExcludedGroups" : [
+                            "Dune"
+                        ]
+                    }
+                }
+            }
+        },
+        "defender_license": true
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
+
+test_SensitiveATP_Correct_V10 if {
+    PolicyId := "MS.DEFENDER.1.5v1"
+
+    Output := tests with input as {
+        "atp_policy_rules" : [
+            {
+                "Identity" : "Strict Preset Security Policy",
+                "SentTo": null,
+                "SentToMemberOf": null,
+                "RecipientDomainIs": null,
+                "ExceptIfSentTo": null,
+                "ExceptIfSentToMemberOf": [
+                    "Dune",
+                    "Dune12"
+                ],
+                "ExceptIfRecipientDomainIs": null,
+                "Conditions":  null,
+                "Exceptions":  [
+                    "Rules.Tasks"
+                ],
+                "State":  "Enabled"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {
+                        "ExcludedGroups" : [
+                            "Dune",
+                            "Dune12"
+                        ]
+                    }
+                }
+            }
+        },
+        "defender_license": true
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
+
+test_SensitiveATP_Correct_V11 if {
+    PolicyId := "MS.DEFENDER.1.5v1"
+
+    Output := tests with input as {
+        "atp_policy_rules" : [
+            {
+                "Identity" : "Strict Preset Security Policy",
+                "SentTo": null,
+                "SentToMemberOf": null,
+                "RecipientDomainIs": [
+                    "random.mail.example.com"
+                ],
+                "ExceptIfSentTo": null,
+                "ExceptIfSentToMemberOf": null,
+                "ExceptIfRecipientDomainIs": null,
+                "Conditions":  [
+                    "Rules.Tasks"
+                ],
+                "Exceptions":  null,
+                "State":  "Enabled"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {
+                        "IncludedDomains" : [
+                            "random.mail.example.com"
+                        ]
+                    }
+                }
+            }
+        },
+        "defender_license": true
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
+
+test_SensitiveATP_Correct_V12 if {
+    PolicyId := "MS.DEFENDER.1.5v1"
+
+    Output := tests with input as {
+        "atp_policy_rules" : [
+            {
+                "Identity" : "Strict Preset Security Policy",
+                "SentTo": null,
+                "SentToMemberOf": null,
+                "RecipientDomainIs": [
+                    "random.mail.example.com",
+                    "random.example.com"
+                ],
+                "ExceptIfSentTo": null,
+                "ExceptIfSentToMemberOf": null,
+                "ExceptIfRecipientDomainIs": null,
+                "Conditions":  [
+                    "Rules.Tasks"
+                ],
+                "Exceptions":  null,
+                "State":  "Enabled"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {
+                        "IncludedDomains" : [
+                            "random.mail.example.com",
+                            "random.example.com"
+                        ]
+                    }
+                }
+            }
+        },
+        "defender_license": true
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
+
+test_SensitiveATP_Correct_V13 if {
+    PolicyId := "MS.DEFENDER.1.5v1"
+
+    Output := tests with input as {
+        "atp_policy_rules" : [
+            {
+                "Identity" : "Strict Preset Security Policy",
+                "SentTo": null,
+                "SentToMemberOf": null,
+                "RecipientDomainIs": null,
+                "ExceptIfSentTo": null,
+                "ExceptIfSentToMemberOf": null,
+                "ExceptIfRecipientDomainIs": [
+                    "random.mail.example.com"
+                ],
+                "Conditions":  null,
+                "Exceptions":  [
+                    "Rules.Tasks"
+                ],
+                "State":  "Enabled"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {
+                        "ExcludedDomains" : [
+                            "random.mail.example.com"
+                        ]
+                    }
+                }
+            }
+        },
+        "defender_license": true
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
+
+test_SensitiveATP_Correct_V14 if {
+    PolicyId := "MS.DEFENDER.1.5v1"
+
+    Output := tests with input as {
+        "atp_policy_rules" : [
+            {
+                "Identity" : "Strict Preset Security Policy",
+                "SentTo": null,
+                "SentToMemberOf": null,
+                "RecipientDomainIs": null,
+                "ExceptIfSentTo": null,
+                "ExceptIfSentToMemberOf": null,
+                "ExceptIfRecipientDomainIs": [
+                    "random.mail.example.com",
+                    "random.example.com"
+                ],
+                "Conditions":  null,
+                "Exceptions":  [
+                    "Rules.Tasks"
+                ],
+                "State":  "Enabled"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {
+                        "ExcludedDomains" : [
+                            "random.mail.example.com",
+                            "random.example.com"
+                        ]
+                    }
+                }
+            }
+        },
+        "defender_license": true
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
+
+test_SensitiveATP_Correct_V15 if {
+    PolicyId := "MS.DEFENDER.1.5v1"
+
+    Output := tests with input as {
+        "atp_policy_rules" : [
+            {
+                "Identity" : "Strict Preset Security Policy",
+                "SentTo": [
+                    "johndoe@random.example.com"
+                ],
+                "SentToMemberOf": null,
+                "RecipientDomainIs": null,
+                "ExceptIfSentTo": [
+                    "janedoe@random.example.com"
+                ],
+                "ExceptIfSentToMemberOf": null,
+                "ExceptIfRecipientDomainIs": null,
+                "Conditions":  [
+                    "Rules.Tasks"
+                ],
+                "Exceptions":  [
+                    "Rules.Tasks"
+                ],
+                "State":  "Enabled"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {
+                        "IncludedUsers" : [
+                            "johndoe@random.example.com"
+                        ],
+                        "ExcludedUsers" : [
+                            "janedoe@random.example.com"
+                        ]
+                    }
+                }
+            }
+        },
+        "defender_license": true
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
+
+test_SensitiveATP_Correct_V16 if {
+    PolicyId := "MS.DEFENDER.1.5v1"
+
+    Output := tests with input as {
+        "atp_policy_rules" : [
+            {
+                "Identity" : "Strict Preset Security Policy",
+                "SentTo": null,
+                "SentToMemberOf": [
+                    "Dune"
+                ],
+                "RecipientDomainIs": null,
+                "ExceptIfSentTo": null,
+                "ExceptIfSentToMemberOf": [
+                    "Dune12"
+                ],
+                "ExceptIfRecipientDomainIs": null,
+                "Conditions":  [
+                    "Rules.Tasks"
+                ],
+                "Exceptions":  [
+                    "Rules.Tasks"
+                ],
+                "State":  "Enabled"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {
+                        "IncludedGroups" : [
+                            "Dune"
+                        ],
+                        "ExcludedGroups" : [
+                            "Dune12"
+                        ]
+                    }
+                }
+            }
+        },
+        "defender_license": true
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
+
+test_SensitiveATP_Correct_V17 if {
+    PolicyId := "MS.DEFENDER.1.5v1"
+
+    Output := tests with input as {
+        "atp_policy_rules" : [
+            {
+                "Identity" : "Strict Preset Security Policy",
+                "SentTo": null,
+                "SentToMemberOf": null,
+                "RecipientDomainIs": [
+                    "random.example.com"
+                ],
+                "ExceptIfSentTo": null,
+                "ExceptIfSentToMemberOf": null,
+                "ExceptIfRecipientDomainIs": [
+                    "random.mail.example.com"
+                ],
+                "Conditions":  [
+                    "Rules.Tasks"
+                ],
+                "Exceptions":  [
+                    "Rules.Tasks"
+                ],
+                "State":  "Enabled"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {
+                        "IncludedDomains" : [
+                            "random.example.com"
+                        ],
+                        "ExcludedDomains" : [
+                            "random.mail.example.com"
+                        ]
+                    }
+                }
+            }
+        },
+        "defender_license": true
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
+
+test_SensitiveATP_Correct_V18 if {
+    PolicyId := "MS.DEFENDER.1.5v1"
+
+    Output := tests with input as {
+        "atp_policy_rules" : [
+            {
+                "Identity" : "Strict Preset Security Policy",
+                "SentTo": [
+                    "johndoe@random.example.com"
+                ],
+                "SentToMemberOf": [
+                    "Dune"
+                ],
+                "RecipientDomainIs": null,
+                "ExceptIfSentTo": [
+                    "janedoe@random.example.com"
+                ],
+                "ExceptIfSentToMemberOf": null,
+                "ExceptIfRecipientDomainIs": null,
+                "Conditions":  [
+                    "Rules.Tasks"
+                ],
+                "Exceptions":  [
+                    "Rules.Tasks"
+                ],
+                "State":  "Enabled"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {
+                        "IncludedUsers" : [
+                            "johndoe@random.example.com"
+                        ],
+                        "ExcludedUsers" : [
+                            "janedoe@random.example.com"
+                        ],
+                        "IncludedGroups" : [
+                            "Dune"
+                        ]
+                    }
+                }
+            }
+        },
+        "defender_license": true
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
+
+test_SensitiveATP_Correct_V19 if {
+    PolicyId := "MS.DEFENDER.1.5v1"
+
+    Output := tests with input as {
+        "atp_policy_rules" : [
+            {
+                "Identity" : "Strict Preset Security Policy",
+                "SentTo": [
+                    "johndoe@random.example.com"
+                ],
+                "SentToMemberOf": null,
+                "RecipientDomainIs": null,
+                "ExceptIfSentTo": [
+                    "janedoe@random.example.com"
+                ],
+                "ExceptIfSentToMemberOf": [
+                    "Dune12"
+                ],
+                "ExceptIfRecipientDomainIs": null,
+                "Conditions":  [
+                    "Rules.Tasks"
+                ],
+                "Exceptions":  [
+                    "Rules.Tasks"
+                ],
+                "State":  "Enabled"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {
+                        "IncludedUsers" : [
+                            "johndoe@random.example.com"
+                        ],
+                        "ExcludedUsers" : [
+                            "janedoe@random.example.com"
+                        ],
+                        "ExcludedGroups" : [
+                            "Dune12"
+                        ]
+                    }
+                }
+            }
+        },
+        "defender_license": true
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
+
+test_SensitiveATP_Correct_V20 if {
+    PolicyId := "MS.DEFENDER.1.5v1"
+
+    Output := tests with input as {
+        "atp_policy_rules" : [
+            {
+                "Identity" : "Strict Preset Security Policy",
+                "SentTo": [
+                    "johndoe@random.example.com"
+                ],
+                "SentToMemberOf": null,
+                "RecipientDomainIs": [
+                    "random.example.com"
+                ],
+                "ExceptIfSentTo": [
+                    "janedoe@random.example.com"
+                ],
+                "ExceptIfSentToMemberOf": null,
+                "ExceptIfRecipientDomainIs": null,
+                "Conditions":  [
+                    "Rules.Tasks"
+                ],
+                "Exceptions":  [
+                    "Rules.Tasks"
+                ],
+                "State":  "Enabled"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {
+                        "IncludedUsers" : [
+                            "johndoe@random.example.com"
+                        ],
+                        "ExcludedUsers" : [
+                            "janedoe@random.example.com"
+                        ],
+                        "IncludedDomains" : [
+                            "random.example.com"
+                        ]
+                    }
+                }
+            }
+        },
+        "defender_license": true
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
+
+test_SensitiveATP_Correct_V21 if {
+    PolicyId := "MS.DEFENDER.1.5v1"
+
+    Output := tests with input as {
+        "atp_policy_rules" : [
+            {
+                "Identity" : "Strict Preset Security Policy",
+                "SentTo": [
+                    "johndoe@random.example.com"
+                ],
+                "SentToMemberOf": null,
+                "RecipientDomainIs": null,
+                "ExceptIfSentTo": [
+                    "janedoe@random.example.com"
+                ],
+                "ExceptIfSentToMemberOf": null,
+                "ExceptIfRecipientDomainIs": [
+                    "random.mail.example.com"
+                ],
+                "Conditions":  [
+                    "Rules.Tasks"
+                ],
+                "Exceptions":  [
+                    "Rules.Tasks"
+                ],
+                "State":  "Enabled"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {
+                        "IncludedUsers" : [
+                            "johndoe@random.example.com"
+                        ],
+                        "ExcludedUsers" : [
+                            "janedoe@random.example.com"
+                        ],
+                        "ExcludedDomains" : [
+                            "random.mail.example.com"
+                        ]
+                    }
+                }
+            }
+        },
+        "defender_license": true
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
+
+test_SensitiveATP_Correct_V22 if {
+    PolicyId := "MS.DEFENDER.1.5v1"
+
+    Output := tests with input as {
+        "atp_policy_rules" : [
+            {
+                "Identity" : "Strict Preset Security Policy",
+                "SentTo": null,
+                "SentToMemberOf": [
+                    "Dune"
+                ],
+                "RecipientDomainIs": [
+                    "random.example.com"
+                ],
+                "ExceptIfSentTo": null,
+                "ExceptIfSentToMemberOf": [
+                    "Dune12"
+                ],
+                "ExceptIfRecipientDomainIs": null,
+                "Conditions":  [
+                    "Rules.Tasks"
+                ],
+                "Exceptions":  [
+                    "Rules.Tasks"
+                ],
+                "State":  "Enabled"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {
+                        "IncludedGroups" : [
+                            "Dune"
+                        ],
+                        "ExcludedGroups" : [
+                            "Dune12"
+                        ],
+                        "IncludedDomains" : [
+                            "random.example.com"
+                        ]
+                    }
+                }
+            }
+        },
+        "defender_license": true
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
+
+test_SensitiveATP_Correct_V23 if {
+    PolicyId := "MS.DEFENDER.1.5v1"
+
+    Output := tests with input as {
+        "atp_policy_rules" : [
+            {
+                "Identity" : "Strict Preset Security Policy",
+                "SentTo": null,
+                "SentToMemberOf": [
+                    "Dune"
+                ],
+                "RecipientDomainIs": null,
+                "ExceptIfSentTo": null,
+                "ExceptIfSentToMemberOf": [
+                    "Dune12"
+                ],
+                "ExceptIfRecipientDomainIs": [
+                    "random.mail.example.com"
+                ],
+                "Conditions":  [
+                    "Rules.Tasks"
+                ],
+                "Exceptions":  [
+                    "Rules.Tasks"
+                ],
+                "State":  "Enabled"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {
+                        "IncludedGroups" : [
+                            "Dune"
+                        ],
+                        "ExcludedGroups" : [
+                            "Dune12"
+                        ],
+                        "ExcludedDomains" : [
+                            "random.mail.example.com"
+                        ]
+                    }
+                }
+            }
+        },
+        "defender_license": true
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
+
+test_SensitiveATP_Correct_V24 if {
+    PolicyId := "MS.DEFENDER.1.5v1"
+
+    Output := tests with input as {
+        "atp_policy_rules" : [
+            {
+                "Identity" : "Strict Preset Security Policy",
+                "SentTo": [
+                    "johndoe@random.example.com"
+                ],
+                "SentToMemberOf": [
+                    "Dune"
+                ],
+                "RecipientDomainIs": [
+                    "random.example.com"
+                ],
+                "ExceptIfSentTo": [
+                    "janedoe@random.example.com"
+                ],
+                "ExceptIfSentToMemberOf": [
+                    "Dune12"
+                ],
+                "ExceptIfRecipientDomainIs": [
+                    "random.mail.example.com"
+                ],
+                "Conditions":  [
+                    "Rules.Tasks"
+                ],
+                "Exceptions":  [
+                    "Rules.Tasks"
+                ],
+                "State":  "Enabled"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {
+                        "IncludedUsers" : [
+                            "johndoe@random.example.com"
+                        ],
+                        "ExcludedUsers" : [
+                            "janedoe@random.example.com"
+                        ],
+                        "IncludedGroups" : [
+                            "Dune"
+                        ],
+                        "ExcludedGroups" : [
+                            "Dune12"
+                        ],
+                        "IncludedDomains" : [
+                            "random.example.com"
+                        ],
+                        "ExcludedDomains" : [
+                            "random.mail.example.com"
+                        ]
+                    }
+                }
+            }
+        },
+        "defender_license": true
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
+
+test_SensitiveATP_Incorrect_V1 if {
+    PolicyId := "MS.DEFENDER.1.5v1"
+
+    Output := tests with input as {
+        "atp_policy_rules" : [
+            {
+                "Identity" : "Strict Preset Security Policy",
+                "SentTo": null,
+                "SentToMemberOf": null,
+                "RecipientDomainIs": null,
+                "ExceptIfSentTo": null,
+                "ExceptIfSentToMemberOf": null,
+                "ExceptIfRecipientDomainIs": null,
+                "Conditions":  null,
+                "Exceptions":  null,
+                "State":  "Disabled"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {
+                    }
+                }
+            }
+        },
         "defender_license": true
     }
 
@@ -1856,18 +3014,161 @@ test_SensitiveAtp_Incorrect_V1 if {
     RuleOutput[0].ReportDetails == "Requirement not met"
 }
 
-test_SensitiveAtp_Incorrect_V2 if {
+test_SensitiveATP_Incorrect_V1 if {
     PolicyId := "MS.DEFENDER.1.5v1"
 
     Output := tests with input as {
-        "atp_policy_rules" : [],
-        "defender_license": false
+        "atp_policy_rules" : [
+            {
+                "Identity" : "Standard Preset Security Policy",
+                "SentTo": null,
+                "SentToMemberOf": null,
+                "RecipientDomainIs": null,
+                "ExceptIfSentTo": null,
+                "ExceptIfSentToMemberOf": null,
+                "ExceptIfRecipientDomainIs": null,
+                "Conditions":  null,
+                "Exceptions":  null,
+                "State":  "Enabled"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {
+                    }
+                }
+            }
+        },
+        "defender_license": true
     }
 
     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
 
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
-    RuleOutput[0].ReportDetails == "Requirement not met **NOTE: Either you do not have sufficient permissions or your tenant does not have a license for Microsoft Defender for Office 365 Plan 1, which is required for this feature.**"
+    RuleOutput[0].ReportDetails == "Requirement not met"
+}
+
+test_SensitiveATP_Incorrect_V3 if {
+    PolicyId := "MS.DEFENDER.1.5v1"
+
+    Output := tests with input as {
+        "atp_policy_rules" : [
+            {}
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {
+                    }
+                }
+            }
+        },
+        "defender_license": true
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement not met"
+}
+
+test_SensitiveATP_Incorrect_V4 if {
+    PolicyId := "MS.DEFENDER.1.5v1"
+
+    Output := tests with input as {
+        "atp_policy_rules" : [
+            {
+                "Identity" : "Strict Preset Security Policy",
+                "SentTo": null,
+                "SentToMemberOf": null,
+                "RecipientDomainIs": null,
+                "ExceptIfSentTo": [
+                    "johndoe@random.example.com"
+                ],
+                "ExceptIfSentToMemberOf": null,
+                "ExceptIfRecipientDomainIs": null,
+                "Conditions":  null,
+                "Exceptions":  [
+                    "Rules.Tasks"
+                ],
+                "State":  "Enabled"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {}
+                }
+            }
+        },
+        "defender_license": true
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement not met"
+}
+
+test_SensitiveATP_Incorrect_V5 if {
+    PolicyId := "MS.DEFENDER.1.5v1"
+
+    Output := tests with input as {
+        "atp_policy_rules" : [
+            {
+                "Identity" : "Strict Preset Security Policy",
+                "SentTo": [
+                    "johndoe@random.example.com"
+                ],
+                "SentToMemberOf": null,
+                "RecipientDomainIs": null,
+                "ExceptIfSentTo": null,
+                "ExceptIfSentToMemberOf": null,
+                "ExceptIfRecipientDomainIs": null,
+                "Conditions":  [
+                    "Rules.Tasks"
+                ],
+                "Exceptions":  null,
+                "State":  "Enabled"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.1.5v1" : {
+                    "SensitiveAccounts" : {
+                        "IncludedUsers" : [
+                            "johndoe@random.example.com"
+                        ],
+                        "ExcludedUsers" : [
+                            "janedoe@random.example.com"
+                        ],
+                        "IncludedGroups" : [
+                            "Dune"
+                        ],
+                        "ExcludedGroups" : [
+                            "Dune12"
+                        ],
+                        "IncludedDomains" : [
+                            "random.example.com"
+                        ],
+                        "ExcludedDomains" : [
+                            "random.mail.example.com"
+                        ]
+                    }
+                }
+            }
+        },
+        "defender_license": true
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement not met"
 }
 #--

--- a/sample-config-files/defender-config.yaml
+++ b/sample-config-files/defender-config.yaml
@@ -43,7 +43,7 @@ Defender:
         -
       ExcludedDomains:
         -
-  MS.DEFENDER.1.4v1: *CommonSensitiveAccountFilter
+  MS.DEFENDER.1.5v1: *CommonSensitiveAccountFilter
   MS.DEFENDER.2.1v1 : &UserImpersonationProtection
       SensitiveUsers:
         - John Doe;jdoe@someemail.com

--- a/sample-config-files/defender-config.yaml
+++ b/sample-config-files/defender-config.yaml
@@ -43,6 +43,7 @@ Defender:
         -
       ExcludedDomains:
         -
+  MS.DEFENDER.1.4v1: *CommonSensitiveAccountFilter
   MS.DEFENDER.2.1v1 : &UserImpersonationProtection
       SensitiveUsers:
         - John Doe;jdoe@someemail.com


### PR DESCRIPTION
## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

Update MS.DEFENDER.1.5v1 rego policy to validate that the existing tenant Defender for Office365 strict preset security policy configuration includes the sensitive accounts filter expressions specified in the configuration file provided via the `-ConfigFilePath` parameter to `Invoke-Scuba` OR that the Defender for Office365 protections are enabled for all recipients.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->
This change is required as the old check only made sure that a custom policy for Defender for Office365 was present.  The baseline updates and ability to specify sensitive accounts via a configuration file allows for a more accurate assessment and the check needs to be changed to match the updated baseline policy.


Closes #487 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Run unit tests to validate changes pass. `cd  Testing; .\runUnitTests.ps1 -p defender`
Change can be tested by executing the `Invoke-Scuba` command using the example `sample-config-files\defender-config.yaml` configuration file.
Tested in G5/G5 high tenants.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Rebased branch against base branch if upstream changes were present

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Check to ensure no additional tests failed after the merge
