### PR TITLE
Update Service Principal documentation in the README

### DIFF
--- a/PowerShell/ScubaGear/Modules/Connection/Connection.psm1
+++ b/PowerShell/ScubaGear/Modules/Connection/Connection.psm1
@@ -59,7 +59,6 @@ function Connect-Tenant {
                        'User.Read.All',
                        'Policy.Read.All',
                        'Organization.Read.All',
-                       'UserAuthenticationMethod.Read.All',
                        'RoleManagement.Read.Directory',
                        'GroupMember.Read.All',
                        'Directory.Read.All'

--- a/README.md
+++ b/README.md
@@ -153,28 +153,28 @@ The following API permissions are required for Microsoft Graph Powershell:
 - SecurityEvents.Read.All
 
 ### Application Service Principal Permissions & Setup
-Below are the permissions for running the tool non-interactively. The minimum API permissions for all products are listed in the image below. The minimum user role permissions that need to be granted to the application are listed in the *Assign the following Azure AD roles to the service principal* subsection.
+The minimum API permissions & user roles for each product that need to be assigned to the application are listed in the table below.
 
-This [video](https://www.youtube.com/watch?v=GyF8HV_35GA) provides a good tutorial for creating an application manually in the Azure Portal. Augment the API permissions and replace the role assignment instructions in the video with the permissions listed below.
+| Product                  | API Permissions                                      | Azure AD Roles                   |
+|--------------------------|------------------------------------------------------|----------------------------------|
+| Azure Active Directory   | Directory.Read.All, GroupMember.Read.All,            |                                  |
+|                          | Organization.Read.All, Policy.Read.All,              |                                  |
+|                          | RoleManagement.Read.Directory, User.Read.All,        |                                  |
+|                          | UserAuthenticationMethod.Read.All                    |                                  |
+| Defender for Office 365  | Exchange.ManageAsApp                                 | Global Reader                    |
+| Exchange Online          | Exchange.ManageAsApp                                 | Global Reader                    |
+| Power Platform           |                                                      | Power Platform Administrator     |
+| SharePoint Online        | Site.FullControl.All                                 | Global Reader                    |
+| Microsoft Teams          |                                                      | Global Reader                    |
 
-
-**API Permissions**
-![ScubaGear App Service Principal API Permissions](/images/appserviceprincipal-api-permssions.png)
-
+This [video](https://www.youtube.com/watch?v=GyF8HV_35GA) provides a good tutorial for creating an application manually in the Azure Portal. Augment the API permissions and replace the role assignment instructions in the video with the permissions listed above.
 
 **Power Platform**
-
-For Power Platform, the application must be [manually registered to Power Platform via interactive authentication](https://learn.microsoft.com/en-us/power-platform/admin/powershell-create-service-principal#registering-an-admin-management-application).
+For Power Platform, the application must be [manually registered to Power Platform via interactive authentication with a administrative account](https://learn.microsoft.com/en-us/power-platform/admin/powershell-create-service-principal#registering-an-admin-management-application).
 ```powershell
 Add-PowerAppsAccount -Endpoint prod -TenantID $tenantId # use -Endpoint usgov for gcc tenants
-New-PowerAppManagementApp -ApplicationId $appId # Must be run from a Power Platform Adminstrator or Global Adminstrator account
+New-PowerAppManagementApp -ApplicationId $appId # Must be run from a Power Platform Administrator or Global Adminstrator account
 ```
-
-
-**Assign the following Azure AD roles to the service principal**
-- SharePoint Administrator
-- Global Reader
-
 
 **Certificate store notes**
 - Power Platform has a [hardcoded expectation](https://github.com/microsoft/Microsoft365DSC/issues/2781) that the certificate is located in "Cert:\CurrentUser\My".

--- a/README.md
+++ b/README.md
@@ -150,10 +150,9 @@ The following API permissions are required for Microsoft Graph Powershell:
 - RoleManagement.Read.Directory
 - User.Read.All
 - UserAuthenticationMethod.Read.All
-- SecurityEvents.Read.All
 
-### Application Service Principal Permissions & Setup
-The minimum API permissions & user roles for each product that need to be assigned to the application are listed in the table below.
+### Service Principal Application Permissions & Setup
+The minimum API permissions & user roles for each product that need to be assigned to a service principal application for ScubaGear app-only authentication are listed in the table below.
 
 | Product                  | API Permissions                                      | Azure AD Roles                   |
 |--------------------------|------------------------------------------------------|----------------------------------|
@@ -163,22 +162,23 @@ The minimum API permissions & user roles for each product that need to be assign
 |                          | UserAuthenticationMethod.Read.All                    |                                  |
 | Defender for Office 365  | Exchange.ManageAsApp                                 | Global Reader                    |
 | Exchange Online          | Exchange.ManageAsApp                                 | Global Reader                    |
-| Power Platform           |                                                      | Power Platform Administrator     |
-| SharePoint Online        | Site.FullControl.All                                 | Global Reader                    |
+| Power Platform           | [See Power Platform App Registration]()                                              |                                  |
+| SharePoint Online        | Sites.FullControl.All                                 | Global Reader                    |
 | Microsoft Teams          |                                                      | Global Reader                    |
 
 This [video](https://www.youtube.com/watch?v=GyF8HV_35GA) provides a good tutorial for creating an application manually in the Azure Portal. Augment the API permissions and replace the role assignment instructions in the video with the permissions listed above.
 
-**Power Platform**
-For Power Platform, the application must be [manually registered to Power Platform via interactive authentication with a administrative account](https://learn.microsoft.com/en-us/power-platform/admin/powershell-create-service-principal#registering-an-admin-management-application).
+#### Power Platform APP Registration
+
+For Power Platform, the application must be [manually registered to Power Platform via interactive authentication with a administrative account](https://learn.microsoft.com/en-us/power-platform/admin/powershell-create-service-principal#registering-an-admin-management-application). See [Limitations of Service Principals](https://learn.microsoft.com/en-us/power-platform/admin/powershell-create-service-principal#limitations-of-service-principals) for how applications are treated within Power Platform.
 ```powershell
 Add-PowerAppsAccount -Endpoint prod -TenantID $tenantId # use -Endpoint usgov for gcc tenants
-New-PowerAppManagementApp -ApplicationId $appId # Must be run from a Power Platform Administrator or Global Adminstrator account
+New-PowerAppManagementApp -ApplicationId $appId # Must be run from a Power Platform Administrator or Global Administrator account
 ```
 
 **Certificate store notes**
 - Power Platform has a [hardcoded expectation](https://github.com/microsoft/Microsoft365DSC/issues/2781) that the certificate is located in "Cert:\CurrentUser\My".
-- MS Graph seems to also have an expectation that the certificate at least be located in one of the local client's certificate store(s).
+- MS Graph has an expectation that the certificate at least be located in one of the local client's certificate store(s).
 
 > **Notes**: Only authentication via `CertificateThumbprint` is currently supported. We will also be supporting automated app registration in a later release.
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,6 @@ The following API permissions are required for Microsoft Graph Powershell:
 - Policy.Read.All
 - RoleManagement.Read.Directory
 - User.Read.All
-- UserAuthenticationMethod.Read.All
 
 ### Service Principal Application Permissions & Setup
 The minimum API permissions & user roles for each product that need to be assigned to a service principal application for ScubaGear app-only authentication are listed in the table below.
@@ -159,7 +158,7 @@ The minimum API permissions & user roles for each product that need to be assign
 | Azure Active Directory   | Directory.Read.All, GroupMember.Read.All,            |                                  |
 |                          | Organization.Read.All, Policy.Read.All,              |                                  |
 |                          | RoleManagement.Read.Directory, User.Read.All,        |                                  |
-|                          | UserAuthenticationMethod.Read.All                    |                                  |
+|                          |                    |                                  |
 | Defender for Office 365  | Exchange.ManageAsApp                                 | Global Reader                    |
 | Exchange Online          | Exchange.ManageAsApp                                 | Global Reader                    |
 | Power Platform           | [See Power Platform App Registration](#power-platform-app-registration)                                                |                                  |

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ The minimum API permissions & user roles for each product that need to be assign
 
 This [video](https://www.youtube.com/watch?v=GyF8HV_35GA) provides a good tutorial for creating an application manually in the Azure Portal. Augment the API permissions and replace the role assignment instructions in the video with the permissions listed above.
 
-#### Power Platform APP Registration
+#### Power Platform App Registration
 For Power Platform, the application must be [manually registered to Power Platform via interactive authentication](https://learn.microsoft.com/en-us/power-platform/admin/powershell-create-service-principal#registering-an-admin-management-application) with a administrative account. See [Limitations of Service Principals](https://learn.microsoft.com/en-us/power-platform/admin/powershell-create-service-principal#limitations-of-service-principals) for how applications are treated within Power Platform.
 ```powershell
 Add-PowerAppsAccount -Endpoint prod -TenantID $tenantId # use -Endpoint usgov for gcc tenants

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ The minimum API permissions & user roles for each product that need to be assign
 |                          | UserAuthenticationMethod.Read.All                    |                                  |
 | Defender for Office 365  | Exchange.ManageAsApp                                 | Global Reader                    |
 | Exchange Online          | Exchange.ManageAsApp                                 | Global Reader                    |
-| Power Platform           | [See Power Platform App Registration]()                                              |                                  |
+| Power Platform           | [See Power Platform App Registration](#power-platform-app-registration)                                              |                                  |
 | SharePoint Online        | Sites.FullControl.All                                 | Global Reader                    |
 | Microsoft Teams          |                                                      | Global Reader                    |
 
@@ -177,7 +177,7 @@ New-PowerAppManagementApp -ApplicationId $appId # Must be run from a Power Platf
 ```
 
 **Certificate store notes**
-- Power Platform has a [hardcoded expectation](https://github.com/microsoft/Microsoft365DSC/issues/2781) that the certificate is located in "Cert:\CurrentUser\My".
+- Power Platform has a [hardcoded expectation](https://github.com/microsoft/Microsoft365DSC/issues/2781) that the certificate is located in `Cert:\CurrentUser\My`.
 - MS Graph has an expectation that the certificate at least be located in one of the local client's certificate store(s).
 
 > **Notes**: Only authentication via `CertificateThumbprint` is currently supported. We will also be supporting automated app registration in a later release.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,6 @@ The minimum API permissions & user roles for each product that need to be assign
 This [video](https://www.youtube.com/watch?v=GyF8HV_35GA) provides a good tutorial for creating an application manually in the Azure Portal. Augment the API permissions and replace the role assignment instructions in the video with the permissions listed above.
 
 #### Power Platform APP Registration
-
 For Power Platform, the application must be [manually registered to Power Platform via interactive authentication with a administrative account](https://learn.microsoft.com/en-us/power-platform/admin/powershell-create-service-principal#registering-an-admin-management-application). See [Limitations of Service Principals](https://learn.microsoft.com/en-us/power-platform/admin/powershell-create-service-principal#limitations-of-service-principals) for how applications are treated within Power Platform.
 ```powershell
 Add-PowerAppsAccount -Endpoint prod -TenantID $tenantId # use -Endpoint usgov for gcc tenants

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The minimum API permissions & user roles for each product that need to be assign
 This [video](https://www.youtube.com/watch?v=GyF8HV_35GA) provides a good tutorial for creating an application manually in the Azure Portal. Augment the API permissions and replace the role assignment instructions in the video with the permissions listed above.
 
 #### Power Platform APP Registration
-For Power Platform, the application must be [manually registered to Power Platform via interactive authentication with a administrative account](https://learn.microsoft.com/en-us/power-platform/admin/powershell-create-service-principal#registering-an-admin-management-application). See [Limitations of Service Principals](https://learn.microsoft.com/en-us/power-platform/admin/powershell-create-service-principal#limitations-of-service-principals) for how applications are treated within Power Platform.
+For Power Platform, the application must be [manually registered to Power Platform via interactive authentication](https://learn.microsoft.com/en-us/power-platform/admin/powershell-create-service-principal#registering-an-admin-management-application) with a administrative account. See [Limitations of Service Principals](https://learn.microsoft.com/en-us/power-platform/admin/powershell-create-service-principal#limitations-of-service-principals) for how applications are treated within Power Platform.
 ```powershell
 Add-PowerAppsAccount -Endpoint prod -TenantID $tenantId # use -Endpoint usgov for gcc tenants
 New-PowerAppManagementApp -ApplicationId $appId # Must be run from a Power Platform Administrator or Global Administrator account

--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ The minimum API permissions & user roles for each product that need to be assign
 |                          | UserAuthenticationMethod.Read.All                    |                                  |
 | Defender for Office 365  | Exchange.ManageAsApp                                 | Global Reader                    |
 | Exchange Online          | Exchange.ManageAsApp                                 | Global Reader                    |
-| Power Platform           | [See Power Platform App Registration](#power-platform-app-registration)                                              |                                  |
-| SharePoint Online        | Sites.FullControl.All                                 | Global Reader                    |
+| Power Platform           | [See Power Platform App Registration](#power-platform-app-registration)                                                |                                  |
+| SharePoint Online        | Sites.FullControl.All, Directory.Read.All            |                                  |
 | Microsoft Teams          |                                                      | Global Reader                    |
 
 This [video](https://www.youtube.com/watch?v=GyF8HV_35GA) provides a good tutorial for creating an application manually in the Azure Portal. Augment the API permissions and replace the role assignment instructions in the video with the permissions listed above.


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->
This PR simply updates service principal permissions documentation in the README after doing some extensive testing. 
A few surprises for 2 of the products. Notes below. 

### Notable Notes:
#### SharePoint
- These Graph API Permissions are not needed by PnP PowerShell. Unsure why they are listed in this [documentation](https://microsoft365dsc.com/resources/sharepoint/SPOSite/#application-permissions). Removed them from our list of needed SP permissions.
  - `Application.Read.All`
  - `Domain.ReadAll`
- SharePoint needs both the `Sites.FullControl.All` SharePoint API permission AND the `Global Reader`  or `Directory.Read.All`  to function. 
  - This is because `Get-MgBetaOrganization` which is used for SharePoint authentication requires either the `Global Reader` role or the `Directory.Read.All` API permission to execute.
  -  `Sites.FullControl.All` gives both Read and write permissions to the application, which is unfortunate when all we need is read.
#### Teams
- Contrary to the [documentation](https://learn.microsoft.com/en-us/microsoftteams/teams-powershell-application-authentication#setup-application-based-authentication) the Graph API permission `Organization.Read.All` is not enough enough for  *-Cs cmdlets to function with app-only auth. 
- In fact, none of those permissions in the documentation were sufficient for Teams after testing.
- Only the `Global Reader` role is both necessary and required for Teams to function correctly. 


## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->
Closes #271 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Created a separate service principal for each product and would create/delete the application as more permissions were added. This is because there is some latency when a permission is assigned or removed. 
## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->


## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
