### PR TITLE
Updating the test orchestrator for custom implementation reporting strings

### DIFF
--- a/PowerShell/ScubaGear/Rego/Utils/ReportDetails.rego
+++ b/PowerShell/ScubaGear/Rego/Utils/ReportDetails.rego
@@ -11,7 +11,7 @@ default BASELINEVERSION := "main"
 
 BASELINEVERSION := input.module_version
 
-SCUBABASEURL := sprintf("https://github.com/cisagov/ScubaGear/blob/%v/baselines/", [BASELINEVERSION])
+SCUBABASEURL := sprintf("https://github.com/cisagov/ScubaGear/blob/v%v/baselines/", [BASELINEVERSION])
 
 
 ########################
@@ -37,20 +37,23 @@ PolicyLink(PolicyId) := sprintf(
 
 # Not Implemented Report Details methods
 NotCheckedDetails(PolicyId) := sprintf(
-    "Not currently checked automatically. See %v for instructions on manual check",
+    concat(" ", [
+    "This product does not currently have the capability to check compliance for this policy.",
+    "See %v for instructions on manual check"
+    ]),
     [PolicyLink(PolicyId)]
 )
 
-# 3rd Party Not Implemented Report Details method
+# 3rd Party Report Details method
 DefenderMirrorDetails(PolicyId) := sprintf(
     concat(" ", [
     "A custom product can be used to fulfill this policy requirement.",
-    "If custom product is used, a 3rd party assessment tool or manually review is needed to ensure compliance.",
-    "See %v for instructions on manual check.",
+    "If a custom product is used, a 3rd party assessment tool or manually review is needed to ensure compliance.",
     "If you are using Defender for Office 365 to implement this policy,",
     "ensure that when running ScubaGear defender is in the ProductNames parameter.",
-    "Then, review the corresponding Defender for Office 365 policy that fulfills",
-    "the requirements of this policy."
+    "Then, manually review the corresponding Defender for Office 365 policy that fulfills",
+    "the requirements of this policy.",
+    "See %v for instructions on manual check."
     ]),
     [PolicyLink(PolicyId)]
 )

--- a/Testing/Functional/Products/Products.Tests.ps1
+++ b/Testing/Functional/Products/Products.Tests.ps1
@@ -285,11 +285,11 @@ Describe "Policy Checks for <ProductName>"{
                 $Details | Should -Not -BeNullOrEmpty -Because "expect details, $Details"
 
                 if ($IsNotChecked){
-                    $Details | Should -Match 'Not currently checked automatically.'
+                    $Details | Should -Match 'This product does not currently have the capability to check compliance for this policy.+'
                 }
 
                 if ($IsCustomImplementation){
-                    $Details | Should -Match 'Custom implementation allowed.'
+                    $Details | Should -Match 'A custom product can be used to fulfill this policy requirement.+'
                 }
 
                 # Check final HTML output
@@ -354,11 +354,11 @@ Describe "Policy Checks for <ProductName>"{
 
                                     if ($IsCustomImplementation){
                                         $RowData[2].text | Should -BeLikeExactly "N/A" -Because "custom policies should not have results. [$Msg]"
-                                        $RowData[4].text | Should -Match 'Custom implementation allowed.'
+                                        $RowData[4].text | Should -Match 'A custom product can be used to fulfill this policy requirement.+'
                                     }
                                     elseif ($IsNotChecked){
                                         $RowData[2].text | Should -BeLikeExactly "N/A" -Because "custom policies should not have results. [$Msg]"
-                                        $RowData[4].text | Should -Match 'Not currently checked automatically.'
+                                        $RowData[4].text | Should -Match 'This product does not currently have the capability to check compliance for this policy.+'
                                     }
                                     elseif ($true -eq $ExpectedResult) {
                                         $RowData[2].text | Should -BeLikeExactly "Pass" -Because "expected policy to pass. [$Msg]"


### PR DESCRIPTION
## 🗣 Description ##

Updating the test orchestrator to support multiple possible custom implementation reporting strings.

## 💭 Motivation and context ##

The EXO tests related to Custom Implementation where the isCustomImplementation is set to true fails because the ReportDetail string associated with custom implementations for EXO were updated in the emerald release to provide a more descriptive response about possible custom implementations. Since the test orchestrator uses a single string match, EXO custom implementation tests fail. Updating the test orchestrator custom implementation string match to the new EXO ReportDetail string shows the test pass properly.

closing #619 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] PR passed smoke test check.
- [ ] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [ ] Resolved all merge conflicts on branch
- [ ] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
