### PR TITLE
Update MS.DEFENDER.2.2v1 to assess agency domains in impersonation protection

### DIFF
--- a/Rego/DefenderConfig.rego
+++ b/Rego/DefenderConfig.rego
@@ -296,10 +296,18 @@ ImpersonationProtectionErrorMsg(StrictImpersonationProtection, StandardImpersona
     StandardImpersonationProtection.Result == false
 }
 
-ImpersonationProtectionErrorMsg(StrictImpersonationProtection, StandardImpersonationProtection, _) := Description if {
+ImpersonationProtectionErrorMsg(StrictImpersonationProtection, StandardImpersonationProtection, AccountType) := Description if {
+    Description := "No agency domains defined for impersonation protection assessment. See configuration file documentation for details on how to define."
+    StrictImpersonationProtection.Result == true
+    StandardImpersonationProtection.Result == true
+    AccountType == "agency domains"
+}
+
+ImpersonationProtectionErrorMsg(StrictImpersonationProtection, StandardImpersonationProtection, AccountType) := Description if {
     Description := ""
     StrictImpersonationProtection.Result == true
     StandardImpersonationProtection.Result == true
+    AccountType != "agency domains"
 }
 
 tests[{
@@ -350,7 +358,8 @@ tests[{
     ErrorMessage := ImpersonationProtectionErrorMsg(StrictImpersonationProtection, StandardImpersonationProtection, "agency domains")
     Conditions := [
         StrictImpersonationProtection.Result == true,
-        StandardImpersonationProtection.Result == true
+        StandardImpersonationProtection.Result == true,
+        count(ProtectedConfig) > 0
     ]
     Status := count([x | x := Conditions[_]; x == false]) == 0
 }

--- a/Testing/Unit/Rego/Defender/DefenderConfig_02_test.rego
+++ b/Testing/Unit/Rego/Defender/DefenderConfig_02_test.rego
@@ -470,41 +470,6 @@ test_AgencyDomains_Correct_V2 if {
     RuleOutput[0].ReportDetails == "Requirement met"
 }
 
-test_AgencyDomains_Correct_V3 if {
-    PolicyId := "MS.DEFENDER.2.2v1"
-
-    Output := tests with input as {
-        "anti_phish_policies": [
-            {
-                "Identity" : "Standard Preset Security Policy1659535429826",
-                "Enabled" : true,
-                "EnableTargetedDomainsProtection" : true,
-                "TargetedDomainsToProtect" : null,
-                "TargetedDomainProtectionAction": "Quarantine"
-            },
-            {
-                "Identity" : "Strict Preset Security Policy1659535429826",
-                "Enabled" : true,
-                "EnableTargetedDomainsProtection" : true,
-                "TargetedDomainsToProtect" : null,
-                "TargetedDomainProtectionAction": "Quarantine"
-            }
-        ],
-        "scuba_config" : {
-            "Defender" : {
-                "MS.DEFENDER.2.2v1" : {
-                }
-            }
-        }
-    }
-
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
-
-    count(RuleOutput) == 1
-    RuleOutput[0].RequirementMet
-    RuleOutput[0].ReportDetails == "Requirement met"
-}
-
 test_AgencyDomains_Incorrect_V1 if {
     PolicyId := "MS.DEFENDER.2.2v1"
 
@@ -785,6 +750,40 @@ test_AgencyDomains_Incorrect_V7 if {
     RuleOutput[0].ReportDetails == "Not all agency domains are included for targeted protection in Strict or Standard policy."
 }
 
+test_AgencyDomains_Incorrect_V8 if {
+    PolicyId := "MS.DEFENDER.2.2v1"
+
+    Output := tests with input as {
+        "anti_phish_policies": [
+            {
+                "Identity" : "Standard Preset Security Policy1659535429826",
+                "Enabled" : true,
+                "EnableTargetedDomainsProtection" : true,
+                "TargetedDomainsToProtect" : null,
+                "TargetedDomainProtectionAction": "Quarantine"
+            },
+            {
+                "Identity" : "Strict Preset Security Policy1659535429826",
+                "Enabled" : true,
+                "EnableTargetedDomainsProtection" : true,
+                "TargetedDomainsToProtect" : null,
+                "TargetedDomainProtectionAction": "Quarantine"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.2.2v1" : {
+                }
+            }
+        }
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "No agency domains defined for impersonation protection assessment. See configuration file documentation for details on how to define."
+}
 
 #
 # Policy 3

--- a/Testing/Unit/Rego/Defender/DefenderConfig_02_test.rego
+++ b/Testing/Unit/Rego/Defender/DefenderConfig_02_test.rego
@@ -479,51 +479,6 @@ test_AgencyDomains_Correct_V3 if {
                 "Identity" : "Standard Preset Security Policy1659535429826",
                 "Enabled" : true,
                 "EnableTargetedDomainsProtection" : true,
-                "TargetedDomainsToProtect" : [
-                    "random.mail.example.com",
-                    "random.example.com"
-                ],
-                "TargetedDomainProtectionAction": "Quarantine"
-            },
-            {
-                "Identity" : "Strict Preset Security Policy1659535429826",
-                "Enabled" : true,
-                "EnableTargetedDomainsProtection" : true,
-                "TargetedDomainsToProtect" : [
-                    "random.mail.example.com",
-                    "random.example.com"
-                ],
-                "TargetedDomainProtectionAction": "Quarantine"
-            }
-        ],
-        "scuba_config" : {
-            "Defender" : {
-                "MS.DEFENDER.2.2v1" : {
-                    "AgencyDomains" : [
-                        "random.mail.example.com",
-                        "random.example.com"
-                    ]
-                }
-            }
-        }
-    }
-
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
-
-    count(RuleOutput) == 1
-    RuleOutput[0].RequirementMet
-    RuleOutput[0].ReportDetails == "Requirement met"
-}
-
-test_AgencyDomains_Correct_V4 if {
-    PolicyId := "MS.DEFENDER.2.2v1"
-
-    Output := tests with input as {
-        "anti_phish_policies": [
-            {
-                "Identity" : "Standard Preset Security Policy1659535429826",
-                "Enabled" : true,
-                "EnableTargetedDomainsProtection" : true,
                 "TargetedDomainsToProtect" : null,
                 "TargetedDomainProtectionAction": "Quarantine"
             },

--- a/Testing/Unit/Rego/Defender/DefenderConfig_02_test.rego
+++ b/Testing/Unit/Rego/Defender/DefenderConfig_02_test.rego
@@ -1,11 +1,10 @@
 package defender
 import future.keywords
 
-# TODO: Policy Id(s) needs to be resolved
-
 #
 # Policy 1
 #--
+
 test_TargetedUsers_Correct_V1 if {
     PolicyId := "MS.DEFENDER.2.1v1"
 
@@ -382,124 +381,459 @@ test_TargetedUsers_Incorrect_V6 if {
 #
 # Policy 2
 #--
-# test_OrganizationDomain_Correct if {
-#     ControlNumber := "Defender 2.5"
-#     Requirement := "Domain impersonation protection SHOULD be enabled for domains owned by the agency"
+test_AgencyDomains_Correct_V1 if {
+    PolicyId := "MS.DEFENDER.2.2v1"
 
-#     Output := tests with input as {
-#         "anti_phish_policies" : [
-#             {
-#                 "Name" : "Standard Preset Security Policy1659535429826",
-#                 "Enabled" : true,
-#                 "EnableOrganizationDomainsProtection" : true,
-#                 "EnableTargetedDomainsProtection" : true,
-#                 "TargetedDomainProtectionAction" : "Quarantine",
-#             }
-#         ]
-#     }
+    Output := tests with input as {
+        "anti_phish_policies": [
+            {
+                "Identity" : "Standard Preset Security Policy1659535429826",
+                "Enabled" : true,
+                "EnableTargetedDomainsProtection" : true,
+                "TargetedDomainsToProtect" : [
+                    "random.mail.example.com",
+                    "random.example.com"
+                ],
+                "TargetedDomainProtectionAction": "Quarantine"
+            },
+            {
+                "Identity" : "Strict Preset Security Policy1659535429826",
+                "Enabled" : true,
+                "EnableTargetedDomainsProtection" : true,
+                "TargetedDomainsToProtect" : [
+                    "random.mail.example.com",
+                    "random.example.com"
+                ],
+                "TargetedDomainProtectionAction": "Quarantine"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.2.2v1" : {
+                    "AgencyDomains" : [
+                        "random.mail.example.com",
+                        "random.example.com"
+                    ]
+                }
+            }
+        }
+    }
 
-#     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
 
-#     count(RuleOutput) == 1
-#     RuleOutput[0].RequirementMet
-#     RuleOutput[0].ReportDetails == "Requirement met"
-# }
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
 
-# test_Enabled_Incorrect_V2 if {
-#     ControlNumber := "Defender 2.5"
-#     Requirement := "Domain impersonation protection SHOULD be enabled for domains owned by the agency"
+test_AgencyDomains_Correct_V2 if {
+    PolicyId := "MS.DEFENDER.2.2v1"
 
-#     Output := tests with input as {
-#        "anti_phish_policies" : [
-#             {
-#                 "Name" : "Standard Preset Security Policy1659535429826",
-#                 "Enabled" : false,
-#                 "EnableOrganizationDomainsProtection" : true,
-#                 "EnableTargetedDomainsProtection" : true,
-#                 "TargetedDomainProtectionAction" : "Quarantine",
-#             }
-#         ]
-#     }
+    Output := tests with input as {
+        "anti_phish_policies": [
+            {
+                "Identity" : "Standard Preset Security Policy1659535429826",
+                "Enabled" : true,
+                "EnableTargetedDomainsProtection" : true,
+                "TargetedDomainsToProtect" : [
+                    "random.mail.example.com",
+                    "random.example.com"
+                ],
+                "TargetedDomainProtectionAction": "Quarantine"
+            },
+            {
+                "Identity" : "Strict Preset Security Policy1659535429826",
+                "Enabled" : true,
+                "EnableTargetedDomainsProtection" : true,
+                "TargetedDomainsToProtect" : [
+                    "random.mail.example.com",
+                    "random.example.com"
+                ],
+                "TargetedDomainProtectionAction": "Quarantine"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.2.2v1" : {
+                    "AgencyDomains" : [
+                        "random.mail.example.com"
+                    ]
+                }
+            }
+        }
+    }
 
-#     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
 
-#     count(RuleOutput) == 1
-#     not RuleOutput[0].RequirementMet
-#     RuleOutput[0].ReportDetails == "Requirement not met"
-# }
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
 
-# test_EnableOrganizationDomainsProtection_Incorrect if {
-#     ControlNumber := "Defender 2.5"
-#     Requirement := "Domain impersonation protection SHOULD be enabled for domains owned by the agency"
+test_AgencyDomains_Correct_V3 if {
+    PolicyId := "MS.DEFENDER.2.2v1"
 
-#     Output := tests with input as {
-#        "anti_phish_policies" : [
-#             {
-#                 "Name" : "Standard Preset Security Policy1659535429826",
-#                 "Enabled" : true,
-#                 "EnableOrganizationDomainsProtection" : false,
-#                 "EnableTargetedDomainsProtection" : true,
-#                 "TargetedDomainProtectionAction" : "Quarantine",
-#             }
-#         ]
-#     }
+    Output := tests with input as {
+        "anti_phish_policies": [
+            {
+                "Identity" : "Standard Preset Security Policy1659535429826",
+                "Enabled" : true,
+                "EnableTargetedDomainsProtection" : true,
+                "TargetedDomainsToProtect" : [
+                    "random.mail.example.com",
+                    "random.example.com"
+                ],
+                "TargetedDomainProtectionAction": "Quarantine"
+            },
+            {
+                "Identity" : "Strict Preset Security Policy1659535429826",
+                "Enabled" : true,
+                "EnableTargetedDomainsProtection" : true,
+                "TargetedDomainsToProtect" : [
+                    "random.mail.example.com",
+                    "random.example.com"
+                ],
+                "TargetedDomainProtectionAction": "Quarantine"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.2.2v1" : {
+                    "AgencyDomains" : [
+                        "random.mail.example.com",
+                        "random.example.com"
+                    ]
+                }
+            }
+        }
+    }
 
-#     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
 
-#     count(RuleOutput) == 1
-#     not RuleOutput[0].RequirementMet
-#     RuleOutput[0].ReportDetails == "Requirement not met"
-# }
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
 
-# test_EnableTargetedDomainsProtection_Incorrect if {
-#     ControlNumber := "Defender 2.5"
-#     Requirement := "Domain impersonation protection SHOULD be enabled for domains owned by the agency"
+test_AgencyDomains_Correct_V4 if {
+    PolicyId := "MS.DEFENDER.2.2v1"
 
-#     Output := tests with input as {
-#        "anti_phish_policies" : [
-#             {
-#                 "Name" : "Standard Preset Security Policy1659535429826",
-#                 "Enabled" : true,
-#                 "EnableOrganizationDomainsProtection" : true,
-#                 "EnableTargetedDomainsProtection" : false,
-#                 "TargetedDomainProtectionAction" : "Quarantine",
-#             }
-#         ]
-#     }
+    Output := tests with input as {
+        "anti_phish_policies": [
+            {
+                "Identity" : "Standard Preset Security Policy1659535429826",
+                "Enabled" : true,
+                "EnableTargetedDomainsProtection" : true,
+                "TargetedDomainsToProtect" : null,
+                "TargetedDomainProtectionAction": "Quarantine"
+            },
+            {
+                "Identity" : "Strict Preset Security Policy1659535429826",
+                "Enabled" : true,
+                "EnableTargetedDomainsProtection" : true,
+                "TargetedDomainsToProtect" : null,
+                "TargetedDomainProtectionAction": "Quarantine"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.2.2v1" : {
+                }
+            }
+        }
+    }
 
-#     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
 
-#     count(RuleOutput) == 1
-#     not RuleOutput[0].RequirementMet
-#     RuleOutput[0].ReportDetails == "Requirement not met"
-# }
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
+
+test_AgencyDomains_Incorrect_V1 if {
+    PolicyId := "MS.DEFENDER.2.2v1"
+
+    Output := tests with input as {
+        "anti_phish_policies": [
+            {
+                "Identity" : "Strict Preset Security Policy1659535429826",
+                "Enabled" : true,
+                "EnableTargetedDomainsProtection" : true,
+                "TargetedDomainsToProtect" : [
+                    "random.mail.example.com",
+                    "random.example.com"
+                ],
+                "TargetedDomainProtectionAction": "Quarantine"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.2.2v1" : {
+                    "AgencyDomains" : [
+                        "random.mail.example.com",
+                        "random.example.com"
+                    ]
+                }
+            }
+        }
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Not all agency domains are included for targeted protection in Standard policy."
+}
+
+test_AgencyDomains_Incorrect_V2 if {
+    PolicyId := "MS.DEFENDER.2.2v1"
+
+    Output := tests with input as {
+        "anti_phish_policies": [
+            {
+                "Identity" : "Standard Preset Security Policy1659535429826",
+                "Enabled" : true,
+                "EnableTargetedDomainsProtection" : true,
+                "TargetedDomainsToProtect" : [
+                    "random.mail.example.com",
+                    "random.example.com"
+                ],
+                "TargetedDomainProtectionAction": "Quarantine"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.2.2v1" : {
+                    "AgencyDomains" : [
+                        "random.mail.example.com",
+                        "random.example.com"
+                    ]
+                }
+            }
+        }
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Not all agency domains are included for targeted protection in Strict policy."
+}
+
+test_AgencyDomains_Incorrect_V3 if {
+    PolicyId := "MS.DEFENDER.2.2v1"
+
+    Output := tests with input as {
+        "anti_phish_policies": [
+            {
+                "Identity" : "Some Preset Security Policy1659535429826",
+                "Enabled" : true,
+                "EnableTargetedDomainsProtection" : true,
+                "TargetedDomainsToProtect" : [
+                    "random.mail.example.com",
+                    "random.example.com"
+                ],
+                "TargetedDomainProtectionAction": "Quarantine"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.2.2v1" : {
+                    "AgencyDomains" : [
+                        "random.mail.example.com",
+                        "random.example.com"
+                    ]
+                }
+            }
+        }
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Not all agency domains are included for targeted protection in Strict or Standard policy."
+}
+
+test_AgencyDomains_Incorrect_V4 if {
+    PolicyId := "MS.DEFENDER.2.2v1"
+
+    Output := tests with input as {
+        "anti_phish_policies": [
+            {
+                "Identity" : "Standard Preset Security Policy1659535429826",
+                "Enabled" : false,
+                "EnableTargetedDomainsProtection" : true,
+                "TargetedDomainsToProtect" : [
+                    "random.mail.example.com",
+                    "random.example.com"
+                ],
+                "TargetedDomainProtectionAction": "Quarantine"
+            },
+            {
+                "Identity" : "Strict Preset Security Policy1659535429826",
+                "Enabled" : true,
+                "EnableTargetedDomainsProtection" : true,
+                "TargetedDomainsToProtect" : [
+                    "random.mail.example.com",
+                    "random.example.com"
+                ],
+                "TargetedDomainProtectionAction": "Quarantine"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.2.2v1" : {
+                    "AgencyDomains" : [
+                        "random.mail.example.com",
+                        "random.example.com"
+                    ]
+                }
+            }
+        }
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Not all agency domains are included for targeted protection in Standard policy."
+}
+
+test_AgencyDomains_Incorrect_V5 if {
+    PolicyId := "MS.DEFENDER.2.2v1"
+
+    Output := tests with input as {
+        "anti_phish_policies": [
+            {
+                "Identity" : "Standard Preset Security Policy1659535429826",
+                "Enabled" : true,
+                "EnableTargetedDomainsProtection" : false,
+                "TargetedDomainsToProtect" : [
+                    "random.mail.example.com",
+                    "random.example.com"
+                ],
+                "TargetedDomainProtectionAction": "Quarantine"
+            },
+            {
+                "Identity" : "Strict Preset Security Policy1659535429826",
+                "Enabled" : true,
+                "EnableTargetedDomainsProtection" : true,
+                "TargetedDomainsToProtect" : [
+                    "random.mail.example.com",
+                    "random.example.com"
+                ],
+                "TargetedDomainProtectionAction": "Quarantine"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.2.2v1" : {
+                    "AgencyDomains" : [
+                        "random.mail.example.com",
+                        "random.example.com"
+                    ]
+                }
+            }
+        }
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Not all agency domains are included for targeted protection in Standard policy."
+}
+
+test_AgencyDomains_Incorrect_V6 if {
+    PolicyId := "MS.DEFENDER.2.2v1"
+
+    Output := tests with input as {
+        "anti_phish_policies": [
+            {
+                "Identity" : "Standard Preset Security Policy1659535429826",
+                "Enabled" : true,
+                "EnableTargetedDomainsProtection" : true,
+                "TargetedDomainsToProtect" : [
+                    "random.mail.example.com",
+                    "random.example.com"
+                ],
+                "TargetedDomainProtectionAction": "Quarantine"
+            },
+            {
+                "Identity" : "Strict Preset Security Policy1659535429826",
+                "Enabled" : true,
+                "EnableTargetedDomainsProtection" : true,
+                "TargetedDomainsToProtect" : [
+                    "random.mail.example.com"
+                ],
+                "TargetedDomainProtectionAction": "Quarantine"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.2.2v1" : {
+                    "AgencyDomains" : [
+                        "random.mail.example.com",
+                        "random.example.com"
+                    ]
+                }
+            }
+        }
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Not all agency domains are included for targeted protection in Strict policy."
+}
+
+test_AgencyDomains_Incorrect_V7 if {
+    PolicyId := "MS.DEFENDER.2.2v1"
+
+    Output := tests with input as {
+        "anti_phish_policies": [
+            {
+                "Identity" : "Standard Preset Security Policy1659535429826",
+                "Enabled" : true,
+                "EnableTargetedDomainsProtection" : true,
+                "TargetedDomainsToProtect" : [
+                    "random.mail.example.com",
+                    "random.example.com"
+                ],
+                "TargetedDomainProtectionAction": "Quarantine"
+            },
+            {
+                "Identity" : "Strict Preset Security Policy1659535429826",
+                "Enabled" : true,
+                "EnableTargetedDomainsProtection" : true,
+                "TargetedDomainsToProtect" : [
+                    "random.mail.example.com",
+                    "random.example.com"
+                ],
+                "TargetedDomainProtectionAction": "Quarantine"
+            }
+        ],
+        "scuba_config" : {
+            "Defender" : {
+                "MS.DEFENDER.2.2v1" : {
+                }
+            }
+        }
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Not all agency domains are included for targeted protection in Strict or Standard policy."
+}
+
 
 #
 # Policy 3
 #--
-# test_CustomDomains_Correct if {
-#     ControlNumber := "Defender 2.5"
-#     Requirement := "Domain impersonation protection SHOULD be added for frequent partners"
-
-#     Output := tests with input as {
-#         "anti_phish_policies" : [
-#             {
-#                 "Name" : "Standard Preset Security Policy1659535429826",
-#                 "Enabled" : true,
-#                 "EnableTargetedDomainsProtection" : true,
-#                 "TargetedDomainsToProtect" : [ "test domain" ],
-#                 "TargetedDomainProtectionAction" : "Quarantine"
-#             }
-#         ]
-#     }
-
-#     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
-
-#     count(RuleOutput) == 1
-#     RuleOutput[0].RequirementMet
-#     RuleOutput[0].ReportDetails == "Requirement met"
-# }
-
 test_CustomDomains_Correct_V1 if {
     PolicyId := "MS.DEFENDER.2.3v1"
 

--- a/sample-config-files/defender-config.yaml
+++ b/sample-config-files/defender-config.yaml
@@ -30,6 +30,10 @@ GlobalVars:  # For cross product variables
   AllProductVar: value_example
 Defender:
   MS.DEFENDER.1.4v1: &CommonSensitiveAccountFilter
+    # Defines sensitive accounts filters used to select accounts to assign to
+    # the Strict Preset Security Policy for Exchange Online Protections
+    # Values for each key should match those shown in the 'Apply Exchange 
+    # Online Protection' section of the manage protection settings dialog.
     SensitiveAccounts:
       IncludedUsers:
         - johndoe@random.example.com
@@ -44,9 +48,28 @@ Defender:
       ExcludedDomains:
         -
   MS.DEFENDER.1.5v1: *CommonSensitiveAccountFilter
+    # Defines sensitive accounts filters used to select accounts to assign to
+    # the Strict Preset Security Policy for Defender for Office 365.
+    # Values for each key should match those shown in the 'Apply Defender for 
+    # Office 365 protection' section of the manage protection settings dialog.
+    # Note:  This example uses a YAML alias to re-use MS.DEFENDER.1.4v1 values
   MS.DEFENDER.2.1v1 : &UserImpersonationProtection
+    # Defines sensitive user accounts by display name and email address in
+    # the Strict and Standard Preset Security Policies impersonation 
+    # protection section.
+    # Each value should be a string in the form of the display name and 
+    # email address separated by a semicolon.
       SensitiveUsers:
         - John Doe;jdoe@someemail.com
-  MS.DEFENDER.2.3v1 : &DomainImpersonationProtection
+  MS.DEFENDER.2.2v1 : &AgencyDomainImpersonationProtection
+    # Defines a list of agency domain names that should be specified
+    # in the Strict and Standard Preset Security Policies impersonation
+    # protection section.
+      AgencyDomains:
+        - random.mail.example.com
+  MS.DEFENDER.2.3v1 : &PartnerDomainImpersonationProtection
+    # Defines a list of frequent partner domain names that should be
+    # specified in the Strict and Standard Preset Security Policies
+    # impersonation protection section.
       PartnerDomains:
         - random.mail.example.com


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->
The previous policy only checked that impersonation protection was enabled.  The assessment did not ensure that agency domains were included in the protection specifications.  The new rego assessment uses the `-ConfigFilePath` setting to allow users to specify the agency domains that should be included in both the standard and strict preset security policy impersonation protection configuration. 

The update also includes an expanded sample `defender-config.yaml` file that shows annotated examples of each configuration setting.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->
Defender 2.2 specifies that agency domains should be added to the strict and standard preset policy for impersonation protection settings. By allowing the users to specify these in the config file, we can verify the correct domains are added and all tenant users are protected from impersonation.

Closes #489

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

The updates were tested by validating that all unit tests ran and passed.
Test tenants at the E5/G5/G5 (high) levels were tested to validate that the functional configurations worked as intended both with and without a configuration file specified.  Note that when no configuration file is provided, the policy assessment for MS.DEFENDER.2.2v1 will always fail as no agency domains are specified.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Branch has been rebased with updates from parent branch

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Check that no additional tests are failing in parent branch after merge
