### PR TITLE
Add PIM for groups support to AAD provider

### DIFF
--- a/PowerShell/ScubaGear/Modules/Connection/Connection.psm1
+++ b/PowerShell/ScubaGear/Modules/Connection/Connection.psm1
@@ -61,7 +61,8 @@ function Connect-Tenant {
                        'Organization.Read.All',
                        'RoleManagement.Read.Directory',
                        'GroupMember.Read.All',
-                       'Directory.Read.All'
+                       'Directory.Read.All',
+                       'PrivilegedEligibilitySchedule.Read.AzureADGroup'
                    )
                    $GraphParams = @{
                        'ErrorAction' = 'Stop';

--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -315,7 +315,7 @@ function Get-PrivilegedUser {
                         $PIMEligibleUserId = $GroupMember.PrincipalId
 
                         # If the user's data has not been fetched from graph, go get it
-                        if (-Not $PrivilegedUsers.ContainsKey($PIMEligibleUserId)) {
+                        if (-not $PrivilegedUsers.ContainsKey($PIMEligibleUserId)) {
                             $AADUser = Get-MgBetaUser -ErrorAction Stop -UserId $PIMEligibleUserId
                             $PrivilegedUsers[$PIMEligibleUserId] = @{"DisplayName"=$AADUser.DisplayName; "OnPremisesImmutableId"=$AADUser.OnPremisesImmutableId; "roles"=@()}
                         }

--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -238,7 +238,7 @@ function Get-PrivilegedUser {
                         $PIMEligibleUserId = $GroupMember.PrincipalId
 
                         # If the user's data has not been fetched from graph, go get it
-                        if (-Not $PrivilegedUsers.ContainsKey($PIMEligibleUserId)) {
+                        if (-not $PrivilegedUsers.ContainsKey($PIMEligibleUserId)) {
                             $AADUser = Get-MgBetaUser -ErrorAction Stop -UserId $PIMEligibleUserId
                             $PrivilegedUsers[$PIMEligibleUserId] = @{"DisplayName"=$AADUser.DisplayName; "OnPremisesImmutableId"=$AADUser.OnPremisesImmutableId; "roles"=@()}
                         }

--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -203,7 +203,7 @@ function Get-PrivilegedUser {
                 }
                 # If the current role has not already been added to the user's roles array then add the role
                 if ($PrivilegedUsers[$User.Id].roles -notcontains $Role.DisplayName) {
-                    $PrivilegedUsers[$User.Id].roles += $Role.DisplayName   
+                    $PrivilegedUsers[$User.Id].roles += $Role.DisplayName
                 }
             }
 

--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -196,25 +196,56 @@ function Get-PrivilegedUser {
             $Objecttype = $User.AdditionalProperties."@odata.type" -replace "#microsoft.graph."
 
             if ($Objecttype -eq "user") {
+                # If the user's data has not been fetched from graph, go get it
                 if (-Not $PrivilegedUsers.ContainsKey($User.Id)) {
                     $AADUser = Get-MgBetaUser -ErrorAction Stop -UserId $User.Id
                     $PrivilegedUsers[$AADUser.Id] = @{"DisplayName"=$AADUser.DisplayName; "OnPremisesImmutableId"=$AADUser.OnPremisesImmutableId; "roles"=@()}
                 }
-                $PrivilegedUsers[$User.Id].roles += $Role.DisplayName
+                # If the current role has not already been added to the user's roles array then add the role
+                if ($PrivilegedUsers[$User.Id].roles -notcontains $Role.DisplayName) {
+                    $PrivilegedUsers[$User.Id].roles += $Role.DisplayName   
+                }
             }
 
             elseif ($Objecttype -eq "group") {
                 # In this context $User.Id is a group identifier
-                $GroupMembers = Get-MgBetaGroupMember -All -ErrorAction Stop -GroupId $User.Id
+                $GroupId = $User.Id
+                # Get all of the group members that are Active assigned to the current role
+                $GroupMembers = Get-MgBetaGroupMember -All -ErrorAction Stop -GroupId $GroupId
 
                 foreach ($GroupMember in $GroupMembers) {
                     $Membertype = $GroupMember.AdditionalProperties."@odata.type" -replace "#microsoft.graph."
                     if ($Membertype -eq "user") {
+                        # If the user's data has not been fetched from graph, go get it
                         if (-Not $PrivilegedUsers.ContainsKey($GroupMember.Id)) {
                             $AADUser = Get-MgBetaUser -ErrorAction Stop -UserId $GroupMember.Id
                             $PrivilegedUsers[$AADUser.Id] = @{"DisplayName"=$AADUser.DisplayName; "OnPremisesImmutableId"=$AADUser.OnPremisesImmutableId; "roles"=@()}
                         }
-                        $PrivilegedUsers[$GroupMember.Id].roles += $Role.DisplayName
+                        # If the current role has not already been added to the user's roles array then add the role
+                        if ($PrivilegedUsers[$GroupMember.Id].roles -notcontains $Role.DisplayName) {
+                            $PrivilegedUsers[$GroupMember.Id].roles += $Role.DisplayName
+                        }
+                    }
+                }
+
+                # If the premium license for PIM is there, process the users that are "member" of the PIM group as Eligible
+                if ($TenantHasPremiumLicense) {
+                    # Get the users that are assigned to the PIM group as Eligible members
+                    $PIMGroupMembers = Get-MgBetaIdentityGovernancePrivilegedAccessGroupEligibilityScheduleInstance -All -ErrorAction Stop -Filter "groupId eq '$GroupId'"
+                    foreach ($GroupMember in $PIMGroupMembers) {
+                        # If the user is not a member of the PIM group (i.e. they are an owner) then skip them
+                        if ($GroupMember.AccessId -ne "member") { continue }
+                        $PIMEligibleUserId = $GroupMember.PrincipalId
+
+                        # If the user's data has not been fetched from graph, go get it
+                        if (-Not $PrivilegedUsers.ContainsKey($PIMEligibleUserId)) {
+                            $AADUser = Get-MgBetaUser -ErrorAction Stop -UserId $PIMEligibleUserId
+                            $PrivilegedUsers[$PIMEligibleUserId] = @{"DisplayName"=$AADUser.DisplayName; "OnPremisesImmutableId"=$AADUser.OnPremisesImmutableId; "roles"=@()}
+                        }
+                        # If the current role has not already been added to the user's roles array then add the role
+                        if ($PrivilegedUsers[$PIMEligibleUserId].roles -notcontains $Role.DisplayName) {
+                            $PrivilegedUsers[$PIMEligibleUserId].roles += $Role.DisplayName
+                        }
                     }
                 }
             }
@@ -237,11 +268,15 @@ function Get-PrivilegedUser {
                 try {
                     $UserType = "user"
 
+                    # If the user's data has not been fetched from graph, go get it
                     if (-Not $PrivilegedUsers.ContainsKey($UserObjectId)) {
                         $AADUser = Get-MgBetaUser -ErrorAction Stop -Filter "Id eq '$UserObjectId'"
                         $PrivilegedUsers[$AADUser.Id] = @{"DisplayName"=$AADUser.DisplayName; "OnPremisesImmutableId"=$AADUser.OnPremisesImmutableId; "roles"=@()}
                     }
-                    $PrivilegedUsers[$UserObjectId].roles += $Role.DisplayName
+                    # If the current role has not already been added to the user's roles array then add the role
+                    if ($PrivilegedUsers[$UserObjectId].roles -notcontains $Role.DisplayName) {
+                        $PrivilegedUsers[$UserObjectId].roles += $Role.DisplayName
+                    }
                 }
                 # Catch the specific error which indicates Get-MgBetaUser does not find the user, therefore it is a group
                 catch {
@@ -253,17 +288,40 @@ function Get-PrivilegedUser {
                     }
                 }
 
-                # This if statement handles when the object eligible assigned is a Group
+                # This if statement handles when the object eligible assigned to the current role is a Group
                 if ($UserType -eq "group") {
+                    # Process the the users that are directly assigned to the group (not through PIM groups)
                     $GroupMembers = Get-MgBetaGroupMember -All -ErrorAction Stop -GroupId $UserObjectId
                     foreach ($GroupMember in $GroupMembers) {
                         $Membertype = $GroupMember.AdditionalProperties."@odata.type" -replace "#microsoft.graph."
                         if ($Membertype -eq "user") {
+                            # If the user's data has not been fetched from graph, go get it
                             if (-Not $PrivilegedUsers.ContainsKey($GroupMember.Id)) {
                                 $AADUser = Get-MgBetaUser -ErrorAction Stop -UserId $GroupMember.Id
                                 $PrivilegedUsers[$AADUser.Id] = @{"DisplayName"=$AADUser.DisplayName; "OnPremisesImmutableId"=$AADUser.OnPremisesImmutableId; "roles"=@()}
                             }
-                            $PrivilegedUsers[$GroupMember.Id].roles += $Role.DisplayName
+                            # If the current role has not already been added to the user's roles array then add the role
+                            if ($PrivilegedUsers[$GroupMember.Id].roles -notcontains $Role.DisplayName) {
+                                $PrivilegedUsers[$GroupMember.Id].roles += $Role.DisplayName
+                            }
+                        }
+                    }
+
+                    # Get the users that are assigned to the PIM group as Eligible members
+                    $PIMGroupMembers = Get-MgBetaIdentityGovernancePrivilegedAccessGroupEligibilityScheduleInstance -All -ErrorAction Stop -Filter "groupId eq '$UserObjectId'"
+                    foreach ($GroupMember in $PIMGroupMembers) {
+                        # If the user is not a member of the PIM group (i.e. they are an owner) then skip them
+                        if ($GroupMember.AccessId -ne "member") { continue }
+                        $PIMEligibleUserId = $GroupMember.PrincipalId
+
+                        # If the user's data has not been fetched from graph, go get it
+                        if (-Not $PrivilegedUsers.ContainsKey($PIMEligibleUserId)) {
+                            $AADUser = Get-MgBetaUser -ErrorAction Stop -UserId $PIMEligibleUserId
+                            $PrivilegedUsers[$PIMEligibleUserId] = @{"DisplayName"=$AADUser.DisplayName; "OnPremisesImmutableId"=$AADUser.OnPremisesImmutableId; "roles"=@()}
+                        }
+                        # If the current role has not already been added to the user's roles array then add the role
+                        if ($PrivilegedUsers[$PIMEligibleUserId].roles -notcontains $Role.DisplayName) {
+                            $PrivilegedUsers[$PIMEligibleUserId].roles += $Role.DisplayName
                         }
                     }
                 }
@@ -329,3 +387,4 @@ function Get-PrivilegedRole {
 
     $AADRoles
 }
+

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ The following API permissions are required for Microsoft Graph Powershell:
 - Policy.Read.All
 - RoleManagement.Read.Directory
 - User.Read.All
+- PrivilegedEligibilitySchedule.Read.AzureADGroup
 
 ### Service Principal Application Permissions & Setup
 The minimum API permissions & user roles for each product that need to be assigned to a service principal application for ScubaGear app-only authentication are listed in the table below.

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ The minimum API permissions & user roles for each product that need to be assign
 | Azure Active Directory   | Directory.Read.All, GroupMember.Read.All,            |                                  |
 |                          | Organization.Read.All, Policy.Read.All,              |                                  |
 |                          | RoleManagement.Read.Directory, User.Read.All         |                                  |
+|                          | PrivilegedEligibilitySchedule.Read.AzureADGroup         |                                  |
 | Defender for Office 365  | Exchange.ManageAsApp                                 | Global Reader                    |
 | Exchange Online          | Exchange.ManageAsApp                                 | Global Reader                    |
 | Power Platform           | [See Power Platform App Registration](#power-platform-app-registration)|                |


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request modifies the AAD provider's Get-PrivilegedUser function to support getting user to PIM Group eligible assignments which is a current gap in our code. The PR also addresses a longstanding bug where users would sometimes get a duplicate role in their privileged_users node in the JSON. I also changed the connection module to request the required MS Graph permission scope since we are introducing a new cmdlet and I added the permission to the respective sections in the README file.

Closes #757
Closes #703

## 🧪 Testing ##

I tested this by creating test users and groups in all the test tenants that support PIM to ensure that the AAD code picks up the users that are assigned to a PIM group as Eligible. No updates were necessary to the functional tests because nothing changed in the JSON structure that would affect the Rego. I spoke with Crutch and we might want to add Powershell unit tests in the future that will exercise the code in the Get-PrivilegedUser and Get-PrivilegedRole functions of the AAD provider since those are what the types of changes associated with with this PR were associated with.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!* (kind of - i snuck in a separate bug fix)
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
