### PR TITLE
Fix versioned tag in URLs

### DIFF
--- a/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
+++ b/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
@@ -168,7 +168,7 @@ function New-Report {
         $Number = $BaselineName.ToUpper() + '-' + $BaselineGroup.GroupNumber
         $Name = $BaselineGroup.GroupName
         $GroupAnchor = New-MarkdownAnchor -GroupNumber $BaselineGroup.GroupNumber -GroupName $BaselineGroup.GroupName
-        $MarkdownLink = "<a class='control_group' href=`"$($ScubaGitHubUrl)/blob/$($SettingsExport.module_version)/baselines/$($BaselineName.ToLower()).md#$GroupAnchor`" target=`"_blank`">$Name</a>"
+        $MarkdownLink = "<a class='control_group' href=`"$($ScubaGitHubUrl)/blob/v$($SettingsExport.module_version)/baselines/$($BaselineName.ToLower()).md#$GroupAnchor`" target=`"_blank`">$Name</a>"
         $Fragments += $Fragment | ConvertTo-Html -PreContent "<h2>$Number $MarkdownLink</h2>" -Fragment
     }
 

--- a/Rego/Utils/ReportUtils.rego
+++ b/Rego/Utils/ReportUtils.rego
@@ -7,7 +7,7 @@ default BaselineVersion := "main"
 BaselineVersion := input.module_version
 
 # baselineVersion := "3.0.0." # Baseline version is pinned to a module version
-ScubaBaseUrl := sprintf("https://github.com/cisagov/ScubaGear/blob/%v/baselines/", [BaselineVersion])
+ScubaBaseUrl := sprintf("https://github.com/cisagov/ScubaGear/blob/v%v/baselines/", [BaselineVersion])
 
 ################
 # Helper functions for this file


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->
This request updates both the Rego report utility `ScubaBaseURL` variable and PowerShell HTML report variable `MarkdownLink` in `CreateReport.psm1` to generate versioned URLs to GitHub using the 'v' prefix in front of the release version of the tool.


## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->
Without this fix and with the existing build and sign release action, ScubaGear version tags include the 'v' prefix.  However, URLs in Rego and the HTML report are built without the prefix.  As a result, URLs will be broken and incorrect and users will not be directed to the correct website location for baseline references in test results and reports.

Closes #650 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Ran `Invoke-Scuba -p *` to generate a full set of reports and validated that URL references to the baselines in report details contains the proper 'v' prefix.


## 📷 Screenshots (if appropriate) ##

Generated HTML report with URL preview shows report for MS.AAD.6.1v1 correctly generated a URL link with version as `v1.0.0`.

![Screenshot 2023-11-08 at 4 35 56 PM](https://github.com/cisagov/ScubaGear/assets/108814318/156d2fc5-e4d2-4e3b-8752-1908e79484b5)


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Rebase branch against parent branch as needed prior to merge

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Validate parent branch tests still pass
