### PR TITLE
Update unused function parameters with wildcard variables

### DIFF
--- a/Rego/DefenderConfig.rego
+++ b/Rego/DefenderConfig.rego
@@ -41,7 +41,7 @@ GenerateArrayString(Array, CustomString) := Output if {
     Output := trim(concat(" ", [Length, concat(" ", [CustomString, ArrayString])]), " ")
 }
 
-CustomizeError(Message, CustomString) := Message if {
+CustomizeError(Message, _) := Message if {
     # If the message reports success, don't apply the custom
     # error message
     Message == ReportDetailsBoolean(true)
@@ -59,7 +59,7 @@ ApplyLicenseWarning(Message) := Message if {
     input.defender_license == true
 }
 
-ApplyLicenseWarning(Message) := concat("", [ReportDetailsBoolean(false), LicenseWarning]) if {
+ApplyLicenseWarning(_) := concat("", [ReportDetailsBoolean(false), LicenseWarning]) if {
     # If a defender license is not present, assume failure and
     # replace the message with the warning
     input.defender_license == false
@@ -695,7 +695,7 @@ DefenderErrorMessage4_3(Rules) := GenerateArrayString(Rules, ErrorMessage) if {
     ErrorMessage := "rule(s) found that do(es) not block access or associated policy not set to enforce block action:"
 }
 
-DefenderErrorMessage4_3(Rules) := ErrorMessage if {
+DefenderErrorMessage4_3(_) := ErrorMessage if {
     count(SensitiveInfoPolicies) == 0
     ErrorMessage := "No DLP policy matching all types found for evaluation."
 }
@@ -732,7 +732,7 @@ DefenderErrorMessage4_4(Rules) := GenerateArrayString(Rules, ErrorMessage) if {
     ErrorMessage := "rule(s) found that do(es) not notify at least one user:"
 }
 
-DefenderErrorMessage4_4(Rules) := ErrorMessage if {
+DefenderErrorMessage4_4(_) := ErrorMessage if {
     count(SensitiveInfoPolicies) == 0
     ErrorMessage := "No DLP policy matching all types found for evaluation."
 }

--- a/Rego/EXOConfig.rego
+++ b/Rego/EXOConfig.rego
@@ -7,7 +7,7 @@ import data.report.utils.ReportDetailsBoolean
 import data.report.utils.Description
 import data.report.utils.ReportDetailsString
 
-ReportDetailsArray(Status, Array1, Array2) := Detail if {
+ReportDetailsArray(Status, _, _) := Detail if {
     Status == true
     Detail := "Requirement met"
 }

--- a/Rego/PowerPlatformConfig.rego
+++ b/Rego/PowerPlatformConfig.rego
@@ -6,7 +6,7 @@ import data.report.utils.ReportDetailsBoolean
 import data.report.utils.Description
 import data.report.utils.ReportDetailsString
 
-ReportDetailsArray(Status, Array, String1) :=  Detail if {
+ReportDetailsArray(Status, _, _) :=  Detail if {
     Status == true
     Detail := "Requirement met"
 }

--- a/Rego/TeamsConfig.rego
+++ b/Rego/TeamsConfig.rego
@@ -13,7 +13,7 @@ import data.report.utils.Format
 import data.report.utils.ReportDetailsBoolean
 import data.report.utils.Description
 
-ReportDetailsArray(Status, Array, String1) := Detail if {
+ReportDetailsArray(Status, _, _) := Detail if {
     Status == true
     Detail := "Requirement met"
 }
@@ -358,7 +358,7 @@ ConfigsAllowingEmail[Policy.Identity] {
     Policy.AllowEmailIntoChannel == true
 }
 
-ReportDetails4_1(IsGCC, IsEnabled) := Description if {
+ReportDetails4_1(IsGCC, _) := Description if {
 	IsGCC == true
 	Description := "N/A: Feature is unavailable in GCC environments"
 }

--- a/Rego/Utils/ReportUtils.rego
+++ b/Rego/Utils/ReportUtils.rego
@@ -49,7 +49,7 @@ ReportDetailsBoolean(false) := "Requirement not met"
 Description(String1, String2, String3) := trim(concat(" ", [String1, concat(" ", [String2, String3])]), " ")
 
 #
-ReportDetailsString(Status, String) :=  Detail if {
+ReportDetailsString(Status, _) :=  Detail if {
     Status == true
     Detail := "Requirement met"
 }


### PR DESCRIPTION
## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

Rego compilation errors were being thrown due to unused function parameters. For each instance parameters were changed to the wildcard variable "_".


## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

Resolves issue #195, OPA versions 0.50+ introduce updates to strict mode checking for unused variables. For newer versions of OPA, ScubaGear's automated checks will fail preventing merges into main from happening. 

Although this PR addresses the strict mode errors in Rego policies, it does not address the OPA executable version downloaded in `OPA.ps1` or the version specified in Run OPA tests workflow, #593.


## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
 To test these changes: 

1. Go to OPA documentation, select the version you want to test, then download the executable
2. Run the OPA strict mode check 

```
.\opa_windows_amd64.exe check Rego Testing\Unit\Rego --strict
```
3. Repeat steps for other versions and rerun the strict mode check as needed 


<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Rebase feature branch against parent branch and make sure tests still pass
- [ ] Add comment ready for merge and mention the merge coordinator

