### PR TITLE
add progress bar for OPA download

### DIFF
--- a/OPA.ps1
+++ b/OPA.ps1
@@ -1,4 +1,3 @@
-#Requires -Version 5.1
 <#
     .SYNOPSIS
         This script installs the required OPA executable used by the
@@ -39,7 +38,7 @@ try {
         $downloadedBytes = $downloadedBytes + $count
         Write-Progress -activity "Downloading file '$($InstallUrl.split('/') | Select-Object -Last 1)'" -status "Downloaded ($([System.Math]::Floor($downloadedBytes/1024))K of $($totalLength)K): " -PercentComplete ((([System.Math]::Floor($downloadedBytes/1024)) / $totalLength)  * 100)
     }
-    Write-Progress -activity "Finished downloading file '$($InstallUrl.split('/') | Select-Object -Last 1)'" 
+    Write-Progress -activity "Finished downloading file '$($InstallUrl.split('/') | Select-Object -Last 1)'"
 }
 catch {
     Write-Error "An error has occurred: Unable to download OPA executable. To try manually downloading, see details in README under 'Download the required OPA executable'"

--- a/OPA.ps1
+++ b/OPA.ps1
@@ -19,21 +19,17 @@ $OPAExe = "opa_windows_amd64.exe"
 $InstallUrl = "https://openpolicyagent.org/downloads/v$($ExpectedVersion)/$OPAExe"
 $OutFile=(Join-Path (Get-Location).Path $InstallUrl.SubString($InstallUrl.LastIndexOf('/')))
 $ExpectedHash ="5D71028FED935DC98B9D69369D42D2C03CE84A7720D61ED777E10AAE7528F399"
-
+$Display = "Downloading OPA executable"
 # Download files
 try {
-    Write-Information "Downloading $InstallUrl"
-    $WebClient = New-Object System.Net.WebClient
-    $WebClient.DownloadFile($InstallUrl, $OutFile)
+    Start-BitsTransfer -Source $InstallUrl -Destination $OutFile -DisplayName $Display
     Write-Information ""
     Write-Information "`nDownload of `"$OutFile`" finished."
 }
 catch {
     Write-Error "An error has occurred: Unable to download OPA executable. To try manually downloading, see details in README under 'Download the required OPA executable'"
 }
-finally {
-    $WebClient.Dispose()
-}
+
 
 # Hash checks
 if ((Get-FileHash .\opa_windows_amd64.exe).Hash -eq $ExpectedHash)

--- a/OPA.ps1
+++ b/OPA.ps1
@@ -18,36 +18,16 @@ $OPAExe = "opa_windows_amd64.exe"
 $InstallUrl = "https://openpolicyagent.org/downloads/v$($ExpectedVersion)/$OPAExe"
 $OutFile=(Join-Path (Get-Location).Path $InstallUrl.SubString($InstallUrl.LastIndexOf('/')))
 $ExpectedHash ="5D71028FED935DC98B9D69369D42D2C03CE84A7720D61ED777E10AAE7528F399"
+$Display = "Downloading OPA executable"
 
 # Download files
 try {
-    $uri = New-Object "System.Uri" "$InstallUrl"
-    $request = [System.Net.HttpWebRequest]::Create($uri)
-    $request.set_Timeout(15000) #15 second timeout
-    $response = $request.GetResponse()
-    $totalLength = [System.Math]::Floor($response.get_ContentLength()/1024)
-    $responseStream = $response.GetResponseStream()
-    $targetStream = New-Object -TypeName System.IO.FileStream -ArgumentList $OutFile, Create
-    $buffer = new-object byte[] 15000KB
-    $count = $responseStream.Read($buffer,0,$buffer.length)
-    $downloadedBytes = $count
-    while ($count -gt 0)
-    {
-        $targetStream.Write($buffer, 0, $count)
-        $count = $responseStream.Read($buffer,0,$buffer.length)
-        $downloadedBytes = $downloadedBytes + $count
-        Write-Progress -activity "Downloading file '$($InstallUrl.split('/') | Select-Object -Last 1)'" -status "Downloaded ($([System.Math]::Floor($downloadedBytes/1024))K of $($totalLength)K): " -PercentComplete ((([System.Math]::Floor($downloadedBytes/1024)) / $totalLength)  * 100)
-    }
-    Write-Progress -activity "Finished downloading file '$($InstallUrl.split('/') | Select-Object -Last 1)'"
-}
+    Start-BitsTransfer -Source $InstallUrl -Destination $OutFile -DisplayName $Display
+    Write-Information ""
+    Write-Information "`nDownload of `"$OutFile`" finished."
 catch {
-    Write-Error "An error has occurred: Unable to download OPA executable. To try manually downloading, see details in README under 'Download the required OPA executable'"
-}
-finally {
-    $targetStream.Flush()
-    $targetStream.Close()
-    $targetStream.Dispose()
-    $responseStream.Dispose()
+    $msg = $Error[0].Exception.Message
+    Write-Error "Unable to download OPA executable. To try manually downloading, see details in README under 'Download the required OPA executable'. Error: $msg"
 }
 
 # Hash checks

--- a/OPA.ps1
+++ b/OPA.ps1
@@ -19,17 +19,37 @@ $OPAExe = "opa_windows_amd64.exe"
 $InstallUrl = "https://openpolicyagent.org/downloads/v$($ExpectedVersion)/$OPAExe"
 $OutFile=(Join-Path (Get-Location).Path $InstallUrl.SubString($InstallUrl.LastIndexOf('/')))
 $ExpectedHash ="5D71028FED935DC98B9D69369D42D2C03CE84A7720D61ED777E10AAE7528F399"
-$Display = "Downloading OPA executable"
+
 # Download files
 try {
-    Start-BitsTransfer -Source $InstallUrl -Destination $OutFile -DisplayName $Display
-    Write-Information ""
-    Write-Information "`nDownload of `"$OutFile`" finished."
+    $uri = New-Object "System.Uri" "$InstallUrl"
+    $request = [System.Net.HttpWebRequest]::Create($uri)
+    $request.set_Timeout(15000) #15 second timeout
+    $response = $request.GetResponse()
+    $totalLength = [System.Math]::Floor($response.get_ContentLength()/1024)
+    $responseStream = $response.GetResponseStream()
+    $targetStream = New-Object -TypeName System.IO.FileStream -ArgumentList $OutFile, Create
+    $buffer = new-object byte[] 15000KB
+    $count = $responseStream.Read($buffer,0,$buffer.length)
+    $downloadedBytes = $count
+    while ($count -gt 0)
+    {
+        $targetStream.Write($buffer, 0, $count)
+        $count = $responseStream.Read($buffer,0,$buffer.length)
+        $downloadedBytes = $downloadedBytes + $count
+        Write-Progress -activity "Downloading file '$($InstallUrl.split('/') | Select-Object -Last 1)'" -status "Downloaded ($([System.Math]::Floor($downloadedBytes/1024))K of $($totalLength)K): " -PercentComplete ((([System.Math]::Floor($downloadedBytes/1024)) / $totalLength)  * 100)
+    }
+    Write-Progress -activity "Finished downloading file '$($InstallUrl.split('/') | Select-Object -Last 1)'" 
 }
 catch {
     Write-Error "An error has occurred: Unable to download OPA executable. To try manually downloading, see details in README under 'Download the required OPA executable'"
 }
-
+finally {
+    $targetStream.Flush()
+    $targetStream.Close()
+    $targetStream.Dispose()
+    $responseStream.Dispose()
+}
 
 # Hash checks
 if ((Get-FileHash .\opa_windows_amd64.exe).Hash -eq $ExpectedHash)


### PR DESCRIPTION
## 🗣 Description ##

This update adds progress bar to download OPA

## 💭 Motivation and context ##

An enhancement to the current OPA.ps1 as well as Setup.ps1
closes #197 

## 🧪 Testing ##

Run OPA.ps1  and/or Setup.ps1 and check if there is an download progress bar

-->

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

