### PR TITLE
Update MS.DEFENDER.4.1 and MS.DEFENDER.4.2 assessment checks

### DIFF
--- a/Rego/DefenderConfig.rego
+++ b/Rego/DefenderConfig.rego
@@ -487,35 +487,6 @@ tests[{
     Status := count(error_rules) == 0
 }
 
-# tests[{
-#     "Requirement" : "A custom policy SHALL be configured to protect PII and sensitive information, as defined by the agency: U.S. Individual Taxpayer Identification Number (ITIN)",
-#     "Control" : "Defender 2.2",
-#     "Criticality" : "Shall",
-#     "Commandlet" : ["Get-DlpComplianceRule"],
-# 	"ActualValue" : Rules,
-#     "ReportDetails" : CustomizeError(ReportDetailsBoolean(Status), ErrorMessage),
-#     "RequirementMet" : Status
-# }] {
-#     Rules := ITINRules
-#     ErrorMessage := "No matching rule found for U.S. Individual Taxpayer Identification Number (ITIN)"
-#     Status := count(Rules) > 0
-# }
-
-# tests[{
-#     "Requirement" : "A custom policy SHALL be configured to protect PII and sensitive information, as defined by the agency: Credit Card Number",
-#     "Control" : "Defender 2.2",
-#     "Criticality" : "Shall",
-#     "Commandlet" : ["Get-DlpComplianceRule"],
-# 	"ActualValue" : Rules,
-#     "ReportDetails" : CustomizeError(ReportDetailsBoolean(Status), ErrorMessage),
-#     "RequirementMet" : Status
-# }] {
-#     Rules := CardRules
-#     ErrorMessage := "No matching rule found for Credit Card Number"
-#     Status := count(Rules) > 0
-# }
-#--
-
 #
 # MS.DEFENDER.4.2v1
 #--
@@ -545,18 +516,6 @@ SharePointPolicies[{
     contains(Policy.Workload, "SharePoint")
 }
 
-# OneDrivePolicies[{
-#     "Name" : Policy.Name,
-#     "Locations" : Policy.OneDriveLocation,
-#     "Workload" : Policy.Workload
-# }] {
-#     SensitivePolicies := {Rule.ParentPolicyName | Rule = SensitiveRules[_]}
-#     Policy := input.dlp_compliance_policies[_]
-#     Policy.Name in SensitivePolicies
-#     "All" in Policy.OneDriveLocation
-#     contains(Policy.Workload, "OneDrivePoint") # Is this supposed to be OneDrivePoint or OneDrive?
-#}
-
 OneDrivePolicies[{
     "Name" : Policy.Name,
     "Locations" : Policy.OneDriveLocation,
@@ -566,7 +525,7 @@ OneDrivePolicies[{
     Policy := input.dlp_compliance_policies[_]
     Policy.Name in SensitivePolicies
     "All" in Policy.OneDriveLocation
-    contains(Policy.Workload, "OneDriveForBusiness") # Is this supposed to be OneDrivePoint or OneDrive?
+    contains(Policy.Workload, "OneDriveForBusiness")
 }
 
 TeamsPolicies[{
@@ -581,17 +540,31 @@ TeamsPolicies[{
     contains(Policy.Workload, "Teams")
 }
 
+DevicesPolicies[{
+    "Name" : Policy.Name,
+    "Locations" : Policy.EndpointDlpLocation,
+    "Workload" : Policy.Workload
+    }] {
+    SensitivePolicies := {Rule.ParentPolicyName | Rule = SensitiveRules[_]}
+    Policy := input.dlp_compliance_policies[_]
+    Policy.Name in SensitivePolicies
+    "All" in Policy.EndpointDlpLocation
+    contains(Policy.Workload, "EndpointDevices")
+}
+
 Policies := {
     "Exchange": ExchangePolicies,
     "SharePoint": SharePointPolicies,
     "OneDrive": OneDrivePolicies,
     "Teams": TeamsPolicies,
+    "Devices": DevicesPolicies
 }
 
 error_policies contains "Exchange" if count(Policies.Exchange) == 0
 error_policies contains "SharePoint" if count(Policies.SharePoint) == 0
 error_policies contains "OneDrive" if count(Policies.OneDrive) == 0
 error_policies contains "Teams" if count(Policies.Teams) == 0
+error_policies contains "Devices" if count(Policies.Devices) == 0
 
 tests[{
     "PolicyId": "MS.DEFENDER.4.2v1",
@@ -601,53 +574,10 @@ tests[{
     "ReportDetails": CustomizeError(ReportDetailsBoolean(Status), ErrorMessage),
     "RequirementMet": Status,
 }] {
-    error_policy := "No policy found that applies to:"
+    error_policy := "No enabled policy found that applies to:"
     ErrorMessage := concat(" ", [error_policy, concat(", ", error_policies)])
     Status := count(error_policies) == 0
 }
-
-# tests[{
-#     "Requirement" : "The custom policy SHOULD be applied in SharePoint",
-#     "Control" : "Defender 2.2",
-#     "Criticality" : "Should",
-#     "Commandlet" : ["Get-DLPCompliancePolicy"],
-#     "ActualValue" : Policies,
-#     "ReportDetails" : CustomizeError(ReportDetailsBoolean(Status), ErrorMessage),
-#     "RequirementMet" : Status
-# }] {
-#     Policies := SharePointPolicies
-#     ErrorMessage := "No policy found that applies to SharePoint."
-#     Status := count(Policies) > 0
-# }
-
-# tests[{
-#     "Requirement" : "The custom policy SHOULD be applied in OneDrive",
-#     "Control" : "Defender 2.2",
-#     "Criticality" : "Should",
-#     "Commandlet" : ["Get-DLPCompliancePolicy"],
-#     "ActualValue" : Policies,
-#     "ReportDetails" : CustomizeError(ReportDetailsBoolean(Status), ErrorMessage),
-#     "RequirementMet" : Status
-# }] {
-#     Policies := OneDrivePolicies
-#     ErrorMessage := "No policy found that applies to OneDrive."
-#     Status := count(Policies) > 0
-# }
-
-# tests[{
-#     "Requirement" : "The custom policy SHOULD be applied in Teams",
-#     "Control" : "Defender 2.2",
-#     "Criticality" : "Should",
-#     "Commandlet" : ["Get-DLPCompliancePolicy"],
-#     "ActualValue" : Policies,
-#     "ReportDetails" : CustomizeError(ReportDetailsBoolean(Status), ErrorMessage),
-#     "RequirementMet" : Status
-# }] {
-#     Policies := TeamsPolicies
-#     ErrorMessage := "No policy found that applies to Teams."
-#     Status := count(Policies) > 0
-# }
-#--
 
 #
 # MS.DEFENDER.4.3v1

--- a/Rego/DefenderConfig.rego
+++ b/Rego/DefenderConfig.rego
@@ -435,7 +435,7 @@ SensitiveRules[{
     Rules := input.dlp_compliance_rules[_]
     Rules.Disabled == false
     Rules.IsAdvancedRule == false
-    ContentNames := [Content.name | Content = Rules.ContentContainsSensitiveInformation[_]]
+    ContentNames := [Content.name | Content := Rules.ContentContainsSensitiveInformation[_]]
     Conditions := [ "U.S. Social Security Number (SSN)" in ContentNames,
                     "U.S. Individual Taxpayer Identification Number (ITIN)" in ContentNames,
                     "Credit Card Number" in ContentNames]

--- a/Rego/DefenderConfig.rego
+++ b/Rego/DefenderConfig.rego
@@ -577,7 +577,7 @@ DevicesPolicies[{
     "Locations" : Policy.EndpointDlpLocation,
     "Workload" : Policy.Workload
     }] {
-    SensitivePolicies := {Rule.ParentPolicyName | Rule = SensitiveRules[_]}
+    SensitivePolicies := {Rule.ParentPolicyName | Rule := SensitiveRules[_]}
     Policy := input.dlp_compliance_policies[_]
     Policy.Name in SensitivePolicies
     "All" in Policy.EndpointDlpLocation

--- a/Rego/DefenderConfig.rego
+++ b/Rego/DefenderConfig.rego
@@ -633,6 +633,16 @@ SensitiveRulesNotBlocking[Rule.Name] {
     startswith(Policy.Mode, "TestWith") == true
 }
 
+SensitiveRulesNotBlocking[Rule.Name] {
+    Rule := SensitiveRules[_]
+    Rule.BlockAccess                              
+    Policy := input.dlp_compliance_policies[_]
+    Rule.ParentPolicyName == Policy.Name
+    count(error_rules) == 0
+    Rule.BlockAccessScope != "All"
+}
+
+
 tests[{
     "PolicyId" : "MS.DEFENDER.4.3v1",
     "Criticality" : "Should",

--- a/Rego/DefenderConfig.rego
+++ b/Rego/DefenderConfig.rego
@@ -459,7 +459,6 @@ SensitiveRules[{
     Rules := input.dlp_compliance_rules[_]
     Rules.Disabled == false
     Rules.IsAdvancedRule == true
-    Rules.AdvancedRule
 
     Policy := input.dlp_compliance_policies[_]
     Rules.ParentPolicyName == Policy.Name

--- a/Rego/DefenderConfig.rego
+++ b/Rego/DefenderConfig.rego
@@ -477,7 +477,7 @@ SensitiveRules[{
                     contains(RuleText, "U.S. Individual Taxpayer Identification Number (ITIN)"),
                     contains(RuleText, "Credit Card Number")]
 
-    count([Condition | Condition = Conditions[_]; Condition == true]) > 0
+    count([Condition | Condition := Conditions[_]; Condition == true]) > 0
 }
 
 # Step 1: Ensure that there is coverage for SSNs, ITINs, and credit cards

--- a/Rego/DefenderConfig.rego
+++ b/Rego/DefenderConfig.rego
@@ -444,6 +444,7 @@ SensitiveRules[{
     Policy := input.dlp_compliance_policies[_]
     Rules.ParentPolicyName == Policy.Name
     Policy.Enabled == true
+    Policy.Mode == "Enable"
 }
 
 SensitiveRules[{
@@ -463,6 +464,8 @@ SensitiveRules[{
     Policy := input.dlp_compliance_policies[_]
     Rules.ParentPolicyName == Policy.Name
     Policy.Enabled == true
+    Policy.Mode == "Enable"
+
     # Trim converted end-of-line "rn" delimters and convert single quotes to
     # double for unmarshalling
     RuleText := replace(replace(Rules.AdvancedRule, "rn", ""), "'", "\"")

--- a/Rego/DefenderConfig.rego
+++ b/Rego/DefenderConfig.rego
@@ -634,7 +634,7 @@ SensitiveRulesNotBlocking[Rule.Name] {
 
 SensitiveRulesNotBlocking[Rule.Name] {
     Rule := SensitiveRules[_]
-    Rule.BlockAccess                              
+    Rule.BlockAccess
     Policy := input.dlp_compliance_policies[_]
     Rule.ParentPolicyName == Policy.Name
     count(error_rules) == 0

--- a/Rego/DefenderConfig.rego
+++ b/Rego/DefenderConfig.rego
@@ -629,18 +629,9 @@ SensitiveRulesNotBlocking[Rule.Name] {
     Rule := SensitiveRules[_]
     Policy := input.dlp_compliance_policies[_]
     Rule.ParentPolicyName == Policy.Name
+    Rule.BlockAccess
     startswith(Policy.Mode, "TestWith") == true
 }
-
-SensitiveRulesNotBlocking[Rule.Name] {
-    Rule := SensitiveRules[_]
-    Rule.BlockAccess
-    Policy := input.dlp_compliance_policies[_]
-    Rule.ParentPolicyName == Policy.Name
-    count(error_rules) == 0
-    Rule.BlockAccessScope != "All"
-}
-
 
 tests[{
     "PolicyId" : "MS.DEFENDER.4.3v1",
@@ -662,7 +653,6 @@ tests[{
 # Step 4: ensure that some user is notified in the event of a DLP violation
 SensitiveRulesNotNotifying[Rule.Name] {
     Rule := SensitiveRules[_]
-    count(error_rules) == 0
     count(Rule.NotifyUser) == 0
 }
 

--- a/Rego/DefenderConfig.rego
+++ b/Rego/DefenderConfig.rego
@@ -432,8 +432,8 @@ SensitiveRules[{
     "NotifyUserType" : Rules.NotifyUserType,
     "ContentNames" : ContentNames
 }] {
-	Rules := input.dlp_compliance_rules[_]
-	Rules.Disabled == false
+    Rules := input.dlp_compliance_rules[_]
+    Rules.Disabled == false
     Rules.IsAdvancedRule == false
     ContentNames := [Content.name | Content = Rules.ContentContainsSensitiveInformation[_]]
     Conditions := [ "U.S. Social Security Number (SSN)" in ContentNames,
@@ -449,15 +449,15 @@ SensitiveRules[{
 
 SensitiveRules[{
     "Name" : Rules.Name,
-	"ParentPolicyName" : Rules.ParentPolicyName,
-	"BlockAccess" : Rules.BlockAccess,
-	"BlockAccessScope" : Rules.BlockAccessScope,
-	"NotifyUser" : Rules.NotifyUser,
-	"NotifyUserType" : Rules.NotifyUserType,
+    "ParentPolicyName" : Rules.ParentPolicyName,
+    "BlockAccess" : Rules.BlockAccess,
+    "BlockAccessScope" : Rules.BlockAccessScope,
+    "NotifyUser" : Rules.NotifyUser,
+    "NotifyUserType" : Rules.NotifyUserType,
     "ContentNames" : ContentNames
 }] {
-	Rules := input.dlp_compliance_rules[_]
-	Rules.Disabled == false
+    Rules := input.dlp_compliance_rules[_]
+    Rules.Disabled == false
     Rules.IsAdvancedRule == true
     Rules.AdvancedRule
 
@@ -473,7 +473,7 @@ SensitiveRules[{
     ContentNames := regex.find_n(`(U.S. Social Security Number \(SSN\))|(U.S. Individual Taxpayer Identification Number \(ITIN\))|(Credit Card Number)`,
                                  RuleText, -1)
 
-	Conditions := [ contains(RuleText, "U.S. Social Security Number (SSN)"),
+    Conditions := [ contains(RuleText, "U.S. Social Security Number (SSN)"),
                     contains(RuleText, "U.S. Individual Taxpayer Identification Number (ITIN)"),
                     contains(RuleText, "Credit Card Number")]
 

--- a/Rego/DefenderConfig.rego
+++ b/Rego/DefenderConfig.rego
@@ -474,13 +474,14 @@ tests[{
 }] {
 
 
-    error_rules := "No matching rule found for:"
-    error_rules contains "U.S. Social Security Number (SSN)" if count(SSNRules) == 0
-    error_rules contains "U.S. Individual Taxpayer Identification Number (ITIN)" if count(ITINRules) == 0
-    error_rules contains "Credit Card Number" if count(CardRules) == 0
-    ErrorMessage := concat(" ",  [error_rule, concat(", ", error_rules)])
+    error_header := "No matching rule found for:"
+    error_rules1 := "U.S. Social Security Number (SSN)" if  count(SSNRules) == 0 else ""
+    error_rules2 := "U.S. Individual Taxpayer Identification Number (ITIN)" if  count(ITINRules) == 0 else ""
+    error_rules3 := "Credit Card Number" if count(CardRules) == 0 else ""
+    error_rules  := concat(",",[error_rules1,error_rules2,error_rules3])
+    ErrorMessage := concat(" ", [error_header, error_rules])
 
-    Status := endswith(": ", error_rules)
+    Status := endswith(": ", error_header)
 
     #--------
     # Rules := SSNRules

--- a/Rego/DefenderConfig.rego
+++ b/Rego/DefenderConfig.rego
@@ -629,9 +629,18 @@ SensitiveRulesNotBlocking[Rule.Name] {
     Rule := SensitiveRules[_]
     Policy := input.dlp_compliance_policies[_]
     Rule.ParentPolicyName == Policy.Name
-    Rule.BlockAccess
     startswith(Policy.Mode, "TestWith") == true
 }
+
+SensitiveRulesNotBlocking[Rule.Name] {
+    Rule := SensitiveRules[_]
+    Rule.BlockAccess                              
+    Policy := input.dlp_compliance_policies[_]
+    Rule.ParentPolicyName == Policy.Name
+    count(error_rules) == 0
+    Rule.BlockAccessScope != "All"
+}
+
 
 tests[{
     "PolicyId" : "MS.DEFENDER.4.3v1",
@@ -653,6 +662,7 @@ tests[{
 # Step 4: ensure that some user is notified in the event of a DLP violation
 SensitiveRulesNotNotifying[Rule.Name] {
     Rule := SensitiveRules[_]
+    count(error_rules) == 0
     count(Rule.NotifyUser) == 0
 }
 

--- a/Rego/DefenderConfig.rego
+++ b/Rego/DefenderConfig.rego
@@ -461,25 +461,12 @@ CardRules[Rule.Name] {
     "Credit Card Number" in Rule.ContentNames
 }
 
-#error_rule := "No matching rules found for:"
-
-# error_rules contains "U.S. Social Security Number (SSN)" if count(SSNRules) == 0
-# error_rules contains "U.S. Individual Taxpayer Identification Number (ITIN)" if count(ITINRules) == 0
-# error_rules contains "Credit Card Number" if count(CardRules) == 0
-
-
-#error_rules1 := "U.S. Social Security Number (SSN)" if  count(SSNRules) == 0 else " "
-#error_rules2 := "U.S. Individual Taxpayer Identification Number (ITIN)" if  count(ITINRules) == 0 else " "
-#error_rules3 := "Credit Card Number" if count(CardRules) == 0 else " "
-#error_rules  := concat(",",[error_rules1,error_rules2,error_rules3])
-
-#ErrorMsg := concat(" ",  [error_rule, concat(", ", error_rules)])
-
 Rules := {
     "SSN" : SSNRules,
     "ITIN" : ITINRules,
     "Credit_Card" : CardRules
-    }
+}
+
 error_rules contains "U.S. Social Security Number (SSN)" if count(Rules.SSN) == 0
 error_rules contains "U.S. Individual Taxpayer Identification Number (ITIN)" if count(Rules.ITIN) == 0
 error_rules contains "Credit Card Number" if count(Rules.Credit_Card) == 0
@@ -495,53 +482,11 @@ tests[{
     "ReportDetails" : CustomizeError(ReportDetailsBoolean(Status), ErrorMessage),
     "RequirementMet" : Status,
 }] {
-    #--------
-    # Rules := SSNRules
-    # count(SSNRules) > 0
-
-    # ErrorMessage := concat(",", ["No matching rule found for U.S. Social Security Number (SSN)", "$"])
-    # Status := count(Rules) > 0
-    # Status := endswith(": ", error_rule)
     error_rule := "No matching rules found for:"
     ErrorMessage := concat(" ",  [error_rule, concat(", ", error_rules)])
-    #Conditions := [
-    #    count(Rules[0]) > 0,
-    #    count(Rules[1]) > 0,
-    #    count(Rules[2]) > 0
-    #]
-
-    #Status := count([x | x := Conditions[_]; x == false]) == 0
     Status := count(error_rules) == 0
 }
 
-# tests[{
-#     "Requirement" : "A custom policy SHALL be configured to protect PII and sensitive information, as defined by the agency: U.S. Individual Taxpayer Identification Number (ITIN)",
-#     "Control" : "Defender 2.2",
-#     "Criticality" : "Shall",
-#     "Commandlet" : ["Get-DlpComplianceRule"],
-#     "ActualValue" : Rules,
-#     "ReportDetails" : CustomizeError(ReportDetailsBoolean(Status), ErrorMessage),
-#     "RequirementMet" : Status
-# }] {
-#     Rules := ITINRules
-#     ErrorMessage := "No matching rule found for U.S. Individual Taxpayer Identification Number (ITIN)"
-#     Status := count(Rules) > 0
-# }
-
-# tests[{
-#     "Requirement" : "A custom policy SHALL be configured to protect PII and sensitive information, as defined by the agency: Credit Card Number",
-#     "Control" : "Defender 2.2",
-#     "Criticality" : "Shall",
-#     "Commandlet" : ["Get-DlpComplianceRule"],
-#     "ActualValue" : Rules,
-#     "ReportDetails" : CustomizeError(ReportDetailsBoolean(Status), ErrorMessage),
-#     "RequirementMet" : Status
-# }] {
-#     Rules := CardRules
-#     ErrorMessage := "No matching rule found for Credit Card Number"
-#     Status := count(Rules) > 0
-# }
-#--
 
 #
 # MS.DEFENDER.4.2v1

--- a/Rego/DefenderConfig.rego
+++ b/Rego/DefenderConfig.rego
@@ -470,21 +470,16 @@ tests[{
     "Commandlet" : ["Get-DlpComplianceRule"],
     "ActualValue" : Rules,
     "ReportDetails" : CustomizeError(ReportDetailsBoolean(Status), ErrorMessage),
-    "RequirementMet" : Status
+    "RequirementMet" : Status,
 }] {
 
-    error_rules := "No matching rule found for: "
 
-    Rules := SSNRules
-    error_rules := concat(",", [error_rules, "U.S. Social Security Number (SSN) "]) { count(SSNRules) == 0 }
+    error_rules := "No matching rule found for:"
+    error_rules contains "U.S. Social Security Number (SSN)" if count(SSNRules) == 0
+    error_rules contains "U.S. Individual Taxpayer Identification Number (ITIN)" if count(ITINRules) == 0
+    error_rules contains "Credit Card Number" if count(CardRules) == 0
+    ErrorMessage := concat(" ",  [error_rule, concat(", ", error_rules)])
 
-    Rules := ITINRules
-    error_rules := concat(",", [error_rules, "U.S. Individual Taxpayer Identification Number (ITIN) "]) { count(ITINRules) == 0 }
-
-    Rules := CardRules
-    error_rules := concat(",", [error_rules, "Credit Card Number "]) { count(CardRules) == 0 }
-
-    ErrorMessage := error_rules
     Status := endswith(": ", error_rules)
 
     #--------

--- a/Rego/DefenderConfig.rego
+++ b/Rego/DefenderConfig.rego
@@ -512,7 +512,7 @@ tests[{
     "Commandlet" : ["Get-DlpComplianceRule"],
     "ActualValue" : Rules,
     "ReportDetails" : CustomizeError(ReportDetailsBoolean(Status), ErrorMessage),
-    "RequirementMet" : Status,
+    "RequirementMet" : Status
 }] {
     error_rule := "No matching rules found for:"
     ErrorMessage := concat(" ",  [error_rule, concat(", ", error_rules)])
@@ -604,7 +604,7 @@ tests[{
     "Commandlet": ["Get-DLPCompliancePolicy"],
     "ActualValue": Policies,
     "ReportDetails": CustomizeError(ReportDetailsBoolean(Status), ErrorMessage),
-    "RequirementMet": Status,
+    "RequirementMet": Status
 }] {
     error_policy := "No enabled policy found that applies to:"
     ErrorMessage := concat(" ", [error_policy, concat(", ", error_policies)])

--- a/Rego/DefenderConfig.rego
+++ b/Rego/DefenderConfig.rego
@@ -461,19 +461,24 @@ CardRules[Rule.Name] {
     "Credit Card Number" in Rule.ContentNames
 }
 
-error_rule := "No matching rules found for:"
+#error_rule := "No matching rules found for:"
 
 # error_rules contains "U.S. Social Security Number (SSN)" if count(SSNRules) == 0
 # error_rules contains "U.S. Individual Taxpayer Identification Number (ITIN)" if count(ITINRules) == 0
 # error_rules contains "Credit Card Number" if count(CardRules) == 0
 
 
-error_rules1 := "U.S. Social Security Number (SSN)" if  count(SSNRules) == 0 else " "
-error_rules2 := "U.S. Individual Taxpayer Identification Number (ITIN)" if  count(ITINRules) == 0 else " "
-error_rules3 := "Credit Card Number" if count(CardRules) == 0 else " "
-error_rules  := concat(",",[error_rules1,error_rules2,error_rules3])
+#error_rules1 := "U.S. Social Security Number (SSN)" if  count(SSNRules) == 0 else " "
+#error_rules2 := "U.S. Individual Taxpayer Identification Number (ITIN)" if  count(ITINRules) == 0 else " "
+#error_rules3 := "Credit Card Number" if count(CardRules) == 0 else " "
+#error_rules  := concat(",",[error_rules1,error_rules2,error_rules3])
 
-ErrorMsg := concat(" ",  [error_rule, concat(", ", error_rules)])
+#ErrorMsg := concat(" ",  [error_rule, concat(", ", error_rules)])
+
+Rules := [SSNRules, ITINRules, CardRules]
+error_rules contains "U.S. Social Security Number (SSN)" if count(Rules[0]) == 0
+error_rules contains "U.S. Individual Taxpayer Identification Number (ITIN)" if count(Rules[1]) == 0
+error_rules contains "Credit Card Number" if count(Rules[2]) == 0
 
 tests[{
     #TODO: Appears this policy is broken into 3 parts in code and only 1 in baseline
@@ -486,15 +491,23 @@ tests[{
     "ReportDetails" : CustomizeError(ReportDetailsBoolean(Status), ErrorMessage),
     "RequirementMet" : Status,
 }] {
-
-Status := endswith(": ", error_rules )
-
     #--------
     # Rules := SSNRules
     # count(SSNRules) > 0
 
     # ErrorMessage := concat(",", ["No matching rule found for U.S. Social Security Number (SSN)", "$"])
     # Status := count(Rules) > 0
+    # Status := endswith(": ", error_rule)
+    error_rule := "No matching rules found for:"
+    ErrorMessage := concat(" ",  [error_rule, concat(", ", error_rules)])
+    #Conditions := [
+    #    count(Rules[0]) > 0,
+    #    count(Rules[1]) > 0,
+    #    count(Rules[2]) > 0
+    #]
+
+    #Status := count([x | x := Conditions[_]; x == false]) == 0
+    Status := count(error_rules) == 0
 }
 
 # tests[{

--- a/Rego/DefenderConfig.rego
+++ b/Rego/DefenderConfig.rego
@@ -461,6 +461,20 @@ CardRules[Rule.Name] {
     "Credit Card Number" in Rule.ContentNames
 }
 
+error_rule := "No matching rules found for:"
+
+# error_rules contains "U.S. Social Security Number (SSN)" if count(SSNRules) == 0
+# error_rules contains "U.S. Individual Taxpayer Identification Number (ITIN)" if count(ITINRules) == 0
+# error_rules contains "Credit Card Number" if count(CardRules) == 0
+
+
+error_rules1 := "U.S. Social Security Number (SSN)" if  count(SSNRules) == 0 else " "
+error_rules2 := "U.S. Individual Taxpayer Identification Number (ITIN)" if  count(ITINRules) == 0 else " "
+error_rules3 := "Credit Card Number" if count(CardRules) == 0 else " "
+error_rules  := concat(",",[error_rules1,error_rules2,error_rules3])
+
+ErrorMsg := concat(" ",  [error_rule, concat(", ", error_rules)])
+
 tests[{
     #TODO: Appears this policy is broken into 3 parts in code and only 1 in baseline
     # Combine this and the following two that are commented out into a single test
@@ -473,15 +487,7 @@ tests[{
     "RequirementMet" : Status,
 }] {
 
-
-    error_header := "No matching rule found for:"
-    error_rules1 := "U.S. Social Security Number (SSN)" if  count(SSNRules) == 0 else ""
-    error_rules2 := "U.S. Individual Taxpayer Identification Number (ITIN)" if  count(ITINRules) == 0 else ""
-    error_rules3 := "Credit Card Number" if count(CardRules) == 0 else ""
-    error_rules  := concat(",",[error_rules1,error_rules2,error_rules3])
-    ErrorMessage := concat(" ", [error_header, error_rules])
-
-    Status := endswith(": ", error_header)
+Status := endswith(": ", error_rules )
 
     #--------
     # Rules := SSNRules

--- a/Rego/DefenderConfig.rego
+++ b/Rego/DefenderConfig.rego
@@ -475,10 +475,14 @@ CardRules[Rule.Name] {
 
 #ErrorMsg := concat(" ",  [error_rule, concat(", ", error_rules)])
 
-Rules := [SSNRules, ITINRules, CardRules]
-error_rules contains "U.S. Social Security Number (SSN)" if count(Rules[0]) == 0
-error_rules contains "U.S. Individual Taxpayer Identification Number (ITIN)" if count(Rules[1]) == 0
-error_rules contains "Credit Card Number" if count(Rules[2]) == 0
+Rules := {
+    "SSN" : SSNRules,
+    "ITIN" : ITINRules,
+    "Credit_Card" : CardRules
+    }
+error_rules contains "U.S. Social Security Number (SSN)" if count(Rules.SSN) == 0
+error_rules contains "U.S. Individual Taxpayer Identification Number (ITIN)" if count(Rules.ITIN) == 0
+error_rules contains "Credit Card Number" if count(Rules.Credit_Card) == 0
 
 tests[{
     #TODO: Appears this policy is broken into 3 parts in code and only 1 in baseline

--- a/Rego/DefenderConfig.rego
+++ b/Rego/DefenderConfig.rego
@@ -472,9 +472,27 @@ tests[{
     "ReportDetails" : CustomizeError(ReportDetailsBoolean(Status), ErrorMessage),
     "RequirementMet" : Status
 }] {
+
+    error_rules := "No matching rule found for: "
+
     Rules := SSNRules
-    ErrorMessage := "No matching rule found for U.S. Social Security Number (SSN)"
-    Status := count(Rules) > 0
+    error_rules := concat(",", [error_rules, "U.S. Social Security Number (SSN) "]) { count(SSNRules) == 0 }
+
+    Rules := ITINRules
+    error_rules := concat(",", [error_rules, "U.S. Individual Taxpayer Identification Number (ITIN) "]) { count(ITINRules) == 0 }
+
+    Rules := CardRules
+    error_rules := concat(",", [error_rules, "Credit Card Number "]) { count(CardRules) == 0 }
+
+    ErrorMessage := error_rules
+    Status := endswith(": ", error_rules)
+
+    #--------
+    # Rules := SSNRules
+    # count(SSNRules) > 0
+
+    # ErrorMessage := concat(",", ["No matching rule found for U.S. Social Security Number (SSN)", "$"])
+    # Status := count(Rules) > 0
 }
 
 # tests[{

--- a/Testing/Unit/Rego/Defender/DefenderConfig_04_test.rego
+++ b/Testing/Unit/Rego/Defender/DefenderConfig_04_test.rego
@@ -27,12 +27,57 @@ test_ContentContainsSensitiveInformation_Correct_V1 if {
                     "LastModifier",
                     "Owner"
                 ],
-                "NotifyUserType":  "NotSet"
+                "NotifyUserType":  "NotSet",
+                "IsAdvancedRule": false
             }
         ],
         "dlp_compliance_policies": [
             {
                 "Name": "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
+            }
+        ]
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
+
+test_AdvancedRule_Correct_V2 if {
+    PolicyId := "MS.DEFENDER.4.1v1"
+
+    Output := tests with input as {
+        "dlp_compliance_rules": [
+            {
+                "ContentContainsSensitiveInformation":  null,
+                "Name":  "Baseline Rule",
+                "Disabled" : false,
+                "ParentPolicyName":  "Default Office 365 DLP policy",
+                "BlockAccess":  true,
+                "BlockAccessScope":  "All",
+                "NotifyUser":  [
+                    "SiteAdmin",
+                    "LastModifier",
+                    "Owner"
+                ],
+                "NotifyUserType":  "NotSet",
+                "IsAdvancedRule": true,
+                "AdvancedRule": "{rn  'Version': '1.0',rn  'Condition': {rn    'Operator': 'And',rn    'SubConditions': [rn      {rn        'ConditionName': 'ContentContainsSensitiveInformation',rn        'Value': [rn          {rn            'Groups': [rn              {rn                'Name': 'Default',rn                'Operator': 'Or',rn                'Sensitivetypes': [rn                  {rn                    'Name': 'Credit Card Number',rn                    'Id': '50842eb7-edc8-4019-85dd-5a5c1f2bb085',rn                    'Mincount': 1,rn                    'Maxcount': -1,rn                    'Confidencelevel': 'High',rn                    'Minconfidence': 85,rn                    'Maxconfidence': 100rn                  },rn                  {rn                    'Name': 'U.S. Individual Taxpayer Identification Number (ITIN)',rn                    'Id': 'e55e2a32-f92d-4985-a35d-a0b269eb687b',rn                    'Mincount': 1,rn                    'Maxcount': -1,rn                    'Confidencelevel': 'Medium',rn                    'Minconfidence': 75,rn                    'Maxconfidence': 100rn                  },rn                  {rn                    'Name': 'U.S. Social Security Number (SSN)',rn                    'Id': 'a44669fe-0d48-453d-a9b1-2cc83f2cba77',rn                    'Mincount': 1,rn                    'Maxcount': -1,rn                    'Confidencelevel': 'Medium',rn                    'Minconfidence': 75,rn                    'Maxconfidence': 100rn                  }rn                ]rn              }rn            ],rn            'Operator': 'And'rn          }rn        ]rn      }rn    ]rn  }rn}",
+            }
+        ],
+        "dlp_compliance_policies": [
+            {
+                "ExchangeLocation":  ["All"],
+                "SharePointLocation":  ["All"],
+                "TeamsLocation":  ["All"],
+                "EndpointDlpLocation":  ["All"],
+                "OneDriveLocation":  ["All"],
+                "Workload":  "Exchange, SharePoint, OneDriveForBusiness, Teams, EndpointDevices",
+                "Name":  "Default Office 365 DLP policy",
                 "Mode": "Enable",
                 "Enabled": true
             }
@@ -66,7 +111,8 @@ test_ContentContainsSensitiveInformation_Incorrect_V1 if {
                     "LastModifier",
                     "Owner"
                 ],
-                "NotifyUserType":  "NotSet"
+                "NotifyUserType":  "NotSet",
+                "IsAdvancedRule": false
             }
         ],
         "dlp_compliance_policies": [
@@ -105,7 +151,8 @@ test_ContentContainsSensitiveInformation_Incorrect_V2 if {
                     "LastModifier",
                     "Owner"
                 ],
-                "NotifyUserType":  "NotSet"
+                "NotifyUserType":  "NotSet",
+                "IsAdvancedRule": false
             }
         ],
         "dlp_compliance_policies": [
@@ -144,7 +191,8 @@ test_ContentContainsSensitiveInformation_Incorrect_V3 if {
                     "LastModifier",
                     "Owner"
                 ],
-                "NotifyUserType":  "NotSet"
+                "NotifyUserType":  "NotSet",
+                "IsAdvancedRule": false
             }
         ],
         "dlp_compliance_policies": [
@@ -180,7 +228,8 @@ test_ContentContainsSensitiveInformation_Incorrect_V4 if {
                     "LastModifier",
                     "Owner"
                 ],
-                "NotifyUserType":  "NotSet"
+                "NotifyUserType":  "NotSet",
+                "IsAdvancedRule": false
             }
         ],
         "dlp_compliance_policies": [
@@ -202,7 +251,7 @@ test_ContentContainsSensitiveInformation_Incorrect_V4 if {
 #
 # Policy 2
 #--
-test_Locations_Correct if {
+test_Locations_Correct_V1 if {
     PolicyId := "MS.DEFENDER.4.2v1"
 
     Output := tests with input as {
@@ -223,7 +272,52 @@ test_Locations_Correct if {
                     "LastModifier",
                     "Owner"
                 ],
-                "NotifyUserType":  "NotSet"
+                "NotifyUserType":  "NotSet",
+                "IsAdvancedRule": false
+            }
+        ],
+        "dlp_compliance_policies": [
+            {
+                "ExchangeLocation":  ["All"],
+                "SharePointLocation":  ["All"],
+                "TeamsLocation":  ["All"],
+                "EndpointDlpLocation":  ["All"],
+                "OneDriveLocation":  ["All"],
+                "Workload":  "Exchange, SharePoint, OneDriveForBusiness, Teams, EndpointDevices",
+                "Name":  "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
+            }
+        ]
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
+
+test_Locations_Correct_V2 if {
+    PolicyId := "MS.DEFENDER.4.2v1"
+
+    Output := tests with input as {
+        "dlp_compliance_rules": [
+            {
+                "ContentContainsSensitiveInformation":  null,
+                "Name":  "Baseline Rule",
+                "Disabled" : false,
+                "ParentPolicyName":  "Default Office 365 DLP policy",
+                "BlockAccess":  true,
+                "BlockAccessScope":  "All",
+                "NotifyUser":  [
+                    "SiteAdmin",
+                    "LastModifier",
+                    "Owner"
+                ],
+                "NotifyUserType":  "NotSet",
+                "IsAdvancedRule": true,
+                "AdvancedRule": "{rn  'Version': '1.0',rn  'Condition': {rn    'Operator': 'And',rn    'SubConditions': [rn      {rn        'ConditionName': 'ContentContainsSensitiveInformation',rn        'Value': [rn          {rn            'Groups': [rn              {rn                'Name': 'Default',rn                'Operator': 'Or',rn                'Sensitivetypes': [rn                  {rn                    'Name': 'Credit Card Number',rn                    'Id': '50842eb7-edc8-4019-85dd-5a5c1f2bb085',rn                    'Mincount': 1,rn                    'Maxcount': -1,rn                    'Confidencelevel': 'High',rn                    'Minconfidence': 85,rn                    'Maxconfidence': 100rn                  },rn                  {rn                    'Name': 'U.S. Individual Taxpayer Identification Number (ITIN)',rn                    'Id': 'e55e2a32-f92d-4985-a35d-a0b269eb687b',rn                    'Mincount': 1,rn                    'Maxcount': -1,rn                    'Confidencelevel': 'Medium',rn                    'Minconfidence': 75,rn                    'Maxconfidence': 100rn                  },rn                  {rn                    'Name': 'U.S. Social Security Number (SSN)',rn                    'Id': 'a44669fe-0d48-453d-a9b1-2cc83f2cba77',rn                    'Mincount': 1,rn                    'Maxcount': -1,rn                    'Confidencelevel': 'Medium',rn                    'Minconfidence': 75,rn                    'Maxconfidence': 100rn                  }rn                ]rn              }rn            ],rn            'Operator': 'And'rn          }rn        ]rn      }rn    ]rn  }rn}",
             }
         ],
         "dlp_compliance_policies": [
@@ -270,7 +364,8 @@ test_Locations_Incorrect_V1 if {
                     "LastModifier",
                     "Owner"
                 ],
-                "NotifyUserType":  "NotSet"
+                "NotifyUserType":  "NotSet",
+                "IsAdvancedRule": false
             }
         ],
         "dlp_compliance_policies": [
@@ -317,7 +412,8 @@ test_Locations_Incorrect_V2 if {
                     "LastModifier",
                     "Owner"
                 ],
-                "NotifyUserType":  "NotSet"
+                "NotifyUserType":  "NotSet",
+                "IsAdvancedRule": false
             }
         ],
         "dlp_compliance_policies": [
@@ -364,7 +460,8 @@ test_Locations_Incorrect_V3 if {
                     "LastModifier",
                     "Owner"
                 ],
-                "NotifyUserType":  "NotSet"
+                "NotifyUserType":  "NotSet",
+                "IsAdvancedRule": false
             }
         ],
         "dlp_compliance_policies": [
@@ -411,7 +508,8 @@ test_Locations_Incorrect_V4 if {
                     "LastModifier",
                     "Owner"
                 ],
-                "NotifyUserType":  "NotSet"
+                "NotifyUserType":  "NotSet",
+                "IsAdvancedRule": false
             }
         ],
         "dlp_compliance_policies": [
@@ -458,7 +556,8 @@ test_Locations_Incorrect_V5 if {
                     "LastModifier",
                     "Owner"
                 ],
-                "NotifyUserType":  "NotSet"
+                "NotifyUserType":  "NotSet",
+                "IsAdvancedRule": false
             }
         ],
         "dlp_compliance_policies": [
@@ -505,7 +604,8 @@ test_Locations_Incorrect_V6 if {
                     "LastModifier",
                     "Owner"
                 ],
-                "NotifyUserType":  "NotSet"
+                "NotifyUserType":  "NotSet",
+                "IsAdvancedRule": false
             }
         ],
         "dlp_compliance_policies": [
@@ -552,7 +652,8 @@ test_Locations_Incorrect_V7 if {
                     "LastModifier",
                     "Owner"
                 ],
-                "NotifyUserType":  "NotSet"
+                "NotifyUserType":  "NotSet",
+                "IsAdvancedRule": false
             }
         ],
         "dlp_compliance_policies": [

--- a/Testing/Unit/Rego/Defender/DefenderConfig_04_test.rego
+++ b/Testing/Unit/Rego/Defender/DefenderConfig_04_test.rego
@@ -199,204 +199,6 @@ test_ContentContainsSensitiveInformation_Incorrect_V4 if {
     RuleOutput[0].ReportDetails == "No matching rules found for: Credit Card Number, U.S. Individual Taxpayer Identification Number (ITIN), U.S. Social Security Number (SSN)"
 }
 
-# test_ContentContainsSensitiveInformation_Incorrect_V1 if {
-#     ControlNumber := "Defender 2.2"
-#     Requirement := "A custom policy SHALL be configured to protect PII and sensitive information, as defined by the agency: U.S. Social Security Number (SSN)"
-
-#     Output := tests with input as {
-#         "dlp_compliance_rules": [
-#             {
-#                 "ContentContainsSensitiveInformation":  [
-#                     {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"},
-#                     {"name":  "Credit Card Number"}
-#                 ],
-#                 "Name":  "Baseline Rule",
-# 	            "Disabled" : false,
-#                 "ParentPolicyName":  "Default Office 365 DLP policy",
-# 	            "BlockAccess":  true,
-#                 "BlockAccessScope":  "All",
-# 	            "NotifyUser":  [
-#                     "SiteAdmin",
-#                     "LastModifier",
-#                     "Owner"
-#                 ],
-# 	            "NotifyUserType":  "NotSet"
-#             }
-#         ],
-#         "dlp_compliance_policies": [
-#             {
-#                 "Name": "Default Office 365 DLP policy",
-#                 "Mode": "Enable",
-#                 "Enabled": true
-#             }
-#         ]
-#     }
-
-#     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
-
-#     count(RuleOutput) == 1
-#     not RuleOutput[0].RequirementMet
-#     RuleOutput[0].ReportDetails == "No matching rule found for U.S. Social Security Number (SSN)"
-# }
-
-# test_ContentContainsSensitiveInformation_Correct_V2 if {
-#     ControlNumber := "Defender 2.2"
-#     Requirement := "A custom policy SHALL be configured to protect PII and sensitive information, as defined by the agency: U.S. Individual Taxpayer Identification Number (ITIN)"
-
-#     Output := tests with input as {
-#         "dlp_compliance_rules": [
-#             {
-#                 "ContentContainsSensitiveInformation":  [
-#                     {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"}
-#                 ],
-#                 "Name":  "Baseline Rule",
-# 	            "Disabled" : false,
-#                 "ParentPolicyName":  "Default Office 365 DLP policy",
-# 	            "BlockAccess":  true,
-#                 "BlockAccessScope":  "All",
-# 	            "NotifyUser":  [
-#                     "SiteAdmin",
-#                     "LastModifier",
-#                     "Owner"
-#                 ],
-# 	            "NotifyUserType":  "NotSet"
-#             }
-#         ],
-#         "dlp_compliance_policies": [
-#             {
-#                 "Name": "Default Office 365 DLP policy",
-#                 "Mode": "Enable",
-#                 "Enabled": true
-#             }
-#         ]
-#     }
-
-#     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
-
-#     count(RuleOutput) == 1
-#     RuleOutput[0].RequirementMet
-#     RuleOutput[0].ReportDetails == "Requirement met"
-# }
-
-# test_ContentContainsSensitiveInformation_Incorrect_V2 if {
-#     ControlNumber := "Defender 2.2"
-#     Requirement := "A custom policy SHALL be configured to protect PII and sensitive information, as defined by the agency: U.S. Individual Taxpayer Identification Number (ITIN)"
-
-#     Output := tests with input as {
-#         "dlp_compliance_rules": [
-#             {
-#                 "ContentContainsSensitiveInformation":  [
-#                     {"name":  "Credit Card Number"},
-#                     {"name":  "U.S. Social Security Number (SSN)"}
-#                 ],
-#                 "Name":  "Baseline Rule",
-# 	            "Disabled" : false,
-#                 "ParentPolicyName":  "Default Office 365 DLP policy",
-# 	            "BlockAccess":  true,
-#                 "BlockAccessScope":  "All",
-# 	            "NotifyUser":  [
-#                     "SiteAdmin",
-#                     "LastModifier",
-#                     "Owner"
-#                 ],
-# 	            "NotifyUserType":  "NotSet"
-#             }
-#         ],
-#         "dlp_compliance_policies": [
-#             {
-#                 "Name": "Default Office 365 DLP policy",
-#                 "Mode": "Enable",
-#                 "Enabled": true
-#             }
-#         ]
-#     }
-
-#     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
-
-#     count(RuleOutput) == 1
-#     not RuleOutput[0].RequirementMet
-#     RuleOutput[0].ReportDetails == "No matching rule found for U.S. Individual Taxpayer Identification Number (ITIN)"
-# }
-
-# test_ContentContainsSensitiveInformation_Correct_V3 if {
-#     ControlNumber := "Defender 2.2"
-#     Requirement := "A custom policy SHALL be configured to protect PII and sensitive information, as defined by the agency: Credit Card Number"
-
-#     Output := tests with input as {
-#         "dlp_compliance_rules": [
-#             {
-#                 "ContentContainsSensitiveInformation":  [
-#                     {"name":  "Credit Card Number"}
-#                 ],
-#                 "Name":  "Baseline Rule",
-# 	            "Disabled" : false,
-#                 "ParentPolicyName":  "Default Office 365 DLP policy",
-# 	            "BlockAccess":  true,
-#                 "BlockAccessScope":  "All",
-# 	            "NotifyUser":  [
-#                     "SiteAdmin",
-#                     "LastModifier",
-#                     "Owner"
-#                 ],
-# 	            "NotifyUserType":  "NotSet"
-#             }
-#         ],
-#         "dlp_compliance_policies": [
-#             {
-#                 "Name": "Default Office 365 DLP policy",
-#                 "Mode": "Enable",
-#                 "Enabled": true
-#             }
-#         ]
-#     }
-
-#     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
-
-#     count(RuleOutput) == 1
-#     RuleOutput[0].RequirementMet
-#     RuleOutput[0].ReportDetails == "Requirement met"
-# }
-
-# test_ContentContainsSensitiveInformation_Incorrect_V3 if {
-#     ControlNumber := "Defender 2.2"
-#     Requirement := "A custom policy SHALL be configured to protect PII and sensitive information, as defined by the agency: Credit Card Number"
-
-#     Output := tests with input as {
-#         "dlp_compliance_rules": [
-#             {
-#                 "ContentContainsSensitiveInformation":  [
-#                     {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"},
-#                     {"name":  "U.S. Social Security Number (SSN)"}
-#                 ],
-#                 "Name":  "Baseline Rule",
-# 	            "Disabled" : false,
-#                 "ParentPolicyName":  "Default Office 365 DLP policy",
-# 	            "BlockAccess":  true,
-#                 "BlockAccessScope":  "All",
-# 	            "NotifyUser":  [
-#                     "SiteAdmin",
-#                     "LastModifier",
-#                     "Owner"
-#                 ],
-# 	            "NotifyUserType":  "NotSet"
-#             }
-#         ],
-#         "dlp_compliance_policies": [
-#             {
-#                 "Name": "Default Office 365 DLP policy",
-#                 "Mode": "Enable",
-#                 "Enabled": true
-#             }
-#         ]
-#     }
-
-#     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
-
-#     count(RuleOutput) == 1
-#     not RuleOutput[0].RequirementMet
-#     RuleOutput[0].ReportDetails == "No matching rule found for Credit Card Number"
-# }
-
 #
 # Policy 2
 #--
@@ -524,7 +326,7 @@ test_Locations_Incorrect_V2 if {
                 "SharePointLocation":  [""],
                 "TeamsLocation":  ["All"],
                 "EndpointDlpLocation":  ["All"],
-                "OneDriveLocation":  ["All"],                               
+                "OneDriveLocation":  ["All"],
                 "Workload":  "Exchange, OneDriveForBusiness, Teams, EndpointDevices",
                 "Name":  "Default Office 365 DLP policy",
                 "Mode": "Enable",
@@ -534,7 +336,7 @@ test_Locations_Incorrect_V2 if {
     }
 
     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
-    
+
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].ReportDetails == "No enabled policy found that applies to: SharePoint"
@@ -571,7 +373,7 @@ test_Locations_Incorrect_V3 if {
                 "SharePointLocation":  ["All"],
                 "TeamsLocation":  ["All"],
                 "EndpointDlpLocation":  ["All"],
-                "OneDriveLocation":  [""],                               
+                "OneDriveLocation":  [""],
                 "Workload":  "Exchange, SharePoint, Teams, EndpointDevices",
                 "Name":  "Default Office 365 DLP policy",
                 "Mode": "Enable",
@@ -581,7 +383,7 @@ test_Locations_Incorrect_V3 if {
     }
 
     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
-    
+
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].ReportDetails == "No enabled policy found that applies to: OneDrive"
@@ -618,7 +420,7 @@ test_Locations_Incorrect_V4 if {
                 "SharePointLocation":  ["All"],
                 "TeamsLocation":  [""],
                 "EndpointDlpLocation":  ["All"],
-                "OneDriveLocation":  ["All"],                               
+                "OneDriveLocation":  ["All"],
                 "Workload":  "Exchange, SharePoint, OneDriveForBusiness, EndpointDevices",
                 "Name":  "Default Office 365 DLP policy",
                 "Mode": "Enable",
@@ -628,7 +430,7 @@ test_Locations_Incorrect_V4 if {
     }
 
     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
-    
+
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].ReportDetails == "No enabled policy found that applies to: Teams"
@@ -665,7 +467,7 @@ test_Locations_Incorrect_V5 if {
                 "SharePointLocation":  ["All"],
                 "TeamsLocation":  ["All"],
                 "EndpointDlpLocation":  [""],
-                "OneDriveLocation":  ["All"],                               
+                "OneDriveLocation":  ["All"],
                 "Workload":  "Exchange, SharePoint, OneDriveForBusiness, Teams",
                 "Name":  "Default Office 365 DLP policy",
                 "Mode": "Enable",
@@ -675,7 +477,7 @@ test_Locations_Incorrect_V5 if {
     }
 
     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
-    
+
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].ReportDetails == "No enabled policy found that applies to: Devices"

--- a/Testing/Unit/Rego/Defender/DefenderConfig_04_test.rego
+++ b/Testing/Unit/Rego/Defender/DefenderConfig_04_test.rego
@@ -716,7 +716,7 @@ test_ContentContainsSensitiveInformation_Incorrect_V1 if {
     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
 
     count(RuleOutput) == 1
-    not RuleOutput[0].RequirementMet
+    Not RuleOutput[0].RequirementMet
     RuleOutput[0].ReportDetails == "1 rule(s) found that do(es) not block access or associated policy not set to enforce block action: Baseline Rule"
 }
 #--

--- a/Testing/Unit/Rego/Defender/DefenderConfig_04_test.rego
+++ b/Testing/Unit/Rego/Defender/DefenderConfig_04_test.rego
@@ -680,45 +680,6 @@ test_Locations_Incorrect_V7 if {
 
 #
 # Policy 3
-test_ContentContainsSensitiveInformation_Incorrect_V1 if {
-    PolicyId := "MS.DEFENDER.4.3v1"
-
-    Output := tests with input as {
-        "dlp_compliance_rules": [
-            {
-                "ContentContainsSensitiveInformation":  [
-                    {"name":  "U.S. Social Security Number (SSN)"},
-                    {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"}
-                ],
-                "Name":  "Baseline Rule",
-                "Disabled" : false,
-                "ParentPolicyName":  "Default Office 365 DLP policy",
-                "BlockAccess":  true,
-                "BlockAccessScope":  "All",
-                "NotifyUser":  [
-                    "SiteAdmin",
-                    "LastModifier",
-                    "Owner"
-                ],
-                "NotifyUserType":  "NotSet",
-                "IsAdvancedRule": false
-            }
-        ],
-        "dlp_compliance_policies": [
-            {
-                "Name": "Default Office 365 DLP policy",
-                "Mode": "Enable",
-                "Enabled": true
-            }
-        ]
-    }
-
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
-
-    count(RuleOutput) == 1
-    RuleOutput[0].RequirementMet
-    RuleOutput[0].ReportDetails == "Requirement not met"
-}
 #--
 # test_BlockAccess_Correct if {
 #     ControlNumber := "Defender 2.2"

--- a/Testing/Unit/Rego/Defender/DefenderConfig_04_test.rego
+++ b/Testing/Unit/Rego/Defender/DefenderConfig_04_test.rego
@@ -680,6 +680,45 @@ test_Locations_Incorrect_V7 if {
 
 #
 # Policy 3
+test_ContentContainsSensitiveInformation_Incorrect_V1 if {
+    PolicyId := "MS.DEFENDER.4.3v1"
+
+    Output := tests with input as {
+        "dlp_compliance_rules": [
+            {
+                "ContentContainsSensitiveInformation":  [
+                    {"name":  "U.S. Social Security Number (SSN)"},
+                    {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"}
+                ],
+                "Name":  "Baseline Rule",
+                "Disabled" : false,
+                "ParentPolicyName":  "Default Office 365 DLP policy",
+                "BlockAccess":  true,
+                "BlockAccessScope":  "All",
+                "NotifyUser":  [
+                    "SiteAdmin",
+                    "LastModifier",
+                    "Owner"
+                ],
+                "NotifyUserType":  "NotSet",
+                "IsAdvancedRule": false
+            }
+        ],
+        "dlp_compliance_policies": [
+            {
+                "Name": "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
+            }
+        ]
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement not met"
+}
 #--
 # test_BlockAccess_Correct if {
 #     ControlNumber := "Defender 2.2"

--- a/Testing/Unit/Rego/Defender/DefenderConfig_04_test.rego
+++ b/Testing/Unit/Rego/Defender/DefenderConfig_04_test.rego
@@ -716,8 +716,8 @@ test_ContentContainsSensitiveInformation_Incorrect_V1 if {
     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
 
     count(RuleOutput) == 1
-    RuleOutput[0].RequirementMet
-    RuleOutput[0].ReportDetails == "Requirement not met"
+    Not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "1 rule(s) found that do(es) not block access or associated policy not set to enforce block action: Baseline Rule"
 }
 #--
 # test_BlockAccess_Correct if {

--- a/Testing/Unit/Rego/Defender/DefenderConfig_04_test.rego
+++ b/Testing/Unit/Rego/Defender/DefenderConfig_04_test.rego
@@ -400,51 +400,50 @@ test_ContentContainsSensitiveInformation_Incorrect_V4 if {
 #
 # Policy 2
 #--
-# test_Exchange_Correct if {
-#     ControlNumber := "Defender 2.2"
-#     Requirement := "The custom policy SHOULD be applied in Exchange"
+test_Exchange_Correct if {
+    PolicyId := "MS.DEFENDER.4.2v1"
 
-#     Output := tests with input as {
-#         "dlp_compliance_rules": [
-#             {
-#                 "ContentContainsSensitiveInformation":  [
-#                     {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"},
-#                     {"name":  "Credit Card Number"},
-#                     {"name":  "U.S. Social Security Number (SSN)"}
-#                 ],
-#                 "Name":  "Baseline Rule",
-# 	            "Disabled" : false,
-#                 "ParentPolicyName":  "Default Office 365 DLP policy",
-# 	            "BlockAccess":  true,
-#                 "BlockAccessScope":  "All",
-# 	            "NotifyUser":  [
-#                     "SiteAdmin",
-#                     "LastModifier",
-#                     "Owner"
-#                 ],
-# 	            "NotifyUserType":  "NotSet"
-#             }
-#         ],
-#         "dlp_compliance_policies": [
-#             {
-#                 "ExchangeLocation":  ["All"],
-#                 "Workload":  "Exchange",
-#                 "Name":  "Default Office 365 DLP policy",
-#                 "Mode": "Enable",
-#                 "Enabled": true
-#             }
-#         ]
-#     }
+    Output := tests with input as {
+        "dlp_compliance_rules": [
+            {
+                "ContentContainsSensitiveInformation":  [
+                    {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"},
+                    {"name":  "Credit Card Number"},
+                    {"name":  "U.S. Social Security Number (SSN)"}
+                ],
+                "Name":  "Baseline Rule",
+	            "Disabled" : false,
+                "ParentPolicyName":  "Default Office 365 DLP policy",
+	            "BlockAccess":  true,
+                "BlockAccessScope":  "All",
+	            "NotifyUser":  [
+                    "SiteAdmin",
+                    "LastModifier",
+                    "Owner"
+                ],
+	            "NotifyUserType":  "NotSet"
+            }
+        ],
+        "dlp_compliance_policies": [
+            {
+                "ExchangeLocation":  ["All"],
+                "Workload":  "Exchange",
+                "Name":  "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
+            }
+        ]
+    }
 
-#     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
 
-#     count(RuleOutput) == 1
-#     RuleOutput[0].RequirementMet
-#     RuleOutput[0].ReportDetails == "Requirement met"
-# }
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
 
 # test_ExchangeLocation_Incorrect if {
-#     ControlNumber := "Defender 2.2"
+#     PolicyId := "MS.DEFENDER.4.2v1"
 #     Requirement := "The custom policy SHOULD be applied in Exchange"
 
 #     Output := tests with input as {
@@ -479,7 +478,7 @@ test_ContentContainsSensitiveInformation_Incorrect_V4 if {
 #         ]
 #     }
 
-#     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+#     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
 
 #     count(RuleOutput) == 1
 #     not RuleOutput[0].RequirementMet
@@ -487,7 +486,7 @@ test_ContentContainsSensitiveInformation_Incorrect_V4 if {
 # }
 
 # test_Workload_Incorrect_V1 if {
-#     ControlNumber := "Defender 2.2"
+#     PolicyId := "MS.DEFENDER.4.2v1"
 #     Requirement := "The custom policy SHOULD be applied in Exchange"
 
 #     Output := tests with input as {
@@ -522,7 +521,7 @@ test_ContentContainsSensitiveInformation_Incorrect_V4 if {
 #         ]
 #     }
 
-#     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+#     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
 
 #     count(RuleOutput) == 1
 #     not RuleOutput[0].RequirementMet
@@ -530,7 +529,7 @@ test_ContentContainsSensitiveInformation_Incorrect_V4 if {
 # }
 
 # test_SharePoint_Correct if {
-#     ControlNumber := "Defender 2.2"
+#     PolicyId := "MS.DEFENDER.4.2v1"
 #     Requirement := "The custom policy SHOULD be applied in SharePoint"
 
 #     Output := tests with input as {
@@ -565,7 +564,7 @@ test_ContentContainsSensitiveInformation_Incorrect_V4 if {
 #         ]
 #     }
 
-#     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+#     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
 
 #     count(RuleOutput) == 1
 #     RuleOutput[0].RequirementMet
@@ -573,7 +572,7 @@ test_ContentContainsSensitiveInformation_Incorrect_V4 if {
 # }
 
 # test_SharePointLocation_Incorrect if {
-#     ControlNumber := "Defender 2.2"
+#     PolicyId := "MS.DEFENDER.4.2v1"
 #     Requirement := "The custom policy SHOULD be applied in SharePoint"
 
 #     Output := tests with input as {
@@ -608,7 +607,7 @@ test_ContentContainsSensitiveInformation_Incorrect_V4 if {
 #         ]
 #     }
 
-#     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+#     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
 
 #     count(RuleOutput) == 1
 #     not RuleOutput[0].RequirementMet
@@ -616,7 +615,7 @@ test_ContentContainsSensitiveInformation_Incorrect_V4 if {
 # }
 
 # test_Workload_Incorrect_V2 if {
-#     ControlNumber := "Defender 2.2"
+#     PolicyId := "MS.DEFENDER.4.2v1"
 #     Requirement := "The custom policy SHOULD be applied in SharePoint"
 
 #     Output := tests with input as {
@@ -651,7 +650,7 @@ test_ContentContainsSensitiveInformation_Incorrect_V4 if {
 #         ]
 #     }
 
-#     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+#     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
 
 #     count(RuleOutput) == 1
 #     not RuleOutput[0].RequirementMet
@@ -659,7 +658,7 @@ test_ContentContainsSensitiveInformation_Incorrect_V4 if {
 # }
 
 # test_OneDrive_Correct if {
-#     ControlNumber := "Defender 2.2"
+#     PolicyId := "MS.DEFENDER.4.2v1"
 #     Requirement := "The custom policy SHOULD be applied in OneDrive"
 
 #     Output := tests with input as {
@@ -694,7 +693,7 @@ test_ContentContainsSensitiveInformation_Incorrect_V4 if {
 #         ]
 #     }
 
-#     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+#     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
 
 #     count(RuleOutput) == 1
 #     RuleOutput[0].RequirementMet
@@ -702,7 +701,7 @@ test_ContentContainsSensitiveInformation_Incorrect_V4 if {
 # }
 
 # test_OneDriveLocation_Incorrect if {
-#     ControlNumber := "Defender 2.2"
+#     PolicyId := "MS.DEFENDER.4.2v1"
 #     Requirement := "The custom policy SHOULD be applied in OneDrive"
 
 #     Output := tests with input as {
@@ -737,7 +736,7 @@ test_ContentContainsSensitiveInformation_Incorrect_V4 if {
 #         ]
 #     }
 
-#     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+#     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
 
 #     count(RuleOutput) == 1
 #     not RuleOutput[0].RequirementMet
@@ -745,7 +744,7 @@ test_ContentContainsSensitiveInformation_Incorrect_V4 if {
 # }
 
 # test_Workload_Incorrect_V3 if {
-#     ControlNumber := "Defender 2.2"
+#     PolicyId := "MS.DEFENDER.4.2v1"
 #     Requirement := "The custom policy SHOULD be applied in OneDrive"
 
 #     Output := tests with input as {
@@ -780,7 +779,7 @@ test_ContentContainsSensitiveInformation_Incorrect_V4 if {
 #         ]
 #     }
 
-#     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+#     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
 
 #     count(RuleOutput) == 1
 #     not RuleOutput[0].RequirementMet
@@ -788,7 +787,7 @@ test_ContentContainsSensitiveInformation_Incorrect_V4 if {
 # }
 
 # test_Teams_Correct if {
-#     ControlNumber := "Defender 2.2"
+#     PolicyId := "MS.DEFENDER.4.2v1"
 #     Requirement := "The custom policy SHOULD be applied in Teams"
 
 #     Output := tests with input as {
@@ -823,7 +822,7 @@ test_ContentContainsSensitiveInformation_Incorrect_V4 if {
 #         ]
 #     }
 
-#     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+#     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
 
 #     count(RuleOutput) == 1
 #     RuleOutput[0].RequirementMet
@@ -831,7 +830,7 @@ test_ContentContainsSensitiveInformation_Incorrect_V4 if {
 # }
 
 # test_TeamsLocation_Incorrect if {
-#     ControlNumber := "Defender 2.2"
+#     PolicyId := "MS.DEFENDER.4.2v1"
 #     Requirement := "The custom policy SHOULD be applied in Teams"
 
 #     Output := tests with input as {
@@ -866,7 +865,7 @@ test_ContentContainsSensitiveInformation_Incorrect_V4 if {
 #         ]
 #     }
 
-#     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+#     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
 
 #     count(RuleOutput) == 1
 #     not RuleOutput[0].RequirementMet
@@ -874,7 +873,7 @@ test_ContentContainsSensitiveInformation_Incorrect_V4 if {
 # }
 
 # test_Workload_Incorrect_V4 if {
-#     ControlNumber := "Defender 2.2"
+#     PolicyId := "MS.DEFENDER.4.2v1"
 #     Requirement := "The custom policy SHOULD be applied in Teams"
 
 #     Output := tests with input as {
@@ -909,7 +908,7 @@ test_ContentContainsSensitiveInformation_Incorrect_V4 if {
 #         ]
 #     }
 
-#     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+#     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
 
 #     count(RuleOutput) == 1
 #     not RuleOutput[0].RequirementMet

--- a/Testing/Unit/Rego/Defender/DefenderConfig_04_test.rego
+++ b/Testing/Unit/Rego/Defender/DefenderConfig_04_test.rego
@@ -6,44 +6,198 @@ import future.keywords
 #
 # Policy 1
 #--
-# test_ContentContainsSensitiveInformation_Correct_V1 if {
-#     ControlNumber := "Defender 2.2"
-#     Requirement := "A custom policy SHALL be configured to protect PII and sensitive information, as defined by the agency: U.S. Social Security Number (SSN)"
+test_ContentContainsSensitiveInformation_Correct_V1 if {
+    PolicyId := "MS.DEFENDER.4.1v1"
 
-#     Output := tests with input as {
-#         "dlp_compliance_rules": [
-#             {
-#                 "ContentContainsSensitiveInformation":  [
-#                     {"name":  "U.S. Social Security Number (SSN)"}
-#                 ],
-#                 "Name":  "Baseline Rule",
-# 	            "Disabled" : false,
-#                 "ParentPolicyName":  "Default Office 365 DLP policy",
-# 	            "BlockAccess":  true,
-#                 "BlockAccessScope":  "All",
-# 	            "NotifyUser":  [
-#                     "SiteAdmin",
-#                     "LastModifier",
-#                     "Owner"
-#                 ],
-# 	            "NotifyUserType":  "NotSet"
-#             }
-#         ],
-#         "dlp_compliance_policies": [
-#             {
-#                 "Name": "Default Office 365 DLP policy",
-#                 "Mode": "Enable",
-#                 "Enabled": true
-#             }
-#         ]
-#     }
+    Output := tests with input as {
+        "dlp_compliance_rules": [
+            {
+                "ContentContainsSensitiveInformation":  [
+                    {"name":  "U.S. Social Security Number (SSN)"},
+                    {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"},
+                    {"name":  "Credit Card Number"}
+                ],
+                "Name":  "Baseline Rule",
+                "Disabled" : false,
+                "ParentPolicyName":  "Default Office 365 DLP policy",
+                "BlockAccess":  true,
+                "BlockAccessScope":  "All",
+                "NotifyUser":  [
+                    "SiteAdmin",
+                    "LastModifier",
+                    "Owner"
+                ],
+                "NotifyUserType":  "NotSet"
+            }
+        ],
+        "dlp_compliance_policies": [
+            {
+                "Name": "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
+            }
+        ]
+    }
 
-#     RuleOutput := [Result | Result = Output[_]; Result.Control == ControlNumber; Result.Requirement == Requirement]
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
 
-#     count(RuleOutput) == 1
-#     RuleOutput[0].RequirementMet
-#     RuleOutput[0].ReportDetails == "Requirement met"
-# }
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement met"
+}
+
+test_ContentContainsSensitiveInformation_Incorrect_V1 if {
+    PolicyId := "MS.DEFENDER.4.1v1"
+
+    Output := tests with input as {
+        "dlp_compliance_rules": [
+            {
+                "ContentContainsSensitiveInformation":  [
+                    {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"},
+                    {"name":  "Credit Card Number"}
+                ],
+                "Name":  "Baseline Rule",
+                "Disabled" : false,
+                "ParentPolicyName":  "Default Office 365 DLP policy",
+                "BlockAccess":  true,
+                "BlockAccessScope":  "All",
+                "NotifyUser":  [
+                    "SiteAdmin",
+                    "LastModifier",
+                    "Owner"
+                ],
+                "NotifyUserType":  "NotSet"
+            }
+        ],
+        "dlp_compliance_policies": [
+            {
+                "Name": "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
+            }
+        ]
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "No matching rules found for: U.S. Social Security Number (SSN)"
+}
+
+test_ContentContainsSensitiveInformation_Incorrect_V2 if {
+    PolicyId := "MS.DEFENDER.4.1v1"
+
+    Output := tests with input as {
+        "dlp_compliance_rules": [
+            {
+                "ContentContainsSensitiveInformation":  [
+                    {"name":  "U.S. Social Security Number (SSN)"},
+                    {"name":  "Credit Card Number"}
+                ],
+                "Name":  "Baseline Rule",
+                "Disabled" : false,
+                "ParentPolicyName":  "Default Office 365 DLP policy",
+                "BlockAccess":  true,
+                "BlockAccessScope":  "All",
+                "NotifyUser":  [
+                    "SiteAdmin",
+                    "LastModifier",
+                    "Owner"
+                ],
+                "NotifyUserType":  "NotSet"
+            }
+        ],
+        "dlp_compliance_policies": [
+            {
+                "Name": "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
+            }
+        ]
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "No matching rules found for: U.S. Individual Taxpayer Identification Number (ITIN)"
+}
+
+test_ContentContainsSensitiveInformation_Incorrect_V3 if {
+    PolicyId := "MS.DEFENDER.4.1v1"
+
+    Output := tests with input as {
+        "dlp_compliance_rules": [
+            {
+                "ContentContainsSensitiveInformation":  [
+                    {"name":  "U.S. Social Security Number (SSN)"},
+                    {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"}
+                ],
+                "Name":  "Baseline Rule",
+                "Disabled" : false,
+                "ParentPolicyName":  "Default Office 365 DLP policy",
+                "BlockAccess":  true,
+                "BlockAccessScope":  "All",
+                "NotifyUser":  [
+                    "SiteAdmin",
+                    "LastModifier",
+                    "Owner"
+                ],
+                "NotifyUserType":  "NotSet"
+            }
+        ],
+        "dlp_compliance_policies": [
+            {
+                "Name": "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
+            }
+        ]
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "No matching rules found for: Credit Card Number"
+}
+
+test_ContentContainsSensitiveInformation_Incorrect_V4 if {
+    PolicyId := "MS.DEFENDER.4.1v1"
+
+    Output := tests with input as {
+        "dlp_compliance_rules": [
+            {
+                "ContentContainsSensitiveInformation":  [],
+                "Name":  "Baseline Rule",
+                "Disabled" : false,
+                "ParentPolicyName":  "Default Office 365 DLP policy",
+                "BlockAccess":  true,
+                "BlockAccessScope":  "All",
+                "NotifyUser":  [
+                    "SiteAdmin",
+                    "LastModifier",
+                    "Owner"
+                ],
+                "NotifyUserType":  "NotSet"
+            }
+        ],
+        "dlp_compliance_policies": [
+            {
+                "Name": "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
+            }
+        ]
+    }
+
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "No matching rules found for: Credit Card Number, U.S. Individual Taxpayer Identification Number (ITIN), U.S. Social Security Number (SSN)"
+}
 
 # test_ContentContainsSensitiveInformation_Incorrect_V1 if {
 #     ControlNumber := "Defender 2.2"

--- a/Testing/Unit/Rego/Defender/DefenderConfig_04_test.rego
+++ b/Testing/Unit/Rego/Defender/DefenderConfig_04_test.rego
@@ -400,7 +400,7 @@ test_ContentContainsSensitiveInformation_Incorrect_V4 if {
 #
 # Policy 2
 #--
-test_Exchange_Correct if {
+test_Locations_Correct if {
     PolicyId := "MS.DEFENDER.4.2v1"
 
     Output := tests with input as {
@@ -412,22 +412,26 @@ test_Exchange_Correct if {
                     {"name":  "U.S. Social Security Number (SSN)"}
                 ],
                 "Name":  "Baseline Rule",
-	            "Disabled" : false,
+                "Disabled" : false,
                 "ParentPolicyName":  "Default Office 365 DLP policy",
-	            "BlockAccess":  true,
+                "BlockAccess":  true,
                 "BlockAccessScope":  "All",
-	            "NotifyUser":  [
+                "NotifyUser":  [
                     "SiteAdmin",
                     "LastModifier",
                     "Owner"
                 ],
-	            "NotifyUserType":  "NotSet"
+                "NotifyUserType":  "NotSet"
             }
         ],
         "dlp_compliance_policies": [
             {
                 "ExchangeLocation":  ["All"],
-                "Workload":  "Exchange",
+                "SharePointLocation":  ["All"],
+                "TeamsLocation":  ["All"],
+                "EndpointDlpLocation":  ["All"],
+                "OneDriveLocation":  ["All"],
+                "Workload":  "Exchange, SharePoint, OneDriveForBusiness, Teams, EndpointDevices",
                 "Name":  "Default Office 365 DLP policy",
                 "Mode": "Enable",
                 "Enabled": true
@@ -442,478 +446,334 @@ test_Exchange_Correct if {
     RuleOutput[0].ReportDetails == "Requirement met"
 }
 
-# test_ExchangeLocation_Incorrect if {
-#     PolicyId := "MS.DEFENDER.4.2v1"
-#     Requirement := "The custom policy SHOULD be applied in Exchange"
+# Policy exists, but Exchange location is null
+test_Locations_Incorrect_V1 if {
+    PolicyId := "MS.DEFENDER.4.2v1"
 
-#     Output := tests with input as {
-#         "dlp_compliance_rules": [
-#             {
-#                 "ContentContainsSensitiveInformation":  [
-#                     {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"},
-#                     {"name":  "Credit Card Number"},
-#                     {"name":  "U.S. Social Security Number (SSN)"}
-#                 ],
-#                 "Name":  "Baseline Rule",
-# 	            "Disabled" : false,
-#                 "ParentPolicyName":  "Default Office 365 DLP policy",
-# 	            "BlockAccess":  true,
-#                 "BlockAccessScope":  "All",
-# 	            "NotifyUser":  [
-#                     "SiteAdmin",
-#                     "LastModifier",
-#                     "Owner"
-#                 ],
-# 	            "NotifyUserType":  "NotSet"
-#             }
-#         ],
-#         "dlp_compliance_policies": [
-#             {
-#                 "ExchangeLocation":  [""],
-#                 "Workload":  "Exchange",
-#                 "Name":  "Default Office 365 DLP policy",
-#                 "Mode": "Enable",
-#                 "Enabled": true
-#             }
-#         ]
-#     }
+    Output := tests with input as {
+        "dlp_compliance_rules": [
+            {
+                "ContentContainsSensitiveInformation":  [
+                    {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"},
+                    {"name":  "Credit Card Number"},
+                    {"name":  "U.S. Social Security Number (SSN)"}
+                ],
+                "Name":  "Baseline Rule",
+                "Disabled" : false,
+                "ParentPolicyName":  "Default Office 365 DLP policy",
+                "BlockAccess":  true,
+                "BlockAccessScope":  "All",
+                "NotifyUser":  [
+                    "SiteAdmin",
+                    "LastModifier",
+                    "Owner"
+                ],
+                "NotifyUserType":  "NotSet"
+            }
+        ],
+        "dlp_compliance_policies": [
+            {
+                "ExchangeLocation":  [""],
+                "SharePointLocation":  ["All"],
+                "TeamsLocation":  ["All"],
+                "EndpointDlpLocation":  ["All"],
+                "OneDriveLocation":  ["All"],
+                "Workload":  "SharePoint, OneDriveForBusiness, Teams, EndpointDevices",
+                "Name":  "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
+            }
+        ]
+    }
 
-#     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
 
-#     count(RuleOutput) == 1
-#     not RuleOutput[0].RequirementMet
-#     RuleOutput[0].ReportDetails == "No policy found that applies to Exchange."
-# }
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "No enabled policy found that applies to: Exchange"
+}
 
-# test_Workload_Incorrect_V1 if {
-#     PolicyId := "MS.DEFENDER.4.2v1"
-#     Requirement := "The custom policy SHOULD be applied in Exchange"
+# Policy exists, but SharePoint is not included
+test_Locations_Incorrect_V2 if {
+    PolicyId := "MS.DEFENDER.4.2v1"
 
-#     Output := tests with input as {
-#         "dlp_compliance_rules": [
-#             {
-#                 "ContentContainsSensitiveInformation":  [
-#                     {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"},
-#                     {"name":  "Credit Card Number"},
-#                     {"name":  "U.S. Social Security Number (SSN)"}
-#                 ],
-#                 "Name":  "Baseline Rule",
-# 	            "Disabled" : false,
-#                 "ParentPolicyName":  "Default Office 365 DLP policy",
-# 	            "BlockAccess":  true,
-#                 "BlockAccessScope":  "All",
-# 	            "NotifyUser":  [
-#                     "SiteAdmin",
-#                     "LastModifier",
-#                     "Owner"
-#                 ],
-# 	            "NotifyUserType":  "NotSet"
-#             }
-#         ],
-#         "dlp_compliance_policies": [
-#             {
-#                 "ExchangeLocation":  ["All"],
-#                 "Workload":  "",
-#                 "Name":  "Default Office 365 DLP policy",
-#                 "Mode": "Enable",
-#                 "Enabled": true
-#             }
-#         ]
-#     }
+    Output := tests with input as {
+        "dlp_compliance_rules": [
+            {
+                "ContentContainsSensitiveInformation":  [
+                    {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"},
+                    {"name":  "Credit Card Number"},
+                    {"name":  "U.S. Social Security Number (SSN)"}
+                ],
+                "Name":  "Baseline Rule",
+                "Disabled" : false,
+                "ParentPolicyName":  "Default Office 365 DLP policy",
+                "BlockAccess":  true,
+                "BlockAccessScope":  "All",
+                "NotifyUser":  [
+                    "SiteAdmin",
+                    "LastModifier",
+                    "Owner"
+                ],
+                "NotifyUserType":  "NotSet"
+            }
+        ],
+        "dlp_compliance_policies": [
+            {
+                "ExchangeLocation":  ["All"],
+                "SharePointLocation":  [""],
+                "TeamsLocation":  ["All"],
+                "EndpointDlpLocation":  ["All"],
+                "OneDriveLocation":  ["All"],                               
+                "Workload":  "Exchange, OneDriveForBusiness, Teams, EndpointDevices",
+                "Name":  "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
+            }
+        ]
+    }
 
-#     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "No enabled policy found that applies to: SharePoint"
+}
 
-#     count(RuleOutput) == 1
-#     not RuleOutput[0].RequirementMet
-#     RuleOutput[0].ReportDetails == "No policy found that applies to Exchange."
-# }
+# Policy exists, but OneDrive location not included
+test_Locations_Incorrect_V3 if {
+    PolicyId := "MS.DEFENDER.4.2v1"
 
-# test_SharePoint_Correct if {
-#     PolicyId := "MS.DEFENDER.4.2v1"
-#     Requirement := "The custom policy SHOULD be applied in SharePoint"
+    Output := tests with input as {
+        "dlp_compliance_rules": [
+            {
+                "ContentContainsSensitiveInformation":  [
+                    {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"},
+                    {"name":  "Credit Card Number"},
+                    {"name":  "U.S. Social Security Number (SSN)"}
+                ],
+                "Name":  "Baseline Rule",
+                "Disabled" : false,
+                "ParentPolicyName":  "Default Office 365 DLP policy",
+                "BlockAccess":  true,
+                "BlockAccessScope":  "All",
+                "NotifyUser":  [
+                    "SiteAdmin",
+                    "LastModifier",
+                    "Owner"
+                ],
+                "NotifyUserType":  "NotSet"
+            }
+        ],
+        "dlp_compliance_policies": [
+            {
+                "ExchangeLocation":  ["All"],
+                "SharePointLocation":  ["All"],
+                "TeamsLocation":  ["All"],
+                "EndpointDlpLocation":  ["All"],
+                "OneDriveLocation":  [""],                               
+                "Workload":  "Exchange, SharePoint, Teams, EndpointDevices",
+                "Name":  "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
+            }
+        ]
+    }
 
-#     Output := tests with input as {
-#         "dlp_compliance_rules": [
-#             {
-#                 "ContentContainsSensitiveInformation":  [
-#                     {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"},
-#                     {"name":  "Credit Card Number"},
-#                     {"name":  "U.S. Social Security Number (SSN)"}
-#                 ],
-#                 "Name":  "Baseline Rule",
-# 	            "Disabled" : false,
-#                 "ParentPolicyName":  "Default Office 365 DLP policy",
-# 	            "BlockAccess":  true,
-#                 "BlockAccessScope":  "All",
-# 	            "NotifyUser":  [
-#                     "SiteAdmin",
-#                     "LastModifier",
-#                     "Owner"
-#                 ],
-# 	            "NotifyUserType":  "NotSet"
-#             }
-#         ],
-#         "dlp_compliance_policies": [
-#             {
-#                 "SharePointLocation":  ["All"],
-#                 "Workload":  "SharePoint",
-#                 "Name":  "Default Office 365 DLP policy",
-#                 "Mode": "Enable",
-#                 "Enabled": true
-#             }
-#         ]
-#     }
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "No enabled policy found that applies to: OneDrive"
+}
 
-#     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+# Policy exists, but OneDrive location not included
+test_Locations_Incorrect_V4 if {
+    PolicyId := "MS.DEFENDER.4.2v1"
 
-#     count(RuleOutput) == 1
-#     RuleOutput[0].RequirementMet
-#     RuleOutput[0].ReportDetails == "Requirement met"
-# }
+    Output := tests with input as {
+        "dlp_compliance_rules": [
+            {
+                "ContentContainsSensitiveInformation":  [
+                    {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"},
+                    {"name":  "Credit Card Number"},
+                    {"name":  "U.S. Social Security Number (SSN)"}
+                ],
+                "Name":  "Baseline Rule",
+                "Disabled" : false,
+                "ParentPolicyName":  "Default Office 365 DLP policy",
+                "BlockAccess":  true,
+                "BlockAccessScope":  "All",
+                "NotifyUser":  [
+                    "SiteAdmin",
+                    "LastModifier",
+                    "Owner"
+                ],
+                "NotifyUserType":  "NotSet"
+            }
+        ],
+        "dlp_compliance_policies": [
+            {
+                "ExchangeLocation":  ["All"],
+                "SharePointLocation":  ["All"],
+                "TeamsLocation":  [""],
+                "EndpointDlpLocation":  ["All"],
+                "OneDriveLocation":  ["All"],                               
+                "Workload":  "Exchange, SharePoint, OneDriveForBusiness, EndpointDevices",
+                "Name":  "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
+            }
+        ]
+    }
 
-# test_SharePointLocation_Incorrect if {
-#     PolicyId := "MS.DEFENDER.4.2v1"
-#     Requirement := "The custom policy SHOULD be applied in SharePoint"
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "No enabled policy found that applies to: Teams"
+}
 
-#     Output := tests with input as {
-#         "dlp_compliance_rules": [
-#             {
-#                 "ContentContainsSensitiveInformation":  [
-#                     {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"},
-#                     {"name":  "Credit Card Number"},
-#                     {"name":  "U.S. Social Security Number (SSN)"}
-#                 ],
-#                 "Name":  "Baseline Rule",
-# 	            "Disabled" : false,
-#                 "ParentPolicyName":  "Default Office 365 DLP policy",
-# 	            "BlockAccess":  true,
-#                 "BlockAccessScope":  "All",
-# 	            "NotifyUser":  [
-#                     "SiteAdmin",
-#                     "LastModifier",
-#                     "Owner"
-#                 ],
-# 	            "NotifyUserType":  "NotSet"
-#             }
-#         ],
-#         "dlp_compliance_policies": [
-#             {
-#                 "SharePointLocation":  [""],
-#                 "Workload":  "SharePoint",
-#                 "Name":  "Default Office 365 DLP policy",
-#                 "Mode": "Enable",
-#                 "Enabled": true
-#             }
-#         ]
-#     }
+# Policy exists, but Devices location not included
+test_Locations_Incorrect_V5 if {
+    PolicyId := "MS.DEFENDER.4.2v1"
 
-#     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    Output := tests with input as {
+        "dlp_compliance_rules": [
+            {
+                "ContentContainsSensitiveInformation":  [
+                    {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"},
+                    {"name":  "Credit Card Number"},
+                    {"name":  "U.S. Social Security Number (SSN)"}
+                ],
+                "Name":  "Baseline Rule",
+                "Disabled" : false,
+                "ParentPolicyName":  "Default Office 365 DLP policy",
+                "BlockAccess":  true,
+                "BlockAccessScope":  "All",
+                "NotifyUser":  [
+                    "SiteAdmin",
+                    "LastModifier",
+                    "Owner"
+                ],
+                "NotifyUserType":  "NotSet"
+            }
+        ],
+        "dlp_compliance_policies": [
+            {
+                "ExchangeLocation":  ["All"],
+                "SharePointLocation":  ["All"],
+                "TeamsLocation":  ["All"],
+                "EndpointDlpLocation":  [""],
+                "OneDriveLocation":  ["All"],                               
+                "Workload":  "Exchange, SharePoint, OneDriveForBusiness, Teams",
+                "Name":  "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
+            }
+        ]
+    }
 
-#     count(RuleOutput) == 1
-#     not RuleOutput[0].RequirementMet
-#     RuleOutput[0].ReportDetails == "No policy found that applies to SharePoint."
-# }
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "No enabled policy found that applies to: Devices"
+}
 
-# test_Workload_Incorrect_V2 if {
-#     PolicyId := "MS.DEFENDER.4.2v1"
-#     Requirement := "The custom policy SHOULD be applied in SharePoint"
+# Policy exists, but is not enabled
+test_Locations_Incorrect_V6 if {
+    PolicyId := "MS.DEFENDER.4.2v1"
 
-#     Output := tests with input as {
-#         "dlp_compliance_rules": [
-#             {
-#                 "ContentContainsSensitiveInformation":  [
-#                     {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"},
-#                     {"name":  "Credit Card Number"},
-#                     {"name":  "U.S. Social Security Number (SSN)"}
-#                 ],
-#                 "Name":  "Baseline Rule",
-# 	            "Disabled" : false,
-#                 "ParentPolicyName":  "Default Office 365 DLP policy",
-# 	            "BlockAccess":  true,
-#                 "BlockAccessScope":  "All",
-# 	            "NotifyUser":  [
-#                     "SiteAdmin",
-#                     "LastModifier",
-#                     "Owner"
-#                 ],
-# 	            "NotifyUserType":  "NotSet"
-#             }
-#         ],
-#         "dlp_compliance_policies": [
-#             {
-#                 "SharePointLocation":  ["All"],
-#                 "Workload":  "",
-#                 "Name":  "Default Office 365 DLP policy",
-#                 "Mode": "Enable",
-#                 "Enabled": true
-#             }
-#         ]
-#     }
+    Output := tests with input as {
+        "dlp_compliance_rules": [
+            {
+                "ContentContainsSensitiveInformation":  [
+                    {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"},
+                    {"name":  "Credit Card Number"},
+                    {"name":  "U.S. Social Security Number (SSN)"}
+                ],
+                "Name":  "Baseline Rule",
+                "Disabled" : false,
+                "ParentPolicyName":  "Default Office 365 DLP policy",
+                "BlockAccess":  true,
+                "BlockAccessScope":  "All",
+                "NotifyUser":  [
+                    "SiteAdmin",
+                    "LastModifier",
+                    "Owner"
+                ],
+                "NotifyUserType":  "NotSet"
+            }
+        ],
+        "dlp_compliance_policies": [
+            {
+                "ExchangeLocation":  ["All"],
+                "SharePointLocation":  ["All"],
+                "TeamsLocation":  ["All"],
+                "EndpointDlpLocation":  ["All"],
+                "OneDriveLocation":  ["All"],
+                "Workload":  "Exchange, SharePoint, OneDriveForBusiness, Teams, EndpointDevices",
+                "Name":  "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": false
+            }
+        ]
+    }
 
-#     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
 
-#     count(RuleOutput) == 1
-#     not RuleOutput[0].RequirementMet
-#     RuleOutput[0].ReportDetails == "No policy found that applies to SharePoint."
-# }
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "No enabled policy found that applies to: Devices, Exchange, OneDrive, SharePoint, Teams"
+}
 
-# test_OneDrive_Correct if {
-#     PolicyId := "MS.DEFENDER.4.2v1"
-#     Requirement := "The custom policy SHOULD be applied in OneDrive"
+# Policy exists and is enabled, but block rules are disabled
+test_Locations_Incorrect_V7 if {
+    PolicyId := "MS.DEFENDER.4.2v1"
 
-#     Output := tests with input as {
-#         "dlp_compliance_rules": [
-#             {
-#                 "ContentContainsSensitiveInformation":  [
-#                     {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"},
-#                     {"name":  "Credit Card Number"},
-#                     {"name":  "U.S. Social Security Number (SSN)"}
-#                 ],
-#                 "Name":  "Baseline Rule",
-# 	            "Disabled" : false,
-#                 "ParentPolicyName":  "Default Office 365 DLP policy",
-# 	            "BlockAccess":  true,
-#                 "BlockAccessScope":  "All",
-# 	            "NotifyUser":  [
-#                     "SiteAdmin",
-#                     "LastModifier",
-#                     "Owner"
-#                 ],
-# 	            "NotifyUserType":  "NotSet"
-#             }
-#         ],
-#         "dlp_compliance_policies": [
-#             {
-#                 "OneDriveLocation":  ["All"],
-#                 "Workload":  "OneDrivePoint",
-#                 "Name":  "Default Office 365 DLP policy",
-#                 "Mode": "Enable",
-#                 "Enabled": true
-#             }
-#         ]
-#     }
+    Output := tests with input as {
+        "dlp_compliance_rules": [
+            {
+                "ContentContainsSensitiveInformation":  [
+                    {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"},
+                    {"name":  "Credit Card Number"},
+                    {"name":  "U.S. Social Security Number (SSN)"}
+                ],
+                "Name":  "Baseline Rule",
+                "Disabled" : true,
+                "ParentPolicyName":  "Default Office 365 DLP policy",
+                "BlockAccess":  true,
+                "BlockAccessScope":  "All",
+                "NotifyUser":  [
+                    "SiteAdmin",
+                    "LastModifier",
+                    "Owner"
+                ],
+                "NotifyUserType":  "NotSet"
+            }
+        ],
+        "dlp_compliance_policies": [
+            {
+                "ExchangeLocation":  ["All"],
+                "SharePointLocation":  ["All"],
+                "TeamsLocation":  ["All"],
+                "EndpointDlpLocation":  ["All"],
+                "OneDriveLocation":  ["All"],
+                "Workload":  "Exchange, SharePoint, OneDriveForBusiness, Teams, EndpointDevices",
+                "Name":  "Default Office 365 DLP policy",
+                "Mode": "Enable",
+                "Enabled": true
+            }
+        ]
+    }
 
-#     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
 
-#     count(RuleOutput) == 1
-#     RuleOutput[0].RequirementMet
-#     RuleOutput[0].ReportDetails == "Requirement met"
-# }
-
-# test_OneDriveLocation_Incorrect if {
-#     PolicyId := "MS.DEFENDER.4.2v1"
-#     Requirement := "The custom policy SHOULD be applied in OneDrive"
-
-#     Output := tests with input as {
-#         "dlp_compliance_rules": [
-#             {
-#                 "ContentContainsSensitiveInformation":  [
-#                     {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"},
-#                     {"name":  "Credit Card Number"},
-#                     {"name":  "U.S. Social Security Number (SSN)"}
-#                 ],
-#                 "Name":  "Baseline Rule",
-# 	            "Disabled" : false,
-#                 "ParentPolicyName":  "Default Office 365 DLP policy",
-# 	            "BlockAccess":  true,
-#                 "BlockAccessScope":  "All",
-# 	            "NotifyUser":  [
-#                     "SiteAdmin",
-#                     "LastModifier",
-#                     "Owner"
-#                 ],
-# 	            "NotifyUserType":  "NotSet"
-#             }
-#         ],
-#         "dlp_compliance_policies": [
-#             {
-#                 "OneDriveLocation":  [""],
-#                 "Workload":  "OneDrivePoint",
-#                 "Name":  "Default Office 365 DLP policy",
-#                 "Mode": "Enable",
-#                 "Enabled": true
-#             }
-#         ]
-#     }
-
-#     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
-
-#     count(RuleOutput) == 1
-#     not RuleOutput[0].RequirementMet
-#     RuleOutput[0].ReportDetails == "No policy found that applies to OneDrive."
-# }
-
-# test_Workload_Incorrect_V3 if {
-#     PolicyId := "MS.DEFENDER.4.2v1"
-#     Requirement := "The custom policy SHOULD be applied in OneDrive"
-
-#     Output := tests with input as {
-#         "dlp_compliance_rules": [
-#             {
-#                 "ContentContainsSensitiveInformation":  [
-#                     {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"},
-#                     {"name":  "Credit Card Number"},
-#                     {"name":  "U.S. Social Security Number (SSN)"}
-#                 ],
-#                 "Name":  "Baseline Rule",
-# 	            "Disabled" : false,
-#                 "ParentPolicyName":  "Default Office 365 DLP policy",
-# 	            "BlockAccess":  true,
-#                 "BlockAccessScope":  "All",
-# 	            "NotifyUser":  [
-#                     "SiteAdmin",
-#                     "LastModifier",
-#                     "Owner"
-#                 ],
-# 	            "NotifyUserType":  "NotSet"
-#             }
-#         ],
-#         "dlp_compliance_policies": [
-#             {
-#                 "OneDriveLocation":  ["All"],
-#                 "Workload":  "",
-#                 "Name":  "Default Office 365 DLP policy",
-#                 "Mode": "Enable",
-#                 "Enabled": true
-#             }
-#         ]
-#     }
-
-#     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
-
-#     count(RuleOutput) == 1
-#     not RuleOutput[0].RequirementMet
-#     RuleOutput[0].ReportDetails == "No policy found that applies to OneDrive."
-# }
-
-# test_Teams_Correct if {
-#     PolicyId := "MS.DEFENDER.4.2v1"
-#     Requirement := "The custom policy SHOULD be applied in Teams"
-
-#     Output := tests with input as {
-#         "dlp_compliance_rules": [
-#             {
-#                 "ContentContainsSensitiveInformation":  [
-#                     {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"},
-#                     {"name":  "Credit Card Number"},
-#                     {"name":  "U.S. Social Security Number (SSN)"}
-#                 ],
-#                 "Name":  "Baseline Rule",
-# 	            "Disabled" : false,
-#                 "ParentPolicyName":  "Default Office 365 DLP policy",
-# 	            "BlockAccess":  true,
-#                 "BlockAccessScope":  "All",
-# 	            "NotifyUser":  [
-#                     "SiteAdmin",
-#                     "LastModifier",
-#                     "Owner"
-#                 ],
-# 	            "NotifyUserType":  "NotSet"
-#             }
-#         ],
-#         "dlp_compliance_policies": [
-#             {
-#                 "TeamsLocation":  ["All"],
-#                 "Workload":  "Teams",
-#                 "Name":  "Default Office 365 DLP policy",
-#                 "Mode": "Enable",
-#                 "Enabled": true
-#             }
-#         ]
-#     }
-
-#     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
-
-#     count(RuleOutput) == 1
-#     RuleOutput[0].RequirementMet
-#     RuleOutput[0].ReportDetails == "Requirement met"
-# }
-
-# test_TeamsLocation_Incorrect if {
-#     PolicyId := "MS.DEFENDER.4.2v1"
-#     Requirement := "The custom policy SHOULD be applied in Teams"
-
-#     Output := tests with input as {
-#         "dlp_compliance_rules": [
-#             {
-#                 "ContentContainsSensitiveInformation":  [
-#                     {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"},
-#                     {"name":  "Credit Card Number"},
-#                     {"name":  "U.S. Social Security Number (SSN)"}
-#                 ],
-#                 "Name":  "Baseline Rule",
-# 	            "Disabled" : false,
-#                 "ParentPolicyName":  "Default Office 365 DLP policy",
-# 	            "BlockAccess":  true,
-#                 "BlockAccessScope":  "All",
-# 	            "NotifyUser":  [
-#                     "SiteAdmin",
-#                     "LastModifier",
-#                     "Owner"
-#                 ],
-# 	            "NotifyUserType":  "NotSet"
-#             }
-#         ],
-#         "dlp_compliance_policies": [
-#             {
-#                 "TeamsLocation":  [""],
-#                 "Workload":  "Teams",
-#                 "Name":  "Default Office 365 DLP policy",
-#                 "Mode": "Enable",
-#                 "Enabled": true
-#             }
-#         ]
-#     }
-
-#     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
-
-#     count(RuleOutput) == 1
-#     not RuleOutput[0].RequirementMet
-#     RuleOutput[0].ReportDetails == "No policy found that applies to Teams."
-# }
-
-# test_Workload_Incorrect_V4 if {
-#     PolicyId := "MS.DEFENDER.4.2v1"
-#     Requirement := "The custom policy SHOULD be applied in Teams"
-
-#     Output := tests with input as {
-#         "dlp_compliance_rules": [
-#             {
-#                 "ContentContainsSensitiveInformation":  [
-#                     {"name":  "U.S. Individual Taxpayer Identification Number (ITIN)"},
-#                     {"name":  "Credit Card Number"},
-#                     {"name":  "U.S. Social Security Number (SSN)"}
-#                 ],
-#                 "Name":  "Baseline Rule",
-# 	            "Disabled" : false,
-#                 "ParentPolicyName":  "Default Office 365 DLP policy",
-# 	            "BlockAccess":  true,
-#                 "BlockAccessScope":  "All",
-# 	            "NotifyUser":  [
-#                     "SiteAdmin",
-#                     "LastModifier",
-#                     "Owner"
-#                 ],
-# 	            "NotifyUserType":  "NotSet"
-#             }
-#         ],
-#         "dlp_compliance_policies": [
-#             {
-#                 "TeamsLocation":  ["All"],
-#                 "Workload":  "",
-#                 "Name":  "Default Office 365 DLP policy",
-#                 "Mode": "Enable",
-#                 "Enabled": true
-#             }
-#         ]
-#     }
-
-#     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
-
-#     count(RuleOutput) == 1
-#     not RuleOutput[0].RequirementMet
-#     RuleOutput[0].ReportDetails == "No policy found that applies to Teams."
-# }
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "No enabled policy found that applies to: Devices, Exchange, OneDrive, SharePoint, Teams"
+}
 
 #
 # Policy 3

--- a/Testing/Unit/Rego/Defender/DefenderConfig_04_test.rego
+++ b/Testing/Unit/Rego/Defender/DefenderConfig_04_test.rego
@@ -716,8 +716,8 @@ test_ContentContainsSensitiveInformation_Incorrect_V1 if {
     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
 
     count(RuleOutput) == 1
-    Not RuleOutput[0].RequirementMet
-    RuleOutput[0].ReportDetails == "1 rule(s) found that do(es) not block access or associated policy not set to enforce block action: Baseline Rule"
+    RuleOutput[0].RequirementMet
+    RuleOutput[0].ReportDetails == "Requirement not met"
 }
 #--
 # test_BlockAccess_Correct if {

--- a/Testing/Unit/Rego/Defender/DefenderConfig_04_test.rego
+++ b/Testing/Unit/Rego/Defender/DefenderConfig_04_test.rego
@@ -716,7 +716,7 @@ test_ContentContainsSensitiveInformation_Incorrect_V1 if {
     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
 
     count(RuleOutput) == 1
-    Not RuleOutput[0].RequirementMet
+    not RuleOutput[0].RequirementMet
     RuleOutput[0].ReportDetails == "1 rule(s) found that do(es) not block access or associated policy not set to enforce block action: Baseline Rule"
 }
 #--


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->
Updates in this pull request align the old Defender Data Loss Prevention (DLP) assessment code with the new baseline version policies and ensures the new assessment only produces a single test result for each policy statement rather than multiple results per statement.  These updates include:

- Merged results for MS.DEFENDER.4.1v1 to ensure minimum sensitive info types are included in the DLP custom policy
- Merged results for MS.DEFENDER4.2v1 that checks that custom policy includes desired locations
- Adding support to MS.DEFENDER4.2v1 to check that the Device location is included as per policy update
- Adding initial support for detection of sensitive info types in advanced DLP rules in policies
  Note: Full support for advanced rules is beyond scope of this PR and captures as TODO in #575 

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->
Changes were necessary to support updated architecture that expects a single test result for each unique baseline policy ID rather than multiple results.  Updates were also required to support baseline policy updates that expanded recommended DLP locations and due to a M365 Defender change that defaults to advanced rule syntax for new custom policies that changed the internal representation of sensitive info types included in the rules causing false negatives without an update.

Closes #491 
Closes #492 
Closes #404

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Validated that all unit tests pass for Defender 4 policies.  Ran `Invoke-Scuba -p defender` against G5/GCC high tenants and ensured results matched those expected for DLP policies.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [X] All relevant type-of-change labels have been added.
- [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [X] Tests have been added and/or modified to cover the changes in this PR.
- [X] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Rebase current branch with parent branch to sync changes

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Verify that no additional tests failed after the merge on parent branch
