### PR TITLE
Add Least Privilege Score Check to Policy MS.AAD.7.2v1

### DIFF
--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -709,7 +709,7 @@ NotGlobalAdmins contains User.DisplayName if {
 default GetScoreDescription := "All privileged users are Global Admin"
 GetScoreDescription := concat("", ["Least Privilege Score = ", Score, " (should be 1 or less)"]) if {
     count(NotGlobalAdmins) > 0
-    RawRatio := sprintf("%v", [1])
+    RawRatio := sprintf("%v", [count(GlobalAdmins)/count(NotGlobalAdmins)])
     CutOff := min([4, count(RawRatio)])
     Score := substring(RawRatio, 0, CutOff)
 }

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -729,7 +729,6 @@ tests contains {
         count(GlobalAdmins) <= count(NotGlobalAdmins)
     ]
     Status := count(FilterArray(Conditions, false)) == 0
-    print("Status:", Status)
 }
 #--
 

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -676,11 +676,11 @@ GlobalAdmins contains User.DisplayName if {
 }
 
 #Set conditions under which this policy will pass
+default IsGlobalAdminCountGood := false
 IsGlobalAdminCountGood := true if {
     count(GlobalAdmins) <= 8
     count(GlobalAdmins) >= 2
-} else := false
-
+}
 
 # Pass if there are at least 2, but no more than 8
 # users with Global Admin role.
