### PR TITLE
Add configfilepath option to the invoke runcached option for running scubagear

### DIFF
--- a/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfig.psm1
+++ b/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfig.psm1
@@ -38,7 +38,7 @@ class ScubaConfig {
         }
 
         if (-Not $this.Configuration.OPAPath){
-            $this.Configuration.OPAPath = (Join-Path -Path $PSScriptRoot -ChildPath "..\..\..")
+            $this.Configuration.OPAPath =(Join-Path -Path $env:USERPROFILE -ChildPath ".scubagear\Tools")
         }
 
         if (-Not $this.Configuration.LogIn){

--- a/Testing/Functional/RegoCachedProviderTesting.ps1
+++ b/Testing/Functional/RegoCachedProviderTesting.ps1
@@ -80,7 +80,7 @@ if ($PSCmdlet.ParameterSetName -eq 'Configuration'){
         Write-Error -Message "The config file failed to load: $ConfigFilePath"
     }
     else {
-        $ScubaConfig = [ScubaConfig]::GetInstance().Configuration
+        $RunCachedParams = [ScubaConfig]::GetInstance().Configuration
     }
 }
 

--- a/Testing/Functional/RegoCachedProviderTesting.ps1
+++ b/Testing/Functional/RegoCachedProviderTesting.ps1
@@ -18,7 +18,7 @@ param (
     [Parameter(Mandatory = $false, ParameterSetName = 'Default')]
     [Parameter(Mandatory = $false, ParameterSetName = 'Configuration')]
     [ValidateNotNullOrEmpty()]
-    [ValidateSet("teams", "exo", "defender", "aad", "powerplatform", "sharepoint", "onedrive", '*', IgnoreCase = $false)]
+    [ValidateSet("teams", "exo", "defender", "aad", "powerplatform", "sharepoint", '*', IgnoreCase = $false)]
     [string[]]
     $ProductNames = '*', # The specific products that you want the tool to assess.
 

--- a/Testing/Functional/RegoCachedProviderTesting.ps1
+++ b/Testing/Functional/RegoCachedProviderTesting.ps1
@@ -76,10 +76,12 @@ $RunCachedParams = New-Object -Type PSObject -Property $CachedParams
 
 # Loads and executes parameters from a Configuration file
 if ($PSCmdlet.ParameterSetName -eq 'Configuration'){
+#change [ScubaConfig]
     if (-Not ([ScubaConfig]::GetInstance().LoadConfig($ConfigFilePath))){
         Write-Error -Message "The config file failed to load: $ConfigFilePath"
     }
     else {
+#change [ScubaConfig]
         $RunCachedParams = [ScubaConfig]::GetInstance().Configuration
     }
 }

--- a/Testing/Functional/RegoCachedProviderTesting.ps1
+++ b/Testing/Functional/RegoCachedProviderTesting.ps1
@@ -62,7 +62,7 @@ param (
 )
 
 $M365Environment = "gcc"
-$OPAPath = "./" # Path to OPA Executable
+$OPAPath = (Join-Path -Path $env:USERPROFILE -ChildPath ".scubagear\Tools")# Path to OPA Executable
 
 if ($PSCmdlet.ParameterSetName -eq 'Default'){
     $RunCachedParams = @{


### PR DESCRIPTION
## 🗣 Description ##

add configfilepath option to the invoke runcached option for running scubagear

## 💭 Motivation and context ##

closes #653 

## 🧪 Testing ##

Specify custom parameters in the local JSON and YAML formatted configuration files that match the exclusions in the local ProviderSettingsExport.json and run Invoke-RunCached -ConfigFilePath to verify the exclusions show as a pass in the output report.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

- [ ] Create a release.
