### PR TITLE
Update defender baseline to include missing license requirement for section 1

### DIFF
--- a/baselines/defender.md
+++ b/baselines/defender.md
@@ -110,7 +110,7 @@ Sensitive accounts SHALL be added to Defender for Office 365 Protection in the s
 
 ### License Requirements
 
-- N/A
+- Defender for Office 365 capabilities require Defender for Office 365 Plan 1 or 2. These are included with E5 and G5 and are available as add-ons for E3 and G3.
 
 ### Implementation
 

--- a/baselines/defender.md
+++ b/baselines/defender.md
@@ -319,7 +319,7 @@ Safe attachments SHOULD be enabled for SharePoint, OneDrive, and Microsoft Teams
 
 ### License Requirements
 
-- Requires Defender for Office 365 Plan 1 or 2. These are included with
+- Safe attachments require Defender for Office 365 Plan 1 or 2. These are included with
   E5 and G5 and are available as add-ons for E3 and G3.
 
 ### Implementation


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Upon review of the Defender Rego code I discovered that a few of the policies 1.1, 1.3 and 1.5 rely on the Get-ATPProtectionPolicyRule cmdlet which requires the Defender for Office Plan 1 license. This needs to be reflected in the baseline license requirements section.

## 💭 Motivation and context ##

Change required to reflect the dependency of the Get-ATPProtectionPolicyRule cmdlet required for section one policies in the baseline.

Closes #598

## 🧪 Testing ##

N/A

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
