### PR TITLE
MS.TEAMS.5.* hotfix

### DIFF
--- a/Rego/TeamsConfig.rego
+++ b/Rego/TeamsConfig.rego
@@ -426,7 +426,7 @@ tests[{
 #--
 PoliciesBlockingDefaultApps[Policy.Identity] {
 	Policy := input.app_policies[_]
-	Policy.DefaultCatalogAppsType != "BlockedAppList"
+	Policy.DefaultCatalogAppsType == "BlockedAppList"
 }
 
 tests[{
@@ -448,7 +448,7 @@ tests[{
 #--
 PoliciesAllowingGlobalApps[Policy.Identity] {
 	Policy := input.app_policies[_]
-	Policy.GlobalCatalogAppsType != "BlockedAppList"
+	Policy.GlobalCatalogAppsType == "BlockedAppList"
 }
 
 tests[{
@@ -471,7 +471,7 @@ tests[{
 # 
 PoliciesAllowingCustomApps[Policy.Identity] {
 	Policy := input.app_policies[_]
-	Policy.PrivateCatalogAppsType != "BlockedAppList"
+	Policy.PrivateCatalogAppsType == "BlockedAppList"
 }
 tests[{
 	"PolicyId" : "MS.TEAMS.5.3v1",

--- a/Testing/Unit/Rego/Teams/TeamsConfig_05-test.rego
+++ b/Testing/Unit/Rego/Teams/TeamsConfig_05-test.rego
@@ -11,7 +11,7 @@ test_DefaultCatalogAppsType_Correct_V1 if {
         "app_policies": [
             {
                 "Identity": "Global",
-                "DefaultCatalogAppsType": "BlockedAppList"
+                "DefaultCatalogAppsType": "AllowedAppList"
             }
         ]
     }
@@ -30,7 +30,7 @@ test_DefaultCatalogAppsType_Correct_V2 if {
         "app_policies": [
             {
                 "Identity": "Tag:TestPolicy",
-                "DefaultCatalogAppsType": "BlockedAppList"
+                "DefaultCatalogAppsType": "AllowedAppList"
             }
         ]
     }
@@ -49,7 +49,7 @@ test_DefaultCatalogAppsType_Incorrect_V1 if {
         "app_policies": [
             {
                 "Identity": "Global",
-                "DefaultCatalogAppsType": "AllowedAppList"
+                "DefaultCatalogAppsType": "BlockedAppList"
             }
         ]
     }
@@ -68,7 +68,7 @@ test_DefaultCatalogAppsType_Incorrect_V2 if {
         "app_policies": [
             {
                 "Identity": "Tag:TestPolicy",
-                "DefaultCatalogAppsType": "AllowedAppList"
+                "DefaultCatalogAppsType": "BlockedAppList"
             }
         ]
     }
@@ -87,15 +87,15 @@ test_DefaultCatalogAppsType_Multiple if {
         "app_policies": [
             {
                 "Identity": "Global",
-                "DefaultCatalogAppsType": "BlockedAppList"
+                "DefaultCatalogAppsType": "AllowedAppList"
             },
             {
                 "Identity": "Tag:TestPolicy1",
-                "DefaultCatalogAppsType": "AllowedAppList"
+                "DefaultCatalogAppsType": "BlockedAppList"
             },
             {
                 "Identity": "Tag:TestPolicy2",
-                "DefaultCatalogAppsType": "AllowedAppList"
+                "DefaultCatalogAppsType": "BlockedAppList"
             }
         ]
     }
@@ -120,7 +120,7 @@ test_GlobalCatalogAppsType_Correct_V1 if {
         "app_policies": [
             {
                 "Identity": "Global",
-                "GlobalCatalogAppsType": "BlockedAppList"
+                "GlobalCatalogAppsType": "AllowedAppList"
             }
         ]
     }
@@ -139,7 +139,7 @@ test_GlobalCatalogAppsType_Correct_V2 if {
         "app_policies": [
             {
                 "Identity": "Tag:TestPolicy",
-                "GlobalCatalogAppsType": "BlockedAppList"
+                "GlobalCatalogAppsType": "AllowedAppList"
             }
         ]
     }
@@ -158,7 +158,7 @@ test_GlobalCatalogAppsType_Incorrect_V1 if {
         "app_policies": [
             {
                 "Identity": "Global",
-                "GlobalCatalogAppsType": "AllowedAppList"
+                "GlobalCatalogAppsType": "BlockedAppList"
             }
         ]
     }
@@ -177,7 +177,7 @@ test_GlobalCatalogAppsType_Incorrect_V2 if {
         "app_policies": [
             {
                 "Identity": "Tag:TestPolicy",
-                "GlobalCatalogAppsType": "AllowedAppList"
+                "GlobalCatalogAppsType": "BlockedAppList"
             }
         ]
     }
@@ -196,15 +196,15 @@ test_GlobalCatalogAppsType_Multiple if {
         "app_policies": [
             {
                 "Identity": "Global",
-                "GlobalCatalogAppsType": "AllowedAppList"
-            },
-            {
-                "Identity": "Tag:TestPolicy1",
                 "GlobalCatalogAppsType": "BlockedAppList"
             },
             {
-                "Identity": "Tag:TestPolicy2",
+                "Identity": "Tag:TestPolicy1",
                 "GlobalCatalogAppsType": "AllowedAppList"
+            },
+            {
+                "Identity": "Tag:TestPolicy2",
+                "GlobalCatalogAppsType": "BlockedAppList"
             }
         ]
     }
@@ -229,7 +229,7 @@ test_PrivateCatalogAppsType_Correct_V1 if {
         "app_policies": [
             {
                 "Identity": "Global",
-                "PrivateCatalogAppsType": "BlockedAppList"
+                "PrivateCatalogAppsType": "AllowedAppList"
             }
         ]
     }
@@ -248,7 +248,7 @@ test_PrivateCatalogAppsType_Correct_V2 if {
         "app_policies": [
             {
                 "Identity": "Tag:TestPolicy",
-                "PrivateCatalogAppsType": "BlockedAppList"
+                "PrivateCatalogAppsType": "AllowedAppList"
             }
         ]
     }
@@ -267,7 +267,7 @@ test_PrivateCatalogAppsType_Incorrect_V1 if {
         "app_policies": [
             {
                 "Identity": "Global",
-                "PrivateCatalogAppsType": "AllowedAppList"
+                "PrivateCatalogAppsType": "BlockedAppList"
             }
         ]
     }
@@ -286,7 +286,7 @@ test_PrivateCatalogAppsType_Incorrect_V2 if {
         "app_policies": [
             {
                 "Identity": "Tag:TestPolicy",
-                "PrivateCatalogAppsType": "AllowedAppList"
+                "PrivateCatalogAppsType": "BlockedAppList"
             }
         ]
     }
@@ -305,15 +305,15 @@ test_PrivateCatalogAppsType_Multiple if {
         "app_policies": [
             {
                 "Identity": "Global",
-                "PrivateCatalogAppsType": "AllowedAppList"
-            },
-            {
-                "Identity": "Tag:TestPolicy1",
                 "PrivateCatalogAppsType": "BlockedAppList"
             },
             {
-                "Identity": "Tag:TestPolicy2",
+                "Identity": "Tag:TestPolicy1",
                 "PrivateCatalogAppsType": "AllowedAppList"
+            },
+            {
+                "Identity": "Tag:TestPolicy2",
+                "PrivateCatalogAppsType": "BlockedAppList"
             }
         ]
     }


### PR DESCRIPTION

## 🗣 Description ##
Currently the code shows the opposite result of what we want. 
Modified rego and unit test so that MS.TEAMS.5.1v1, MS.TEAMS.5.2v1, MS.TEAMS.5.3v1 
- passes when the Global is set to "Block all" or "Allow specific apps"
- fails when the Global is set to "Allow all" or "Block specific apps"

## 💭 Motivation and context ##

closes #506 
closes #483 

## 🧪 Testing ##

Test all four cases "Block all", "Allow specific apps", "Allow all" and "Block specific apps" to make sure it works properly. 

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Revert dependencies to default branches.
- [x] Finalize version.

## ✅ Post-merge checklist ##

- [ ] Create a release.