@@ -713,7 +713,7 @@ GetScoreDescription := concat("", ["Least Privilege Score = ", format_int(x,10),
 }
 
 #calculate least privilege score as ratio of priv users with global admin role to priv users without global admin role
-LeastPrivilegeScore := "Policy MS.AAD.7.1 failed so Least Privilege Score is not meaningful" if {
+LeastPrivilegeScore := "Policy MS.AAD.7.1 failed so score not computed" if {
     IsGlobalAdminCountGood == false
 } else := GetScoreDescription
 

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -727,8 +727,10 @@ GetScoreDescription := ScoreDescription if {
 LeastPrivilegeScore(GlobalAdmins, NotGlobalAdmins) := Description if {
     count(FilterArray(GlobalAdminConditions, false)) == 1
     Description := "Policy MS.AAD.7.1 failed so Least Privilege Score is not meaningful"
+    print("Description", Description)
 } else {
    Description := GetScoreDescription
+   print("Description", Description)
 }
 
 # Pass if 7.1 passed and Least Privilege Score < 1, fail if 7.1 failed or Least Privilege score is >= 1

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -675,7 +675,7 @@ GlobalAdmins contains User.DisplayName if {
     "Global Administrator" in User.roles
 }
 
-# Set conditions under which this policy will pass
+#Set conditions under which this policy will pass
 GlobalAdminConditions := [
     count(GlobalAdmins) <= 8,
     count(GlobalAdmins) >= 2
@@ -695,7 +695,7 @@ tests contains {
     Status := count(FilterArray(GlobalAdminConditions, false)) == 0
 }
 #--
-#
+
 # MS.AAD.7.2v1
 #--
 
@@ -705,7 +705,7 @@ NotGlobalAdmins contains User.DisplayName if {
     not "Global Administrator" in User.roles
 }
 
-default GetScoreDescription := "No privileged users that are NOT Global Admin; Least Privilege Score is undefined"
+default GetScoreDescription := "All privileged users are Global Admin"
 GetScoreDescription := concat("", ["Least Privilege Score = ", format_int(x,10), "%"]) if {
     count(NotGlobalAdmins) > 0
     x := count(GlobalAdmins)/count(NotGlobalAdmins)*100

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -697,14 +697,28 @@ tests contains {
 # MS.AAD.7.2v1
 #--
 
+# Save all users that have the Global Admin role
+NotGlobalAdmins contains User.DisplayName if {
+    some User in input.privileged_users
+    not "Global Administrator" in User.roles
+}
+
+SecureScore(GlobalAdmins, NotGlobalAdmins) := Description if {
+    count(NotGlobalAdmins) > 0
+    x := count(GlobalAdmins)/count(NotGlobalAdmins)*100
+    Description := concat(" ", ["Secure Score:", format_int(x,10)])
+} else := "No privileged users that are NOT Global Admin; Secure Score cannot be calculated at this time."
+
 # At this time we are unable to test for 7.2v1
 tests contains {
     "PolicyId": "MS.AAD.7.2v1",
-    "Criticality": "Shall/Not-Implemented",
-    "Commandlet": [],
-    "ActualValue": [],
-    "ReportDetails": NotCheckedDetails("MS.AAD.7.2v1"),
-    "RequirementMet": false
+    "Criticality" : "Shall",
+    "Commandlet" : ["Get-MgBetaSubscribedSku", "Get-PrivilegedUser"],
+    "ActualValue" : GlobalAdmins,
+    "ReportDetails" : concat(": ", [ReportDetailsBoolean(Status), SecureScore(GlobalAdmins,NotGlobalAdmins)]),
+    "RequirementMet" : Status
+} if {
+    Status := count(GlobalAdmins) <= count(NotGlobalAdmins)
 }
 #--
 

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -707,9 +707,9 @@ NotGlobalAdmins contains User.DisplayName if {
 }
 
 default GetScoreDescription := "All privileged users are Global Admin"
-GetScoreDescription := concat("", ["Least Privilege Score = ", Score]) if {
+GetScoreDescription := concat("", ["Least Privilege Score = ", Score, " (should be 1 or less)"]) if {
     count(NotGlobalAdmins) > 0
-    RawRatio := sprintf("%v", [count(GlobalAdmins)/count(NotGlobalAdmins)])
+    RawRatio := sprintf("%v", [1])
     CutOff := min([4, count(RawRatio)])
     Score := substring(RawRatio, 0, CutOff)
 }

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -705,10 +705,11 @@ NotGlobalAdmins contains User.DisplayName if {
     not "Global Administrator" in User.roles
 }
 
+default GetScoreDescription := "No privileged users that are NOT Global Admin; Least Privilege Score = 100%"
 GetScoreDescription := concat("", ["Least Privilege Score = ", format_int(x,10), "%"]) if {
     count(NotGlobalAdmins) > 0
     x := count(GlobalAdmins)/count(NotGlobalAdmins)*100
-} else := "No privileged users that are NOT Global Admin; Least Privilege Score = 100%"
+}
 
 #calculate least privilege score as ratio of priv users with global admin role to priv users without global admin role
 LeastPrivilegeScore := "Policy MS.AAD.7.1 failed so Least Privilege Score is not meaningful" if {

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -712,7 +712,7 @@ GetScoreDescription := concat("", ["Least Privilege Score = ", format_int(x,10),
     x := count(GlobalAdmins)/count(NotGlobalAdmins)*100
 }
 
-#calculate least privilege score as ratio of priv users with global admin role to priv users without global admin role
+# calculate least privilege score as ratio of priv users with global admin role to priv users without global admin role
 LeastPrivilegeScore := "Policy MS.AAD.7.1 failed so score not computed" if {
     IsGlobalAdminCountGood == false
 } else := GetScoreDescription

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -704,11 +704,12 @@ NotGlobalAdmins contains User.DisplayName if {
 }
 
 #calculate secure score as ratio of priv users with global admin role to priv users without global admin role
-SecureScore(GlobalAdmins, NotGlobalAdmins) := Description if {
+LeastPrivilegeScore(GlobalAdmins, NotGlobalAdmins) := Description if {
     count(NotGlobalAdmins) > 0
     x := count(GlobalAdmins)/count(NotGlobalAdmins)*100
-    Description := concat(" ", ["Secure Score:", format_int(x,10)])
-} else := "No privileged users that are NOT Global Admin; Secure Score cannot be calculated at this time."
+    Description := concat(" ", ["Least Privilege Score:", format_int(x,10)])
+} else := "No privileged users that are NOT Global Admin; Least Privilege Score cannot be calculated at this time."
+
 
 # Pass if secure score is <= 1, fail if secure score is > 1, flag if secure score is undefined
 tests contains {
@@ -716,10 +717,10 @@ tests contains {
     "Criticality" : "Shall",
     "Commandlet" : ["Get-MgBetaSubscribedSku", "Get-PrivilegedUser"],
     "ActualValue" : GlobalAdmins,
-    "ReportDetails" : concat(": ", [ReportDetailsBoolean(Status), SecureScore(GlobalAdmins,NotGlobalAdmins)]),
+    "ReportDetails" : concat(": ", [ReportDetailsBoolean(Status), LeastPrivilegeScore(GlobalAdmins,NotGlobalAdmins)]),
     "RequirementMet" : Status
 } if {
-    Status := count(GlobalAdmins) <= count(NotGlobalAdmins)
+    Status := count(GlobalAdmins) < count(NotGlobalAdmins)
 }
 #--
 

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -726,7 +726,7 @@ tests contains {
 } if {
     Conditions := [
         count(FilterArray(GlobalAdminConditions, false)) == 0,
-        count(GlobalAdmins) < count(NotGlobalAdmins)
+        count(GlobalAdmins) <= count(NotGlobalAdmins)
     ]
     Status := count(FilterArray(Conditions, false)) == 0
     print("Status:", Status)

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -697,19 +697,20 @@ tests contains {
 # MS.AAD.7.2v1
 #--
 
-# Save all users that have the Global Admin role
+# Save all users that don't have Global Admin role
 NotGlobalAdmins contains User.DisplayName if {
     some User in input.privileged_users
     not "Global Administrator" in User.roles
 }
 
+#calculate secure score as ratio of priv users with global admin role to priv users without global admin role
 SecureScore(GlobalAdmins, NotGlobalAdmins) := Description if {
     count(NotGlobalAdmins) > 0
     x := count(GlobalAdmins)/count(NotGlobalAdmins)*100
     Description := concat(" ", ["Secure Score:", format_int(x,10)])
 } else := "No privileged users that are NOT Global Admin; Secure Score cannot be calculated at this time."
 
-# At this time we are unable to test for 7.2v1
+# Pass if secure score is <= 1, fail if secure score is > 1, flag if secure score is undefined
 tests contains {
     "PolicyId": "MS.AAD.7.2v1",
     "Criticality" : "Shall",

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -676,10 +676,11 @@ GlobalAdmins contains User.DisplayName if {
 }
 
 #Set conditions under which this policy will pass
-GlobalAdminConditions := [
-    count(GlobalAdmins) <= 8,
+IsGlobalAdminCountGood := true if {
+    count(GlobalAdmins) <= 8
     count(GlobalAdmins) >= 2
-]
+} else := false
+
 
 # Pass if there are at least 2, but no more than 8
 # users with Global Admin role.
@@ -692,7 +693,7 @@ tests contains {
     "RequirementMet": Status
 } if {
     DescriptionString := "global admin(s) found"
-    Status := count(FilterArray(GlobalAdminConditions, false)) == 0
+    Status := IsGlobalAdminCountGood
 }
 #--
 
@@ -713,7 +714,7 @@ GetScoreDescription := concat("", ["Least Privilege Score = ", format_int(x,10),
 
 #calculate least privilege score as ratio of priv users with global admin role to priv users without global admin role
 LeastPrivilegeScore := "Policy MS.AAD.7.1 failed so Least Privilege Score is not meaningful" if {
-    count(FilterArray(GlobalAdminConditions, false)) != 0
+    IsGlobalAdminCountGood == false
 } else := GetScoreDescription
 
 # Pass if 7.1 passed and Least Privilege Score < 1, fail if 7.1 failed or Least Privilege score is >= 1
@@ -726,7 +727,7 @@ tests contains {
     "RequirementMet" : Status
 } if {
     Conditions := [
-        count(FilterArray(GlobalAdminConditions, false)) == 0,
+        IsGlobalAdminCountGood,
         count(GlobalAdmins) <= count(NotGlobalAdmins)
     ]
     Status := count(FilterArray(Conditions, false)) == 0

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -705,7 +705,7 @@ NotGlobalAdmins contains User.DisplayName if {
     not "Global Administrator" in User.roles
 }
 
-default GetScoreDescription := "No privileged users that are NOT Global Admin; Least Privilege Score = 100%"
+default GetScoreDescription := "No privileged users that are NOT Global Admin; Least Privilege Score is undefined"
 GetScoreDescription := concat("", ["Least Privilege Score = ", format_int(x,10), "%"]) if {
     count(NotGlobalAdmins) > 0
     x := count(GlobalAdmins)/count(NotGlobalAdmins)*100

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -675,7 +675,7 @@ GlobalAdmins contains User.DisplayName if {
     "Global Administrator" in User.roles
 }
 
-#Set conditions under which this policy will pass
+# Set conditions under which this policy will pass
 GlobalAdminConditions := [
     count(GlobalAdmins) <= 8,
     count(GlobalAdmins) >= 2
@@ -695,7 +695,7 @@ tests contains {
     Status := count(FilterArray(GlobalAdminConditions, false)) == 0
 }
 #--
-
+#
 # MS.AAD.7.2v1
 #--
 

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -707,9 +707,11 @@ NotGlobalAdmins contains User.DisplayName if {
 }
 
 default GetScoreDescription := "All privileged users are Global Admin"
-GetScoreDescription := concat("", ["Least Privilege Score = ", format_int(x,10), "%"]) if {
+GetScoreDescription := concat("", ["Least Privilege Score = ", Score]) if {
     count(NotGlobalAdmins) > 0
-    x := count(GlobalAdmins)/count(NotGlobalAdmins)*100
+    RawRatio := sprintf("%v", [count(GlobalAdmins)/count(NotGlobalAdmins)])
+    CutOff := min([4, count(RawRatio)])
+    Score := substring(RawRatio, 0, CutOff)
 }
 
 # calculate least privilege score as ratio of priv users with global admin role to priv users without global admin role

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
@@ -123,8 +123,42 @@ test_PrivilegedUsers_Incorrect_V2 if {
 #--
 # Policy MS.AAD.7.2v1
 #--
-
+#Correct because the ratio of global admins to non global admins is less than 1
 test_SecureScore_Correct_V1 if {
+    Output := aad.tests with input as {
+        "privileged_users": {
+            "User1": {
+                "DisplayName": "Test Name1",
+                "roles": [
+                    "Privileged Role Administrator",
+                    "Global Administrator"
+                ]
+            },
+            "User2": {
+                "DisplayName": "Test Name2",
+                "roles": [
+                    "Privileged Role Administrator"
+                ]
+            },
+            "User3": {
+                "DisplayName": "Test Name3",
+                "roles": [
+                    "Privileged Role Administrator"
+                ]
+            }
+        }
+    }
+
+    ReportDetailStr := "Requirement met: Least Privilege Score: 50"
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == "MS.AAD.7.2v1"]
+    print(RuleOutput)
+
+    TestResult("MS.AAD.7.2v1", Output, ReportDetailStr, true) == true
+}
+
+#Incorrect because the ratio of global admins to non global admins is equal to 1
+test_SecureScore_Incorrect_V1 if {
     Output := aad.tests with input as {
         "privileged_users": {
             "User1": {
@@ -143,11 +177,47 @@ test_SecureScore_Correct_V1 if {
         }
     }
 
-      ReportDetailStr := concat("", [
-        "secure score"
-    ])
+    ReportDetailStr := "Requirement not met: Least Privilege Score: 100"
 
-    TestResult("MS.AAD.7.2v1", PASS, ReportDetailStr, true) == true
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == "MS.AAD.7.2v1"]
+    print(RuleOutput)
+
+    TestResult("MS.AAD.7.2v1", Output, ReportDetailStr, false) == true
+}
+
+#Incorrect because the ratio of global admins to non global admins is more than 1
+test_SecureScore_Incorrect_V1 if {
+    Output := aad.tests with input as {
+        "privileged_users": {
+            "User1": {
+                "DisplayName": "Test Name1",
+                "roles": [
+                    "Privileged Role Administrator",
+                    "Global Administrator"
+                ]
+            },
+            "User2": {
+                "DisplayName": "Test Name2",
+                "roles": [
+                    "Privileged Role Administrator",
+                    "Global Administrator"
+                ]
+            },
+            "User3": {
+                "DisplayName": "Test Name2",
+                "roles": [
+                    "Privileged Role Administrator"
+                ]
+            }
+        }
+    }
+
+    ReportDetailStr := "Requirement not met: Least Privilege Score: 200"
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == "MS.AAD.7.2v1"]
+    print(RuleOutput)
+
+    TestResult("MS.AAD.7.2v1", Output, ReportDetailStr, false) == true
 }
 
 #--

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
@@ -1,7 +1,6 @@
 package aad_test
 import future.keywords
 import data.aad
-import data.utils.report.NotCheckedDetails
 import data.utils.key.TestResult
 import data.utils.key.FAIL
 import data.utils.key.PASS

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
@@ -204,9 +204,6 @@ test_SecureScore_Incorrect_V1 if {
 
     ReportDetailStr := "Requirement met: Least Privilege Score = 100%"
 
-    RuleOutput := [Result | some Result in Output; Result.PolicyId == "MS.AAD.7.2v1"]
-    print(RuleOutput)
-
     TestResult("MS.AAD.7.2v1", Output, ReportDetailStr, true) == true
 }
 
@@ -238,9 +235,6 @@ test_SecureScore_Incorrect_V2 if {
     }
 
     ReportDetailStr := "Requirement not met: Least Privilege Score = 200%"
-
-    RuleOutput := [Result | some Result in Output; Result.PolicyId == "MS.AAD.7.2v1"]
-    print(RuleOutput)
 
     TestResult("MS.AAD.7.2v1", Output, ReportDetailStr, false) == true
 }

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
@@ -136,7 +136,8 @@ test_SecureScore_Correct_V1 if {
             "User2": {
                 "DisplayName": "Test Name2",
                 "roles": [
-                    "Privileged Role Administrator"
+                    "Privileged Role Administrator",
+                    "Global Administrator"
                 ]
             },
             "User3": {
@@ -144,11 +145,23 @@ test_SecureScore_Correct_V1 if {
                 "roles": [
                     "Privileged Role Administrator"
                 ]
+            },
+            "User4": {
+                "DisplayName": "Test Name4",
+                "roles": [
+                    "Privileged Role Administrator"
+                ]
+            },
+            "User5": {
+                "DisplayName": "Test Name5",
+                "roles": [
+                    "Privileged Role Administrator"
+                ]
             }
         }
     }
 
-    ReportDetailStr := "Requirement met: Least Privilege Score: 50"
+    ReportDetailStr := "Requirement met: Least Privilege Score = 66%"
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == "MS.AAD.7.2v1"]
     print(RuleOutput)
@@ -170,13 +183,26 @@ test_SecureScore_Incorrect_V1 if {
             "User2": {
                 "DisplayName": "Test Name2",
                 "roles": [
+                    "Privileged Role Administrator",
+                    "Global Administrator"
+                ]
+            },
+            "User3": {
+                "DisplayName": "Test Name3",
+                "roles": [
+                    "Privileged Role Administrator"
+                ]
+            },
+            "User4": {
+                "DisplayName": "Test Name4",
+                "roles": [
                     "Privileged Role Administrator"
                 ]
             }
         }
     }
 
-    ReportDetailStr := "Requirement not met: Least Privilege Score: 100"
+    ReportDetailStr := "Requirement not met: Least Privilege Score = 100%"
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == "MS.AAD.7.2v1"]
     print(RuleOutput)
@@ -185,7 +211,7 @@ test_SecureScore_Incorrect_V1 if {
 }
 
 #Incorrect because the ratio of global admins to non global admins is more than 1
-test_SecureScore_Incorrect_V1 if {
+test_SecureScore_Incorrect_V2 if {
     Output := aad.tests with input as {
         "privileged_users": {
             "User1": {
@@ -211,7 +237,7 @@ test_SecureScore_Incorrect_V1 if {
         }
     }
 
-    ReportDetailStr := "Requirement not met: Least Privilege Score: 200"
+    ReportDetailStr := "Requirement not met: Least Privilege Score = 200%"
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == "MS.AAD.7.2v1"]
     print(RuleOutput)

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
@@ -163,9 +163,6 @@ test_SecureScore_Correct_V1 if {
 
     ReportDetailStr := "Requirement met: Least Privilege Score = 66%"
 
-    RuleOutput := [Result | some Result in Output; Result.PolicyId == "MS.AAD.7.2v1"]
-    print(RuleOutput)
-
     TestResult("MS.AAD.7.2v1", Output, ReportDetailStr, true) == true
 }
 

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
@@ -161,7 +161,7 @@ test_SecureScore_Correct_V1 if {
         }
     }
 
-    ReportDetailStr := "Requirement met: Least Privilege Score = 66%"
+    ReportDetailStr := "Requirement met: Least Privilege Score = 0.66"
 
     TestResult("MS.AAD.7.2v1", Output, ReportDetailStr, true) == true
 }
@@ -199,7 +199,7 @@ test_SecureScore_Incorrect_V1 if {
         }
     }
 
-    ReportDetailStr := "Requirement met: Least Privilege Score = 100%"
+    ReportDetailStr := "Requirement met: Least Privilege Score = 1"
 
     TestResult("MS.AAD.7.2v1", Output, ReportDetailStr, true) == true
 }
@@ -231,7 +231,7 @@ test_SecureScore_Incorrect_V2 if {
         }
     }
 
-    ReportDetailStr := "Requirement not met: Least Privilege Score = 200%"
+    ReportDetailStr := "Requirement not met: Least Privilege Score = 2"
 
     TestResult("MS.AAD.7.2v1", Output, ReportDetailStr, false) == true
 }

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
@@ -236,6 +236,41 @@ test_SecureScore_Incorrect_V2 if {
     TestResult("MS.AAD.7.2v1", Output, ReportDetailStr, false) == true
 }
 
+#Incorrect because the ratio of global admins to non global admins is undefined (all are global admins)
+test_SecureScore_Incorrect_V3 if {
+    Output := aad.tests with input as {
+        "privileged_users": {
+            "User1": {
+                "DisplayName": "Test Name1",
+                "roles": [
+                    "Privileged Role Administrator",
+                    "Global Administrator"
+                ]
+            },
+            "User2": {
+                "DisplayName": "Test Name2",
+                "roles": [
+                    "Privileged Role Administrator",
+                    "Global Administrator"
+                ]
+            },
+            "User3": {
+                "DisplayName": "Test Name2",
+                "roles": [
+                    "Privileged Role Administrator",
+                    "Global Administrator"
+                ]
+            }
+        }
+    }
+
+    ReportDetailStr := "Requirement not met: No privileged users that are NOT Global Admin; Least Privilege Score is undefined"
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == "MS.AAD.7.2v1"]
+
+    print(RuleOutput)
+    TestResult("MS.AAD.7.2v1", Output, ReportDetailStr, false) == true
+}
+
 #--
 # Policy MS.AAD.7.3v1
 #--

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
@@ -169,7 +169,7 @@ test_SecureScore_Correct_V1 if {
     TestResult("MS.AAD.7.2v1", Output, ReportDetailStr, true) == true
 }
 
-#Incorrect because the ratio of global admins to non global admins is equal to 1
+#Correct because the ratio of global admins to non global admins is equal to 1
 test_SecureScore_Incorrect_V1 if {
     Output := aad.tests with input as {
         "privileged_users": {
@@ -202,12 +202,12 @@ test_SecureScore_Incorrect_V1 if {
         }
     }
 
-    ReportDetailStr := "Requirement not met: Least Privilege Score = 100%"
+    ReportDetailStr := "Requirement met: Least Privilege Score = 100%"
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == "MS.AAD.7.2v1"]
     print(RuleOutput)
 
-    TestResult("MS.AAD.7.2v1", Output, ReportDetailStr, false) == true
+    TestResult("MS.AAD.7.2v1", Output, ReportDetailStr, true) == true
 }
 
 #Incorrect because the ratio of global admins to non global admins is more than 1

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
@@ -1,7 +1,7 @@
 package aad_test
 import future.keywords
 import data.aad
-#import data.utils.report.NotCheckedDetails
+import data.utils.report.NotCheckedDetails
 import data.utils.key.TestResult
 import data.utils.key.FAIL
 import data.utils.key.PASS

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
@@ -123,15 +123,32 @@ test_PrivilegedUsers_Incorrect_V2 if {
 #--
 # Policy MS.AAD.7.2v1
 #--
-test_NotImplemented_Correct if {
-    PolicyId := "MS.AAD.7.2v1"
 
-    Output := aad.tests with input as { }
+test_SecureScore_Correct_V1 if {
+    Output := aad.tests with input as {
+        "privileged_users": {
+            "User1": {
+                "DisplayName": "Test Name1",
+                "roles": [
+                    "Privileged Role Administrator",
+                    "Global Administrator"
+                ]
+            },
+            "User2": {
+                "DisplayName": "Test Name2",
+                "roles": [
+                    "Privileged Role Administrator"
+                ]
+            }
+        }
+    }
 
-    ReportDetailString := NotCheckedDetails(PolicyId)
-    TestResult(PolicyId, Output, ReportDetailString, false) == true
+      ReportDetailStr := concat("", [
+        "secure score"
+    ])
+
+    TestResult("MS.AAD.7.2v1", PASS, ReportDetailStr, true) == true
 }
-#--
 
 #--
 # Policy MS.AAD.7.3v1

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
@@ -265,9 +265,7 @@ test_SecureScore_Incorrect_V3 if {
     }
 
     ReportDetailStr := "Requirement not met: No privileged users that are NOT Global Admin; Least Privilege Score is undefined"
-    RuleOutput := [Result | some Result in Output; Result.PolicyId == "MS.AAD.7.2v1"]
 
-    print(RuleOutput)
     TestResult("MS.AAD.7.2v1", Output, ReportDetailStr, false) == true
 }
 

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
@@ -264,7 +264,7 @@ test_SecureScore_Incorrect_V3 if {
         }
     }
 
-    ReportDetailStr := "Requirement not met: No privileged users that are NOT Global Admin; Least Privilege Score is undefined"
+    ReportDetailStr := "Requirement not met: All privileged users are Global Admin"
 
     TestResult("MS.AAD.7.2v1", Output, ReportDetailStr, false) == true
 }

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
@@ -161,7 +161,10 @@ test_SecureScore_Correct_V1 if {
         }
     }
 
-    ReportDetailStr := "Requirement met: Least Privilege Score = 0.66"
+    ReportDetailStr := "Requirement met: Least Privilege Score = 0.66 (should be 1 or less)"
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == "MS.AAD.7.2v1"]
+  print(RuleOutput)
 
     TestResult("MS.AAD.7.2v1", Output, ReportDetailStr, true) == true
 }
@@ -199,7 +202,10 @@ test_SecureScore_Incorrect_V1 if {
         }
     }
 
-    ReportDetailStr := "Requirement met: Least Privilege Score = 1"
+    ReportDetailStr := "Requirement met: Least Privilege Score = 1 (should be 1 or less)"
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == "MS.AAD.7.2v1"]
+  print(RuleOutput)
 
     TestResult("MS.AAD.7.2v1", Output, ReportDetailStr, true) == true
 }
@@ -231,7 +237,10 @@ test_SecureScore_Incorrect_V2 if {
         }
     }
 
-    ReportDetailStr := "Requirement not met: Least Privilege Score = 2"
+    ReportDetailStr := "Requirement not met: Least Privilege Score = 2 (should be 1 or less)"
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == "MS.AAD.7.2v1"]
+  print(RuleOutput)
 
     TestResult("MS.AAD.7.2v1", Output, ReportDetailStr, false) == true
 }

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
@@ -122,7 +122,7 @@ test_PrivilegedUsers_Incorrect_V2 if {
 #--
 # Policy MS.AAD.7.2v1
 #--
-#Correct because the ratio of global admins to non global admins is less than 1
+# Correct because the ratio of global admins to non global admins is less than 1
 test_SecureScore_Correct_V1 if {
     Output := aad.tests with input as {
         "privileged_users": {
@@ -166,7 +166,7 @@ test_SecureScore_Correct_V1 if {
     TestResult("MS.AAD.7.2v1", Output, ReportDetailStr, true) == true
 }
 
-#Correct because the ratio of global admins to non global admins is equal to 1
+# Correct because the ratio of global admins to non global admins is equal to 1
 test_SecureScore_Incorrect_V1 if {
     Output := aad.tests with input as {
         "privileged_users": {
@@ -204,7 +204,7 @@ test_SecureScore_Incorrect_V1 if {
     TestResult("MS.AAD.7.2v1", Output, ReportDetailStr, true) == true
 }
 
-#Incorrect because the ratio of global admins to non global admins is more than 1
+# Incorrect because the ratio of global admins to non global admins is more than 1
 test_SecureScore_Incorrect_V2 if {
     Output := aad.tests with input as {
         "privileged_users": {
@@ -236,7 +236,7 @@ test_SecureScore_Incorrect_V2 if {
     TestResult("MS.AAD.7.2v1", Output, ReportDetailStr, false) == true
 }
 
-#Incorrect because the ratio of global admins to non global admins is undefined (all are global admins)
+# Incorrect because the ratio of global admins to non global admins is undefined (all are global admins)
 test_SecureScore_Incorrect_V3 if {
     Output := aad.tests with input as {
         "privileged_users": {

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
@@ -163,9 +163,6 @@ test_SecureScore_Correct_V1 if {
 
     ReportDetailStr := "Requirement met: Least Privilege Score = 0.66 (should be 1 or less)"
 
-    RuleOutput := [Result | some Result in Output; Result.PolicyId == "MS.AAD.7.2v1"]
-  print(RuleOutput)
-
     TestResult("MS.AAD.7.2v1", Output, ReportDetailStr, true) == true
 }
 
@@ -204,9 +201,6 @@ test_SecureScore_Incorrect_V1 if {
 
     ReportDetailStr := "Requirement met: Least Privilege Score = 1 (should be 1 or less)"
 
-    RuleOutput := [Result | some Result in Output; Result.PolicyId == "MS.AAD.7.2v1"]
-  print(RuleOutput)
-
     TestResult("MS.AAD.7.2v1", Output, ReportDetailStr, true) == true
 }
 
@@ -238,9 +232,6 @@ test_SecureScore_Incorrect_V2 if {
     }
 
     ReportDetailStr := "Requirement not met: Least Privilege Score = 2 (should be 1 or less)"
-
-    RuleOutput := [Result | some Result in Output; Result.PolicyId == "MS.AAD.7.2v1"]
-  print(RuleOutput)
 
     TestResult("MS.AAD.7.2v1", Output, ReportDetailStr, false) == true
 }

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
@@ -1,7 +1,7 @@
 package aad_test
 import future.keywords
 import data.aad
-import data.utils.report.NotCheckedDetails
+#import data.utils.report.NotCheckedDetails
 import data.utils.key.TestResult
 import data.utils.key.FAIL
 import data.utils.key.PASS

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
@@ -136,20 +136,20 @@ test_SecureScore_Correct_V1 if {
             "User2": {
                 "DisplayName": "Test Name2",
                 "roles": [
-                    "Privileged Role Administrator",
+                    "Cloud Application Administrator",
                     "Global Administrator"
                 ]
             },
             "User3": {
                 "DisplayName": "Test Name3",
                 "roles": [
-                    "Privileged Role Administrator"
+                    "Application Administrator"
                 ]
             },
             "User4": {
                 "DisplayName": "Test Name4",
                 "roles": [
-                    "Privileged Role Administrator"
+                    "User Administrator"
                 ]
             },
             "User5": {
@@ -180,14 +180,14 @@ test_SecureScore_Incorrect_V1 if {
             "User2": {
                 "DisplayName": "Test Name2",
                 "roles": [
-                    "Privileged Role Administrator",
+                    "User Administrator",
                     "Global Administrator"
                 ]
             },
             "User3": {
                 "DisplayName": "Test Name3",
                 "roles": [
-                    "Privileged Role Administrator"
+                    "Application Administrator"
                 ]
             },
             "User4": {
@@ -211,14 +211,14 @@ test_SecureScore_Incorrect_V2 if {
             "User1": {
                 "DisplayName": "Test Name1",
                 "roles": [
-                    "Privileged Role Administrator",
+                    "User Administrator",
                     "Global Administrator"
                 ]
             },
             "User2": {
                 "DisplayName": "Test Name2",
                 "roles": [
-                    "Privileged Role Administrator",
+                    "Application Administrator",
                     "Global Administrator"
                 ]
             },
@@ -250,14 +250,14 @@ test_SecureScore_Incorrect_V3 if {
             "User2": {
                 "DisplayName": "Test Name2",
                 "roles": [
-                    "Privileged Role Administrator",
+                    "User Administrator",
                     "Global Administrator"
                 ]
             },
             "User3": {
                 "DisplayName": "Test Name2",
                 "roles": [
-                    "Privileged Role Administrator",
+                    "Hybrid Identity Administrator",
                     "Global Administrator"
                 ]
             }
@@ -265,6 +265,74 @@ test_SecureScore_Incorrect_V3 if {
     }
 
     ReportDetailStr := "Requirement not met: All privileged users are Global Admin"
+
+    TestResult("MS.AAD.7.2v1", Output, ReportDetailStr, false) == true
+}
+
+# Incorrect because the total number of global admins is greater than eight
+test_SecureScore_Incorrect_V4 if {
+    Output := aad.tests with input as {
+        "privileged_users": {
+            "User1": {
+                "DisplayName": "Test Name1",
+                "roles": [
+                    "Privileged Role Administrator",
+                    "Global Administrator"
+                ]
+            },
+            "User2": {
+                "DisplayName": "Test Name2",
+                "roles": [
+                    "Exchange Administrator",
+                    "Global Administrator"
+                ]
+            },
+            "User3": {
+                "DisplayName": "Test Name3",
+                "roles": [
+                    "Global Administrator"
+                ]
+            },
+            "User4": {
+                "DisplayName": "Test Name4",
+                "roles": [
+                    "Global Administrator"
+                ]
+            },
+            "User5": {
+                "DisplayName": "Test Name5",
+                "roles": [
+                    "Global Administrator"
+                ]
+            },
+            "User6": {
+                "DisplayName": "Test Name6",
+                "roles": [
+                    "Global Administrator"
+                ]
+            },
+            "User7": {
+                "DisplayName": "Test Name7",
+                "roles": [
+                    "Global Administrator"
+                ]
+            },
+            "User8": {
+                "DisplayName": "Test Name8",
+                "roles": [
+                    "Global Administrator"
+                ]
+            },
+            "User9": {
+                "DisplayName": "Test Name9",
+                "roles": [
+                    "Global Administrator"
+                ]
+            }
+        }
+    }
+
+    ReportDetailStr := "Requirement not met: Policy MS.AAD.7.1 failed so score not computed"
 
     TestResult("MS.AAD.7.2v1", Output, ReportDetailStr, false) == true
 }

--- a/Testing/Functional/Products/TestPlans/aad.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/aad.testplan.yaml
@@ -912,6 +912,47 @@ TestPlan:
         Postconditions: []
         ExpectedResult: true
 
+      - TestDescription: MS.AAD.7.2v1 Compliant case - Less number of Global Admins and other privileged users
+        Preconditions:
+          - Command: UpdateProviderExport
+            Splat:
+              Updates:
+                privileged_users:
+                  16b4d5c2-71c9-4644-8728-74e3a8324d81:
+                    DisplayName: Test User1
+                    roles:
+                      - Global Administrator
+                    OnPremisesImmutableId: null
+                  26b4d5c2-71c9-4644-8728-74e3a8324d82:
+                    DisplayName: Test User2
+                    roles:
+                      - Global Administrator
+                      - Exchange Administrator
+                    OnPremisesImmutableId: null
+                  36b4d5c2-71c9-4644-8728-74e3a8324d83:
+                    DisplayName: Test User3
+                    roles:
+                      - User Administrator
+                      - Exchange Administrator
+                    OnPremisesImmutableId: null
+                  46b4d5c2-71c9-4644-8728-74e3a8324d84:
+                    DisplayName: Test User4
+                    roles:
+                      - Hybrid Identity Administrator
+                    OnPremisesImmutableId: null
+                  56b4d5c2-71c9-4644-8728-74e3a8324d85:
+                    DisplayName: Test User5
+                    roles:
+                      - User Administrator
+                    OnPremisesImmutableId: null
+                  66b4d5c2-71c9-4644-8728-74e3a8324d86:
+                    DisplayName: Test User6
+                    roles:
+                      - Sharepoint Administrator
+                    OnPremisesImmutableId: null
+        Postconditions: []
+        ExpectedResult: true
+
   - PolicyId: MS.AAD.7.3v1
     TestDriver: RunCached
     Tests:

--- a/Testing/Functional/Products/TestPlans/aad.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/aad.testplan.yaml
@@ -858,7 +858,7 @@ TestPlan:
                     roles:
                       - Global Administrator
                     OnPremisesImmutableId: null
-                    26b4d5c2-71c9-4644-8728-74e3a8324d82:
+                  26b4d5c2-71c9-4644-8728-74e3a8324d82:
                     DisplayName: Test User2
                     roles:
                       - Global Administrator

--- a/Testing/Functional/Products/TestPlans/aad.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/aad.testplan.yaml
@@ -864,7 +864,7 @@ TestPlan:
                       - Global Administrator
                       - Exchange Administrator
                     OnPremisesImmutableId: null
-                    36b4d5c2-71c9-4644-8728-74e3a8324d83:
+                  36b4d5c2-71c9-4644-8728-74e3a8324d83:
                     DisplayName: Test User3
                     roles:
                       - User Administrator

--- a/Testing/Functional/Products/TestPlans/aad.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/aad.testplan.yaml
@@ -788,13 +788,129 @@ TestPlan:
         ExpectedResult: true
 
   - PolicyId: MS.AAD.7.2v1
-    TestDriver: RunScuba
+    TestDriver: RunCached
     Tests:
-      - TestDescription: MS.AAD.7.2v1 Not Checked
-        Preconditions: []
+      - TestDescription: MS.AAD.7.2v1 Non-Compliant case - Too many Global Admins
+        Preconditions:
+          - Command: UpdateProviderExport
+            Splat:
+              Updates:
+                privileged_users:
+                  16b4d5c2-71c9-4644-8728-74e3a8324d81:
+                    DisplayName: Test User1
+                    roles:
+                      - Global Administrator
+                    OnPremisesImmutableId: null
+                  26b4d5c2-71c9-4644-8728-74e3a8324d82:
+                    DisplayName: Test User2
+                    roles:
+                      - Global Administrator
+                      - Exchange Administrator
+                    OnPremisesImmutableId: null
+                  36b4d5c2-71c9-4644-8728-74e3a8324d83:
+                    DisplayName: Test User3
+                    roles:
+                      - User Administrator
+                      - Global Administrator
+                    OnPremisesImmutableId: null
+                  46b4d5c2-71c9-4644-8728-74e3a8324d84:
+                    DisplayName: Test User4
+                    roles:
+                      - Hybrid Identity Administrator
+                      - Global Administrator
+                    OnPremisesImmutableId: null
+                  56b4d5c2-71c9-4644-8728-74e3a8324d85:
+                    DisplayName: Test User5
+                    roles:
+                      - Global Administrator
+                    OnPremisesImmutableId: null
+                  66b4d5c2-71c9-4644-8728-74e3a8324d86:
+                    DisplayName: Test User6
+                    roles:
+                      - Global Administrator
+                      - Sharepoint Administrator
+                    OnPremisesImmutableId: null
+                  76b4d5c2-71c9-4644-8728-74e3a8324d87:
+                    DisplayName: Test User7
+                    roles:
+                      - Global Administrator
+                    OnPremisesImmutableId: null
+                  86b4d5c2-71c9-4644-8728-74e3a8324d88:
+                    DisplayName: Test User8
+                    roles:
+                      - Global Administrator
+                    OnPremisesImmutableId: null
+                  96b4d5c2-71c9-4644-8728-74e3a8324d89:
+                    DisplayName: Test User9
+                    roles:
+                      - Global Administrator
+                    OnPremisesImmutableId: null
         Postconditions: []
-        IsNotChecked: true
         ExpectedResult: false
+      - TestDescription: MS.AAD.7.2v1 Non-Compliant case - More Global Admins than other privileged roles
+        Preconditions:
+          - Command: UpdateProviderExport
+            Splat:
+              Updates:
+                privileged_users:
+                  16b4d5c2-71c9-4644-8728-74e3a8324d81:
+                    DisplayName: Test User1
+                    roles:
+                      - Global Administrator
+                    OnPremisesImmutableId: null
+                    26b4d5c2-71c9-4644-8728-74e3a8324d82:
+                    DisplayName: Test User2
+                    roles:
+                      - Global Administrator
+                      - Exchange Administrator
+                    OnPremisesImmutableId: null
+                    36b4d5c2-71c9-4644-8728-74e3a8324d83:
+                    DisplayName: Test User3
+                    roles:
+                      - User Administrator
+                    OnPremisesImmutableId: null
+        Postconditions: []
+        ExpectedResult: false
+      - TestDescription: MS.AAD.7.2v1 Compliant case - Equal number of Global Admins and other privileged users
+        Preconditions:
+          - Command: UpdateProviderExport
+            Splat:
+              Updates:
+                privileged_users:
+                  16b4d5c2-71c9-4644-8728-74e3a8324d81:
+                    DisplayName: Test User1
+                    roles:
+                      - Global Administrator
+                    OnPremisesImmutableId: null
+                  26b4d5c2-71c9-4644-8728-74e3a8324d82:
+                    DisplayName: Test User2
+                    roles:
+                      - Global Administrator
+                      - Exchange Administrator
+                    OnPremisesImmutableId: null
+                  36b4d5c2-71c9-4644-8728-74e3a8324d83:
+                    DisplayName: Test User3
+                    roles:
+                      - User Administrator
+                      - Global Administrator
+                    OnPremisesImmutableId: null
+                  46b4d5c2-71c9-4644-8728-74e3a8324d84:
+                    DisplayName: Test User4
+                    roles:
+                      - Hybrid Identity Administrator
+                    OnPremisesImmutableId: null
+                  56b4d5c2-71c9-4644-8728-74e3a8324d85:
+                    DisplayName: Test User5
+                    roles:
+                      - User Administrator
+                    OnPremisesImmutableId: null
+                  66b4d5c2-71c9-4644-8728-74e3a8324d86:
+                    DisplayName: Test User6
+                    roles:
+                      - Sharepoint Administrator
+                    OnPremisesImmutableId: null
+        Postconditions: []
+        ExpectedResult: true
 
   - PolicyId: MS.AAD.7.3v1
     TestDriver: RunCached

--- a/Testing/Functional/Products/TestPlans/aad.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/aad.testplan.yaml
@@ -912,7 +912,7 @@ TestPlan:
         Postconditions: []
         ExpectedResult: true
 
-      - TestDescription: MS.AAD.7.2v1 Compliant case - Less number of Global Admins and other privileged users
+      - TestDescription: MS.AAD.7.2v1 Compliant case - Less number of Global Admins than other privileged users
         Preconditions:
           - Command: UpdateProviderExport
             Splat:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->
This pull request modifies the AAD Rego code for policy MS.AAD.7.2 "Privileged users SHALL be provisioned with finer-grained roles instead of Global Administrator." by implementing a custom calculation for computing the tenant's least privilege check.  The least privilege score is calculated as the ratio of the number of users with Global Admin privileges to the number of users with other highly privileged roles. This change allows ScubaGear to automatically check for the least privilege score versus having the user manually check the Secure Score value for the action named **Use least privileged administrative roles**. This PR also includes Rego unit tests to check the logic in the Rego code.

Closes #760 

## 🧪 Testing ##
I tested this against the G5 and E5 tenants which each had different scores. In addition, the unit tests check for the different pass and fail cases. To test this, run the ScubaGear tool against aad and check the report output for policy MS.AAD.7.2. To verify the result is correct, review the privileged_users array in the ProviderSettingsExport.json to count the number of users with Global Admin privileges and the number with other privileged roles but not Global Admin, and compute the ratio. This policy is dependent on MS.AAD.7.1 such that if MS.AAD.7.1 fails, MS.AAD.7.2 will automatically fail. This is because it is not meaningful to compute a least privilege score if the number of Global Admins exceeds the limit specified in the policy for MS.AAD.7.1,

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [ ] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] PR passed smoke test check.
- [ ] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [ ] Resolved all merge conflicts on branch
- [ ] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
