### PR TITLE
Implement MS.AAD.6.1v1 check user password expiration 

### DIFF
--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -101,6 +101,9 @@ function Export-AADProvider {
     # Read the properties and relationships of an authentication method policy
     $AuthenticationMethodPolicy = ConvertTo-Json @($Tracker.TryCommand("Get-MgBetaPolicyAuthenticationMethodPolicy"))
 
+    # 6.1
+    $DomainSettings = ConvertTo-Json @($Tracker.TryCommand("Get-MgBetaDomain"))
+
     $SuccessfulCommands = ConvertTo-Json @($Tracker.GetSuccessfulCommands())
     $UnSuccessfulCommands = ConvertTo-Json @($Tracker.GetUnSuccessfulCommands())
 
@@ -115,6 +118,7 @@ function Export-AADProvider {
     "service_plans": $ServicePlans,
     "directory_settings": $DirectorySettings,
     "authentication_method": $AuthenticationMethodPolicy,
+    "domain_settings": $DomainSettings,
     "aad_successful_commands": $SuccessfulCommands,
     "aad_unsuccessful_commands": $UnSuccessfulCommands,
 "@

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -636,7 +636,7 @@ tests contains {
     # Then check if at least 1 or more domains with user passwords set to expire exist
     DescriptionString := "domain(s) failed"
     Conditions := [count(UserPasswordsSetToExpire) == 0, count(UserPasswordsSetToNotExpire) > 0]
-    Status := count([Condition | some Condition in Conditions; Condition == false]) == 0
+    Status := count(FilterArray(Conditions, false)) == 0
 }
 #--
 

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -19,6 +19,7 @@ import data.utils.aad.HasAcceptableMFA
 import data.utils.aad.PolicyConditionsMatch
 import data.utils.aad.CAPLINK
 import data.utils.aad.DomainReportDetails
+import data.utils.aad.INT_MAX
 
 
 #############
@@ -611,8 +612,6 @@ tests contains {
 #--
 
 # User passwords are set to not expire if they equal INT_MAX
-INT_MAX := 2147483647
-
 UserPasswordsSetToNotExpire contains Domain.Id if {
     some Domain in input.domain_settings
     Domain.PasswordValidityPeriodInDays == INT_MAX

--- a/PowerShell/ScubaGear/Rego/Utils/AAD.rego
+++ b/PowerShell/ScubaGear/Rego/Utils/AAD.rego
@@ -174,7 +174,7 @@ HasAcceptableMFA(Policy) := true if {
 
 DomainReportDetails(Status, _, _) := Description if {
     Status == true
-    Description := "Requirement met"
+    Description := PASS
 }
 
 DomainReportDetails(Status, Array, DescriptionString) := Description if {

--- a/PowerShell/ScubaGear/Rego/Utils/AAD.rego
+++ b/PowerShell/ScubaGear/Rego/Utils/AAD.rego
@@ -164,3 +164,18 @@ HasAcceptableMFA(Policy) := true if {
     Count(Strengths - AcceptableMFA) == 0
     Count(Strengths) > 0
 } else := false
+
+
+############################################################################
+# The report formatting functions below are for the MS.AAD.6.1v1 policy    #
+############################################################################
+
+DomainReportDetails(Status, _, _) := Description if {
+    Status == true
+    Description := "Requirement met"
+}
+
+DomainReportDetails(Status, Array, DescriptionString) := Description if {
+    Status == false
+    Description := ReportFullDetailsArray(Array, DescriptionString)
+}

--- a/PowerShell/ScubaGear/Rego/Utils/AAD.rego
+++ b/PowerShell/ScubaGear/Rego/Utils/AAD.rego
@@ -24,6 +24,8 @@ P2WARNINGSTR :=
 
 CAPLINK := "<a href='#caps'>View all CA policies</a>."
 
+INT_MAX := 2147483647
+
 ########################################
 # Specific AAD Report Details Function #
 ########################################

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_06_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_06_test.rego
@@ -1,19 +1,88 @@
 package aad_test
 import future.keywords
 import data.aad
-import data.utils.report.NotCheckedDetails
 import data.utils.key.TestResult
 
 
 #
 # Policy MS.AAD.6.1v1
 #--
-test_NotImplemented_Correct if {
-    PolicyId := "MS.AAD.6.1v1"
 
-    Output := aad.tests with input as { }
+# User passwords are set to not expire if they equal INT_MAX
+INT_MAX := 2147483647
 
-    ReportDetailString := NotCheckedDetails(PolicyId)
-    TestResult(PolicyId, Output, ReportDetailString, false) == true
+test_PasswordValidityPeriodInDays_Correct if {
+    Output := aad.tests with input as { 
+        "domain_settings" : [
+            {
+                "Id" : "test.url.com",
+                "PasswordValidityPeriodInDays" : INT_MAX,
+                "IsVerified" : true
+            },
+            {
+                "Id" : "test1.url.com",
+                "PasswordValidityPeriodInDays" : INT_MAX,
+                "IsVerified" : true
+            },
+            {   
+                "Id" : "test2.url.com",
+                "PasswordValidityPeriodInDays" : INT_MAX,
+                "IsVerified" : true
+            }
+        ]
+    }
+
+    ReportDetailString := "Requirement met"
+    TestResult("MS.AAD.6.1v1", Output, ReportDetailString, true) == true
+}
+
+test_PasswordValidityPeriodInDays_Incorrect if {
+    Output := aad.tests with input as { 
+        "domain_settings" : [
+            {
+                "Id" : "test.url.com",
+                "PasswordValidityPeriodInDays" : 0,
+                "IsVerified" : true
+            },
+            {
+                "Id" : "test1.url.com",
+                "PasswordValidityPeriodInDays" : 0,
+                "IsVerified" : true
+            },
+            {   
+                "Id" : "test2.url.com",
+                "PasswordValidityPeriodInDays" : INT_MAX,
+                "IsVerified" : true
+            }
+        ]
+    }
+
+    ReportDetailString := "2 domain(s) failed:<br/>test.url.com, test1.url.com"
+    TestResult("MS.AAD.6.1v1", Output, ReportDetailString, false) == true
+}
+
+test_IsVerified_Correct if {
+    Output := aad.tests with input as { 
+        "domain_settings" : [
+            {
+                "Id" : "test.url.com",
+                "PasswordValidityPeriodInDays" : 0,
+                "IsVerified" : null
+            },
+            {
+                "Id" : "test1.url.com",
+                "PasswordValidityPeriodInDays" : 0,
+                "IsVerified" : false
+            },
+            {   
+                "Id" : "test2.url.com",
+                "PasswordValidityPeriodInDays" : INT_MAX,
+                "IsVerified" : true
+            }
+        ]
+    }
+
+    ReportDetailString := "Requirement met"
+    TestResult("MS.AAD.6.1v1", Output, ReportDetailString, true) == true
 }
 #--

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_06_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_06_test.rego
@@ -2,14 +2,12 @@ package aad_test
 import future.keywords
 import data.aad
 import data.utils.key.TestResult
+import data.utils.aad.INT_MAX
 
 
 #
 # Policy MS.AAD.6.1v1
 #--
-
-# User passwords are set to not expire if they equal INT_MAX
-INT_MAX := 2147483647
 
 test_PasswordValidityPeriodInDays_Correct if {
     Output := aad.tests with input as { 

--- a/Testing/Functional/Products/TestPlans/aad.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/aad.testplan.yaml
@@ -589,10 +589,14 @@ TestPlan:
         ExpectedResult: true
 
   - PolicyId: MS.AAD.6.1v1
-    TestDriver: RunScuba
+    TestDriver: RunCached
     Tests:
-      - TestDescription: MS.AAD.6.1v1 Not Checked
-        Preconditions: []
+      - TestDescription: MS.AAD.6.1v1 Compliant case - User passwords set to not expire for all domains
+        Preconditions: 
+          - Command: UpdateProviderExport
+            Splat: 
+              Updates: 
+                
         Postconditions: []
         IsNotChecked: true
         ExpectedResult: false

--- a/Testing/Functional/Products/TestPlans/aad.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/aad.testplan.yaml
@@ -591,15 +591,57 @@ TestPlan:
   - PolicyId: MS.AAD.6.1v1
     TestDriver: RunCached
     Tests:
-      - TestDescription: MS.AAD.6.1v1 Compliant case - User passwords set to not expire for all domains
+      - TestDescription: MS.AAD.6.1v1 Compliant case - User passwords for all domains are set to not expire
         Preconditions: 
           - Command: UpdateProviderExport
             Splat: 
-              Updates: 
-                
+              updates: 
+                domain_settings:
+                  - Id: test.url.com
+                    PasswordValidityPeriodInDays: 2147483647
+                    IsVerified: true
+                  - Id: test1.url.com
+                    PasswordValidityPeriodInDays: 2147483647
+                    IsVerified: true
+                  - Id: test2.url.com
+                    PasswordValidityPeriodInDays: 2147483647
+                    IsVerified: true
         Postconditions: []
-        IsNotChecked: true
+        ExpectedResult: true
+      - TestDescription: MS.AAD.6.1v1 Non-Compliant case - User passwords for some domains are set to expire
+        Preconditions: 
+          - Command: UpdateProviderExport
+            Splat: 
+              updates: 
+                domain_settings:
+                  - Id: test.url.com
+                    PasswordValidityPeriodInDays: 0
+                    IsVerified: true
+                  - Id: test1.url.com
+                    PasswordValidityPeriodInDays: 0
+                    IsVerified: true
+                  - Id: test2.url.com
+                    PasswordValidityPeriodInDays: 2147483647
+                    IsVerified: true
+        Postconditions: []
         ExpectedResult: false
+      - TestDescription: MS.AAD.6.1v1 Compliant case - User passwords shall be verified
+        Preconditions: 
+          - Command: UpdateProviderExport
+            Splat: 
+              updates: 
+                domain_settings:
+                  - Id: test.url.com
+                    PasswordValidityPeriodInDays: 0
+                    IsVerified: null
+                  - Id: test1.url.com
+                    PasswordValidityPeriodInDays: 0
+                    IsVerified: false
+                  - Id: test2.url.com
+                    PasswordValidityPeriodInDays: 2147483647
+                    IsVerified: true
+        Postconditions: []
+        ExpectedResult: true
 
   - PolicyId: MS.AAD.7.1v1
     TestDriver: RunCached


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->
- Import AAD settings from Get-MgBetaDomain in `ExportAADProvider.psm1`, 
- Write unit tests to indicate correct and incorrect values in `AADConfig_06_test.rego`, write functional tests in `aad.testplan.yaml`
- Implement MS.AAD.6.1v1 policy in `AADconfig.rego`.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->
 
MS.AAD.6.1v1 was marked as not implementable, but it can now be checked with `Get-MgDomain`.

This resolves #398 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

From the Testing directory, run `.\RunUnitTests.ps1 -p aad -c 6`

To run functional tests, setup $TestContainers array, setup $PesterConfig to filter based on MS.AAD.6.1v1 tag, then run the following: 

`$Config = New-PesterConfiguration -Hashtable $PesterConfig`
`Invoke-Pester -Configuration $Config`

Run the tool against commercial, gcc, and gcchigh environments 

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.




