### PR TITLE
Refactor escape sequence handling

### DIFF
--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -528,8 +528,14 @@ function Invoke-ProviderList {
                 $ProviderJSON
         }
 "@
-            $BaselineSettingsExport = $BaselineSettingsExport.replace("\`"", "'")
-            $BaselineSettingsExport = $BaselineSettingsExport.replace("\", "")
+
+            # Strip the character sequences that Rego tries to interpret as escape sequences,
+            # resulting in the error "unable to parse input: yaml: line x: found unknown escape character"
+            # "\/", ex: "\/Date(1705651200000)\/"
+            $BaselineSettingsExport = $BaselineSettingsExport.replace("\/", "")
+            # "\B", ex: "Removed an entry in Tenant Allow\Block List"
+            $BaselineSettingsExport = $BaselineSettingsExport.replace("\B", "/B")
+
             $FinalPath = Join-Path -Path $OutFolderPath -ChildPath "$($OutProviderFileName).json" -ErrorAction 'Stop'
             $BaselineSettingsExport | Set-Content -Path $FinalPath -Encoding $(Get-FileEncoding) -ErrorAction 'Stop'
             $ProdProviderFailed

--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -123,11 +123,6 @@ function Export-AADProvider {
     "aad_unsuccessful_commands": $UnSuccessfulCommands,
 "@
 
-    # We need to remove the backslash characters from the
-    # json, otherwise rego gets mad.
-    $json = $json.replace("\`"", "'")
-    $json = $json.replace("\", "")
-
     $json
 }
 

--- a/PowerShell/ScubaGear/Modules/Providers/ExportDefenderProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportDefenderProvider.psm1
@@ -143,9 +143,5 @@ function Export-DefenderProvider {
     "defender_unsuccessful_commands": $UnSuccessfulCommands,
 "@
 
-    # We need to remove the backslash characters from the
-    # json, otherwise rego gets mad.
-    $json = $json.replace("\`"", "'")
-    $json = $json.replace("\", "")
     $json
 }

--- a/PowerShell/ScubaGear/Modules/Providers/ExportEXOProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportEXOProvider.psm1
@@ -86,10 +86,6 @@ function Export-EXOProvider {
     "exo_unsuccessful_commands": $UnSuccessfulCommands,
 "@
 
-    # We need to remove the backslash characters from the
-    # json, otherwise rego gets mad.
-    $json = $json.replace("\`"", "'")
-    $json = $json.replace("\", "")
     $json
 }
 

--- a/PowerShell/ScubaGear/Modules/Providers/ExportPowerPlatformProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportPowerPlatformProvider.psm1
@@ -203,10 +203,6 @@ $($_)
     "powerplatform_unsuccessful_commands": $PowerPlatformUnSuccessfulCommands,
 "@
 
-    # We need to remove the backslash characters from the
-    # json, otherwise rego gets mad.
-    $json = $json.replace("\`"", "'")
-    $json = $json.replace("\", "")
     $json = $json -replace "[^\x00-\x7f]","" # remove all characters that are not utf-8
     $json
 }

--- a/PowerShell/ScubaGear/Modules/Providers/ExportSharePointProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportSharePointProvider.psm1
@@ -61,8 +61,5 @@ function Export-SharePointProvider {
     "SharePoint_unsuccessful_commands": $UnSuccessfulCommands,
 "@
 
-    # We need to remove the backslash characters from the json, otherwise rego gets mad.
-    $json = $json.replace("\`"", "'")
-    $json = $json.replace("\", "")
     $json
 }

--- a/PowerShell/ScubaGear/Modules/Providers/ExportTeamsProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportTeamsProvider.psm1
@@ -34,10 +34,6 @@ function Export-TeamsProvider {
     "teams_unsuccessful_commands": $TeamsUnSuccessfulCommands,
 "@
 
-    # We need to remove the backslash characters from the
-    # json, otherwise rego gets mad.
-    $json = $json.replace("\`"", "'")
-    $json = $json.replace("\", "")
     $json
 }
 


### PR DESCRIPTION
## 🗣 Description ##
This PR makes it so that ScubaGear no longer attempts to remove all backslashes, only the specific character sequences known to cause problems for Rego.

## 💭 Motivation and context ##
The provider output can include characters that Rego attempts to interpret as escape sequences (such as `\/`, which is output when you convert a date to json in PowerShell 5 (e.g., `Get-Date | Convert-ToJson`). These sequences result in the error "unable to parse input: yaml: line x: found unknown escape character." Previously, ScubaGear attempted to circumvent this issue by wholesale removing all backslashes from the resulting json. However, there are cases where that technique resulted in broken json (see #807 and #770). 

Closes #818.

## 🧪 Testing ##
Tested on the E5, G3, G5, and GCCHigh tenants, asserting that the number of tests passing/failing matched for both this branch and main. Also, engineered a problematic transport rule that would cause a parsing error as described in https://github.com/cisagov/ScubaGear/issues/807#issuecomment-1899765241. That rule causes the parsing error in main but not this branch.

## ✅ Pre-approval checklist ##
- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] PR passed smoke test check.
- [ ] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [ ] Resolved all merge conflicts on branch
- [ ] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
