### PR TITLE
Remove DoH Retry for NXDOMAIN

### DIFF
--- a/PowerShell/ScubaGear/Modules/Providers/ExportEXOProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportEXOProvider.psm1
@@ -8,6 +8,7 @@ function Export-EXOProvider {
     #>
 
     [CmdletBinding()]
+    [OutputType([String])]
     param()
 
     # Manually importing the module name here to bypass cmdlet name conflicts
@@ -26,18 +27,18 @@ function Export-EXOProvider {
     MS.EXO.2.1v1 SPF
     #>
     $domains = $Tracker.TryCommand("Get-AcceptedDomain")
-    $SPFRecords = ConvertTo-Json @($Tracker.TryCommand("Get-ScubaSpfRecords", @{"Domains"=$domains})) -Depth 3
+    $SPFRecords = ConvertTo-Json @($Tracker.TryCommand("Get-ScubaSpfRecord", @{"Domains"=$domains})) -Depth 3
 
     <#
     MS.EXO.3.1v1 DKIM
     #>
     $DKIMConfig = ConvertTo-Json @($Tracker.TryCommand("Get-DkimSigningConfig"))
-    $DKIMRecords = ConvertTo-Json @($Tracker.TryCommand("Get-ScubaDkimRecords", @{"Domains"=$domains})) -Depth 3
+    $DKIMRecords = ConvertTo-Json @($Tracker.TryCommand("Get-ScubaDkimRecord", @{"Domains"=$domains})) -Depth 3
 
     <#
     MS.EXO.4.1v1 DMARC
     #>
-    $DMARCRecords = ConvertTo-Json @($Tracker.TryCommand("Get-ScubaDmarcRecords", @{"Domains"=$domains})) -Depth 3
+    $DMARCRecords = ConvertTo-Json @($Tracker.TryCommand("Get-ScubaDmarcRecord", @{"Domains"=$domains})) -Depth 3
 
     <#
     MS.EXO.5.1v1
@@ -198,6 +199,7 @@ function Invoke-RobustDnsTxt {
     Internal
     #>
     [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
     param (
         [Parameter(Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
@@ -356,7 +358,7 @@ function Invoke-RobustDnsTxt {
     }
 }
 
-function Get-ScubaSpfRecords {
+function Get-ScubaSpfRecord {
     <#
     .Description
     Gets the SPF records for each domain in $Domains
@@ -388,13 +390,13 @@ function Get-ScubaSpfRecords {
     }
 
     if ($NLowConf -gt 0) {
-        Write-Warning "Get-ScubaSpfRecords: for $($NLowConf) domain(s), the tradtional DNS queries returned an empty answer section and the DoH queries failed. Will assume SPF not configured, but can't guarantee that failure isn't due to something like split horizon DNS. See ProviderSettingsExport.json under 'spf_records' for more details."
+        Write-Warning "Get-ScubaSpfRecord: for $($NLowConf) domain(s), the tradtional DNS queries returned an empty answer section and the DoH queries failed. Will assume SPF not configured, but can't guarantee that failure isn't due to something like split horizon DNS. See ProviderSettingsExport.json under 'spf_records' for more details."
     }
     $DnsLog += $Response.LogEntries
     $SPFRecords
 }
 
-function Get-ScubaDkimRecords {
+function Get-ScubaDkimRecord {
     <#
     .Description
     Gets the DKIM records for each domain in $Domains
@@ -445,12 +447,12 @@ function Get-ScubaDkimRecords {
     }
 
     if ($NLowConf -gt 0) {
-        Write-Warning "Get-ScubaDkimRecords: for $($NLowConf) domain(s), the tradtional DNS queries returned an empty answer section and the DoH queries failed. Will assume DKIM not configured, but can't guarantee that failure isn't due to something like split horizon DNS. See ProviderSettingsExport.json under 'dkim_records' for more details."
+        Write-Warning "Get-ScubaDkimRecord: for $($NLowConf) domain(s), the tradtional DNS queries returned an empty answer section and the DoH queries failed. Will assume DKIM not configured, but can't guarantee that failure isn't due to something like split horizon DNS. See ProviderSettingsExport.json under 'dkim_records' for more details."
     }
     $DKIMRecords
 }
 
-function Get-ScubaDmarcRecords {
+function Get-ScubaDmarcRecord {
     <#
     .Description
     Gets the DMARC records for each domain in $Domains
@@ -496,7 +498,7 @@ function Get-ScubaDmarcRecords {
     }
 
     if ($NLowConf -gt 0) {
-        Write-Warning "Get-ScubaDmarcRecords: for $($NLowConf) domain(s), the tradtional DNS queries returned an empty answer section and the DoH queries failed. Will assume DMARC not configured, but can't guarantee that failure isn't due to something like split horizon DNS. See ProviderSettingsExport.json under 'dmarc_records' for more details."
+        Write-Warning "Get-ScubaDmarcRecord: for $($NLowConf) domain(s), the tradtional DNS queries returned an empty answer section and the DoH queries failed. Will assume DMARC not configured, but can't guarantee that failure isn't due to something like split horizon DNS. See ProviderSettingsExport.json under 'dmarc_records' for more details."
     }
     $DMARCRecords
 }

--- a/PowerShell/ScubaGear/Modules/Providers/ExportEXOProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportEXOProvider.psm1
@@ -214,7 +214,7 @@ function Invoke-RobustDnsTxt {
 
     $TryNumber = 0
     $Success = $false
-    $TradEmptyOrNx = $false
+    $TradEmpty = $false
     while ($TryNumber -lt $MaxTries) {
         $TryNumber += 1
         try {
@@ -242,22 +242,20 @@ function Invoke-RobustDnsTxt {
                     "query_method"="traditional";
                     "query_result"="Query returned 0 txt records"
                 }
-                $TradEmptyOrNx = $true
+                $TradEmpty = $true
                 break
             }
         }
         catch {
             if ($_.FullyQualifiedErrorId -eq "DNS_ERROR_RCODE_NAME_ERROR,Microsoft.DnsClient.Commands.ResolveDnsName") {
-                # The server returned NXDomain, no need to retry the traditional query, this was not
-                # a transient failure. Don't set $Success to $true though, as we want to retry this
-                # query from a public resolver, in case the internal DNS server returns a different
-                # answer than what is served to the public (i.e., split horizon DNS).
+                # The server returned NXDomain, no need to retry the traditional query or retry with
+                # DoH, this was not a transient failure. Break out of loop and set $Success to $true
                 $LogEntries += @{
                     "query_name"=$Qname;
                     "query_method"="traditional";
                     "query_result"="Query returned NXDomain"
                 }
-                $TradEmptyOrNx = $true
+                $Success = $True
                 break
             }
             else {
@@ -341,15 +339,15 @@ function Invoke-RobustDnsTxt {
     }
 
     # There are three possible outcomes of this function:
-    # - Full confidence: we know conclusively that the domain exists or not, either via an answer
-    # from traditional DNS, an answer from DoH, or NXDomain from DoH.
-    # - Medium confidence: domain likely doesn't exist, but there is some doubt (NXDomain from
+    # - Full confidence: we know conclusively that the domain exists or not, either via a non-empty
+    # answer from traditional DNS or an answer from DoH.
+    # - Medium confidence: domain likely doesn't exist, but there is some doubt (empty answer from
     # traditonal DNS and DoH failed).
     # No confidence: all queries failed. Throw an exception in this case.
     if ($Success) {
         @{"Answers" = $Answers; "HighConfidence" = $true; "LogEntries" = $LogEntries}
     }
-    elseif ($TradEmptyOrNx) {
+    elseif ($TradEmpty) {
         @{"Answers" = $Answers; "HighConfidence" = $false; "LogEntries" = $LogEntries}
     }
     else {
@@ -390,7 +388,7 @@ function Get-ScubaSpfRecords {
     }
 
     if ($NLowConf -gt 0) {
-        Write-Warning "Get-ScubaSpfRecords: for $($NLowConf) domain(s), the tradtional DNS queries returned either NXDomain or an empty answer section and the DoH queries failed. Will assume SPF not configured, but can't guarantee that failure isn't due to something like split horizon DNS. See ProviderSettingsExport.json under 'spf_records' for more details."
+        Write-Warning "Get-ScubaSpfRecords: for $($NLowConf) domain(s), the tradtional DNS queries returned an empty answer section and the DoH queries failed. Will assume SPF not configured, but can't guarantee that failure isn't due to something like split horizon DNS. See ProviderSettingsExport.json under 'spf_records' for more details."
     }
     $DnsLog += $Response.LogEntries
     $SPFRecords
@@ -447,7 +445,7 @@ function Get-ScubaDkimRecords {
     }
 
     if ($NLowConf -gt 0) {
-        Write-Warning "Get-ScubaDkimRecords: for $($NLowConf) domain(s), the tradtional DNS queries returned either NXDomain or an empty answer section and the DoH queries failed. Will assume DKIM not configured, but can't guarantee that failure isn't due to something like split horizon DNS. See ProviderSettingsExport.json under 'dkim_records' for more details."
+        Write-Warning "Get-ScubaDkimRecords: for $($NLowConf) domain(s), the tradtional DNS queries returned an empty answer section and the DoH queries failed. Will assume DKIM not configured, but can't guarantee that failure isn't due to something like split horizon DNS. See ProviderSettingsExport.json under 'dkim_records' for more details."
     }
     $DKIMRecords
 }
@@ -498,7 +496,7 @@ function Get-ScubaDmarcRecords {
     }
 
     if ($NLowConf -gt 0) {
-        Write-Warning "Get-ScubaDmarcRecords: for $($NLowConf) domain(s), the tradtional DNS queries returned either NXDomain or an empty answer section and the DoH queries failed. Will assume DMARC not configured, but can't guarantee that failure isn't due to something like split horizon DNS. See ProviderSettingsExport.json under 'dmarc_records' for more details."
+        Write-Warning "Get-ScubaDmarcRecords: for $($NLowConf) domain(s), the tradtional DNS queries returned an empty answer section and the DoH queries failed. Will assume DMARC not configured, but can't guarantee that failure isn't due to something like split horizon DNS. See ProviderSettingsExport.json under 'dmarc_records' for more details."
     }
     $DMARCRecords
 }

--- a/PowerShell/ScubaGear/Modules/Providers/ProviderHelpers/CommandTracker.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ProviderHelpers/CommandTracker.psm1
@@ -1,4 +1,4 @@
-Import-Module -Name $PSScriptRoot/../ExportEXOProvider.psm1 -Function Get-ScubaSpfRecords, Get-ScubaDkimRecords, Get-ScubaDmarcRecords
+Import-Module -Name $PSScriptRoot/../ExportEXOProvider.psm1 -Function Get-ScubaSpfRecord, Get-ScubaDkimRecord, Get-ScubaDmarcRecord
 Import-Module -Name $PSScriptRoot/../ExportAADProvider.psm1 -Function Get-PrivilegedRole, Get-PrivilegedUser
 
 class CommandTracker {

--- a/PowerShell/ScubaGear/Rego/EXOConfig.rego
+++ b/PowerShell/ScubaGear/Rego/EXOConfig.rego
@@ -81,7 +81,7 @@ DomainsWithoutSpf contains DNSResponse.domain if {
 tests contains {
     "PolicyId": "MS.EXO.2.2v1",
     "Criticality": "Shall",
-    "Commandlet": ["Get-ScubaSpfRecords", "Get-AcceptedDomain"],
+    "Commandlet": ["Get-ScubaSpfRecord", "Get-AcceptedDomain"],
     "ActualValue": Domains,
     "ReportDetails": ReportDetailsArray(Status, Domains, "agency domain(s) found in violation:"),
     "RequirementMet": Status
@@ -119,7 +119,7 @@ tests contains {
     "Criticality": "Should",
     "Commandlet": [
         "Get-DkimSigningConfig",
-        "Get-ScubaDkimRecords",
+        "Get-ScubaDkimRecord",
         "Get-AcceptedDomain"
     ],
     "ActualValue": [input.dkim_records, input.dkim_config],
@@ -154,7 +154,7 @@ tests contains {
     "PolicyId": "MS.EXO.4.1v1",
     "Criticality": "Shall",
     "Commandlet": [
-        "Get-ScubaDmarcRecords",
+        "Get-ScubaDmarcRecord",
         "Get-AcceptedDomain"
     ],
     "ActualValue": input.dmarc_records,
@@ -183,7 +183,7 @@ tests contains {
     "PolicyId": "MS.EXO.4.2v1",
     "Criticality": "Shall",
     "Commandlet": [
-        "Get-ScubaDmarcRecords",
+        "Get-ScubaDmarcRecord",
         "Get-AcceptedDomain"
     ],
     "ActualValue": input.dmarc_records,
@@ -223,7 +223,7 @@ tests contains {
     "PolicyId": "MS.EXO.4.3v1",
     "Criticality": "Shall",
     "Commandlet": [
-        "Get-ScubaDmarcRecords",
+        "Get-ScubaDmarcRecord",
         "Get-AcceptedDomain"
     ],
     "ActualValue": input.dmarc_records,
@@ -279,7 +279,7 @@ tests contains {
     "PolicyId": "MS.EXO.4.4v1",
     "Criticality": "Should",
     "Commandlet": [
-        "Get-ScubaDmarcRecords",
+        "Get-ScubaDmarcRecord",
         "Get-AcceptedDomain"
     ],
     "ActualValue": input.dmarc_records,


### PR DESCRIPTION
## 🗣 Description ##
- Adjust DNS query logic so that a retry over DoH is not triggered by NXDOMAIN.
- Make EXO PowerShell compliant with the new linter

## 💭 Motivation and context ##
Closes #764. Aims to reduce warning fatigue.

## 🧪 Testing ##
- Ran against the regular testing tenant, all results are correct
- Ran the `Invoke-RobustDnsTxt` function in one of the pilot environments that has the empty DNS response issue. Retries over DoH still occurred as designed.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.