### PR TITLE
Update test plan for Teams product to fix issues observed during Nightly-Products-Functional-Test workflow

### DIFF
--- a/Testing/Functional/Products/TestPlans/teams.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/teams.testplan.yaml
@@ -5,12 +5,12 @@ TestPlan:
     Tests:
       - TestDescription: MS.TEAMS.1.1v1 Non-compliant - Allows External Participant Give Request Control
         Preconditions:
-          - Command: "Get-CsTeamsMeetingPolicy | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AllowExternalParticipantGiveRequestControl $true}"
+          - Command: "Get-CsTeamsMeetingPolicy | Where-Object {$_.Identity -notin @('Tag:AllOn','Tag:AllOff','Tag:Kiosk','Tag:default','Tag:RestrictedAnonymousAccess','Tag:RestrictedAnonymousNoRecording')} | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AllowExternalParticipantGiveRequestControl $true}"
         Postconditions: []
         ExpectedResult: false
       - TestDescription: MS.TEAMS.1.1v1 Compliant - Does not Allows  External Participant Give Request Control
         Preconditions:
-          - Command: "Get-CsTeamsMeetingPolicy | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AllowExternalParticipantGiveRequestControl $false}"
+          - Command: "Get-CsTeamsMeetingPolicy | Where-Object {$_.Identity -notin @('Tag:AllOn','Tag:AllOff','Tag:Kiosk','Tag:default','Tag:RestrictedAnonymousAccess','Tag:RestrictedAnonymousNoRecording')} | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AllowExternalParticipantGiveRequestControl $false}"
         Postconditions: []
         ExpectedResult: true
   - PolicyId: MS.TEAMS.1.2v1
@@ -18,12 +18,12 @@ TestPlan:
     Tests:
       - TestDescription: MS.TEAMS.1.2v1 Non-compliant - Allows External Participant Give Request Control
         Preconditions:
-          - Command: "Get-CsTeamsMeetingPolicy | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AllowAnonymousUsersToStartMeeting $true}"
+          - Command: "Get-CsTeamsMeetingPolicy | Where-Object {$_.Identity -notin @('Tag:AllOn','Tag:AllOff','Tag:Kiosk','Tag:default','Tag:RestrictedAnonymousAccess','Tag:RestrictedAnonymousNoRecording')} | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AllowAnonymousUsersToStartMeeting $true}"
         Postconditions: []
         ExpectedResult: false
       - TestDescription: MS.TEAMS.1.2v1 Compliant - Does not Allows  External Participant Give Request Control
         Preconditions:
-          - Command: "Get-CsTeamsMeetingPolicy | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AllowAnonymousUsersToStartMeeting $false}"
+          - Command: "Get-CsTeamsMeetingPolicy | Where-Object {$_.Identity -notin @('Tag:AllOn','Tag:AllOff','Tag:Kiosk','Tag:default','Tag:RestrictedAnonymousAccess','Tag:RestrictedAnonymousNoRecording')} | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AllowAnonymousUsersToStartMeeting $false}"
         Postconditions: []
         ExpectedResult: true
   - PolicyId: MS.TEAMS.1.3v1
@@ -81,7 +81,7 @@ TestPlan:
           - Command: Set-CsTeamsMeetingPolicy
             Splat:
               Identity: Global
-              AutoAdmittedUsers: Everyone
+              AutoAdmittedUsers: EveryOne
         Postconditions: []
         ExpectedResult: false
       - TestDescription: MS.TEAMS.1.4v1 Non-compliant - AutoAdmittedUsers = OrganizerOnly
@@ -121,62 +121,62 @@ TestPlan:
     Tests:
       - TestDescription: MS.TEAMS.1.5v1 Non-compliant - AutoAdmittedUsers = InvitedUsers
         Preconditions:
-          - Command: "Get-CsTeamsMeetingPolicy | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AutoAdmittedUsers InvitedUsers }"
-          - Command: "Get-CsTeamsMeetingPolicy | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AllowPSTNUsersToBypassLobby $true }"
+          - Command: "Get-CsTeamsMeetingPolicy | Where-Object {$_.Identity -notin @('Tag:AllOn','Tag:AllOff','Tag:Kiosk','Tag:default','Tag:RestrictedAnonymousAccess','Tag:RestrictedAnonymousNoRecording')} | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AutoAdmittedUsers InvitedUsers }"
+          - Command: "Get-CsTeamsMeetingPolicy | Where-Object {$_.Identity -notin @('Tag:AllOn','Tag:AllOff','Tag:Kiosk','Tag:default','Tag:RestrictedAnonymousAccess','Tag:RestrictedAnonymousNoRecording')} | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AllowPSTNUsersToBypassLobby $true }"
         Postconditions: []
         ExpectedResult: false
       - TestDescription: MS.TEAMS.1.5v1 Non-compliant - AutoAdmittedUsers = Everyone
         Preconditions:
-          - Command: "Get-CsTeamsMeetingPolicy | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AutoAdmittedUsers Everyone }"
-          - Command: "Get-CsTeamsMeetingPolicy | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AllowPSTNUsersToBypassLobby $true }"
+          - Command: "Get-CsTeamsMeetingPolicy | Where-Object {$_.Identity -notin @('Tag:AllOn','Tag:AllOff','Tag:Kiosk','Tag:default','Tag:RestrictedAnonymousAccess','Tag:RestrictedAnonymousNoRecording')} | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AutoAdmittedUsers Everyone }"
+          - Command: "Get-CsTeamsMeetingPolicy | Where-Object {$_.Identity -notin @('Tag:AllOn','Tag:AllOff','Tag:Kiosk','Tag:default','Tag:RestrictedAnonymousAccess','Tag:RestrictedAnonymousNoRecording')} | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AllowPSTNUsersToBypassLobby $true }"
         Postconditions: []
         ExpectedResult: false
       - TestDescription: MS.TEAMS.1.5v1 Non-compliant - AutoAdmittedUsers = EveryoneInCompany
         Preconditions:
-          - Command: "Get-CsTeamsMeetingPolicy | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AutoAdmittedUsers EveryoneInCompany }"
-          - Command: "Get-CsTeamsMeetingPolicy | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AllowPSTNUsersToBypassLobby $true }"
+          - Command: "Get-CsTeamsMeetingPolicy | Where-Object {$_.Identity -notin @('Tag:AllOn','Tag:AllOff','Tag:Kiosk','Tag:default','Tag:RestrictedAnonymousAccess','Tag:RestrictedAnonymousNoRecording')} | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AutoAdmittedUsers EveryoneInCompany }"
+          - Command: "Get-CsTeamsMeetingPolicy | Where-Object {$_.Identity -notin @('Tag:AllOn','Tag:AllOff','Tag:Kiosk','Tag:default','Tag:RestrictedAnonymousAccess','Tag:RestrictedAnonymousNoRecording')} | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AllowPSTNUsersToBypassLobby $true }"
         Postconditions: []
         ExpectedResult: false
       - TestDescription: MS.TEAMS.1.5v1 Non-compliant - AutoAdmittedUsers = EveryoneInSameAndFederatedCompany
         Preconditions:
-          - Command: "Get-CsTeamsMeetingPolicy | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AutoAdmittedUsers EveryoneInSameAndFederatedCompany }"
-          - Command: "Get-CsTeamsMeetingPolicy | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AllowPSTNUsersToBypassLobby $true }"
+          - Command: "Get-CsTeamsMeetingPolicy | Where-Object {$_.Identity -notin @('Tag:AllOn','Tag:AllOff','Tag:Kiosk','Tag:default','Tag:RestrictedAnonymousAccess','Tag:RestrictedAnonymousNoRecording')} | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AutoAdmittedUsers EveryoneInSameAndFederatedCompany }"
+          - Command: "Get-CsTeamsMeetingPolicy | Where-Object {$_.Identity -notin @('Tag:AllOn','Tag:AllOff','Tag:Kiosk','Tag:default','Tag:RestrictedAnonymousAccess','Tag:RestrictedAnonymousNoRecording')} | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AllowPSTNUsersToBypassLobby $true }"
         Postconditions: []
         ExpectedResult: false
       - TestDescription: MS.TEAMS.1.5v1 Non-compliant - AutoAdmittedUsers = EveryoneInCompanyExcludingGuests
         Preconditions:
-          - Command: "Get-CsTeamsMeetingPolicy | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AutoAdmittedUsers EveryoneInCompanyExcludingGuests }"
-          - Command: "Get-CsTeamsMeetingPolicy | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AllowPSTNUsersToBypassLobby $true }"
+          - Command: "Get-CsTeamsMeetingPolicy | Where-Object {$_.Identity -notin @('Tag:AllOn','Tag:AllOff','Tag:Kiosk','Tag:default','Tag:RestrictedAnonymousAccess','Tag:RestrictedAnonymousNoRecording')} | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AutoAdmittedUsers EveryoneInCompanyExcludingGuests }"
+          - Command: "Get-CsTeamsMeetingPolicy | Where-Object {$_.Identity -notin @('Tag:AllOn','Tag:AllOff','Tag:Kiosk','Tag:default','Tag:RestrictedAnonymousAccess','Tag:RestrictedAnonymousNoRecording')} | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AllowPSTNUsersToBypassLobby $true }"
         Postconditions: []
         ExpectedResult: false
       - TestDescription: MS.TEAMS.1.5v1 Compliant - AutoAdmittedUsers = InvitedUsers
         Preconditions:
-          - Command: "Get-CsTeamsMeetingPolicy | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AutoAdmittedUsers InvitedUsers }"
-          - Command: "Get-CsTeamsMeetingPolicy | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AllowPSTNUsersToBypassLobby $false }"
+          - Command: "Get-CsTeamsMeetingPolicy | Where-Object {$_.Identity -notin @('Tag:AllOn','Tag:AllOff','Tag:Kiosk','Tag:default','Tag:RestrictedAnonymousAccess','Tag:RestrictedAnonymousNoRecording')} | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AutoAdmittedUsers InvitedUsers }"
+          - Command: "Get-CsTeamsMeetingPolicy | Where-Object {$_.Identity -notin @('Tag:AllOn','Tag:AllOff','Tag:Kiosk','Tag:default','Tag:RestrictedAnonymousAccess','Tag:RestrictedAnonymousNoRecording')} | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AllowPSTNUsersToBypassLobby $false }"
         Postconditions: []
         ExpectedResult: true
       - TestDescription: MS.TEAMS.1.5v1 Compliant - AutoAdmittedUsers = OrganizerOnly
         Preconditions:
-          - Command: "Get-CsTeamsMeetingPolicy | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AutoAdmittedUsers OrganizerOnly }"
-          - Command: "Get-CsTeamsMeetingPolicy | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AllowPSTNUsersToBypassLobby $false }"
+          - Command: "Get-CsTeamsMeetingPolicy | Where-Object {$_.Identity -notin @('Tag:AllOn','Tag:AllOff','Tag:Kiosk','Tag:default','Tag:RestrictedAnonymousAccess','Tag:RestrictedAnonymousNoRecording')} | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AutoAdmittedUsers OrganizerOnly }"
+          - Command: "Get-CsTeamsMeetingPolicy | Where-Object {$_.Identity -notin @('Tag:AllOn','Tag:AllOff','Tag:Kiosk','Tag:default','Tag:RestrictedAnonymousAccess','Tag:RestrictedAnonymousNoRecording')} | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AllowPSTNUsersToBypassLobby $false }"
         Postconditions: []
         ExpectedResult: true
       - TestDescription: MS.TEAMS.1.5v1 Compliant - AutoAdmittedUsers = EveryoneInCompany
         Preconditions:
-          - Command: "Get-CsTeamsMeetingPolicy | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AutoAdmittedUsers EveryoneInCompany }"
-          - Command: "Get-CsTeamsMeetingPolicy | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AllowPSTNUsersToBypassLobby $false }"
+          - Command: "Get-CsTeamsMeetingPolicy | Where-Object {$_.Identity -notin @('Tag:AllOn','Tag:AllOff','Tag:Kiosk','Tag:default','Tag:RestrictedAnonymousAccess','Tag:RestrictedAnonymousNoRecording')} | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AutoAdmittedUsers EveryoneInCompany }"
+          - Command: "Get-CsTeamsMeetingPolicy | Where-Object {$_.Identity -notin @('Tag:AllOn','Tag:AllOff','Tag:Kiosk','Tag:default','Tag:RestrictedAnonymousAccess','Tag:RestrictedAnonymousNoRecording')} | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AllowPSTNUsersToBypassLobby $false }"
         Postconditions: []
         ExpectedResult: true
       - TestDescription: MS.TEAMS.1.5v1 Compliant - AutoAdmittedUsers = EveryoneInSameAndFederatedCompany
         Preconditions:
-          - Command: "Get-CsTeamsMeetingPolicy | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AutoAdmittedUsers EveryoneInSameAndFederatedCompany }"
-          - Command: "Get-CsTeamsMeetingPolicy | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AllowPSTNUsersToBypassLobby $false }"
+          - Command: "Get-CsTeamsMeetingPolicy | Where-Object {$_.Identity -notin @('Tag:AllOn','Tag:AllOff','Tag:Kiosk','Tag:default','Tag:RestrictedAnonymousAccess','Tag:RestrictedAnonymousNoRecording')} | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AutoAdmittedUsers EveryoneInSameAndFederatedCompany }"
+          - Command: "Get-CsTeamsMeetingPolicy | Where-Object {$_.Identity -notin @('Tag:AllOn','Tag:AllOff','Tag:Kiosk','Tag:default','Tag:RestrictedAnonymousAccess','Tag:RestrictedAnonymousNoRecording')} | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AllowPSTNUsersToBypassLobby $false }"
         Postconditions: []
         ExpectedResult: true
       - TestDescription: MS.TEAMS.1.5v1 Compliant - AutoAdmittedUsers = EveryoneInCompanyExcludingGuests
         Preconditions:
-          - Command: "Get-CsTeamsMeetingPolicy | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AutoAdmittedUsers EveryoneInCompanyExcludingGuests }"
-          - Command: "Get-CsTeamsMeetingPolicy | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AllowPSTNUsersToBypassLobby $false }"
+          - Command: "Get-CsTeamsMeetingPolicy | Where-Object {$_.Identity -notin @('Tag:AllOn','Tag:AllOff','Tag:Kiosk','Tag:default','Tag:RestrictedAnonymousAccess','Tag:RestrictedAnonymousNoRecording')} | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AutoAdmittedUsers EveryoneInCompanyExcludingGuests }"
+          - Command: "Get-CsTeamsMeetingPolicy | Where-Object {$_.Identity -notin @('Tag:AllOn','Tag:AllOff','Tag:Kiosk','Tag:default','Tag:RestrictedAnonymousAccess','Tag:RestrictedAnonymousNoRecording')} | % {Set-CsTeamsMeetingPolicy -Identity $($_.Identity) -AllowPSTNUsersToBypassLobby $false }"
         Postconditions: []
         ExpectedResult: true
   - PolicyId: MS.TEAMS.1.6v1

--- a/Testing/Functional/Products/TestPlans/teams.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/teams.testplan.yaml
@@ -68,14 +68,6 @@ TestPlan:
   - PolicyId: MS.TEAMS.1.4v1
     TestDriver: RunScuba
     Tests:
-      - TestDescription: MS.TEAMS.1.4v1 Non-compliant - AutoAdmittedUsers = InvitedUsers
-        Preconditions:
-          - Command: Set-CsTeamsMeetingPolicy
-            Splat:
-              Identity: Global
-              AutoAdmittedUsers: InvitedUsers
-        Postconditions: []
-        ExpectedResult: false
       - TestDescription: MS.TEAMS.1.4v1 Non-compliant - AutoAdmittedUsers is Everyone
         Preconditions:
           - Command: Set-CsTeamsMeetingPolicy
@@ -86,6 +78,14 @@ TestPlan:
             Splat:
               Identity: Global
               AutoAdmittedUsers: EveryOne
+        Postconditions: []
+        ExpectedResult: false
+      - TestDescription: MS.TEAMS.1.4v1 Non-compliant - AutoAdmittedUsers = InvitedUsers
+        Preconditions:
+          - Command: Set-CsTeamsMeetingPolicy
+            Splat:
+              Identity: Global
+              AutoAdmittedUsers: InvitedUsers
         Postconditions: []
         ExpectedResult: false
       - TestDescription: MS.TEAMS.1.4v1 Non-compliant - AutoAdmittedUsers = OrganizerOnly

--- a/Testing/Functional/Products/TestPlans/teams.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/teams.testplan.yaml
@@ -93,6 +93,10 @@ TestPlan:
           - Command: Set-CsTeamsMeetingPolicy
             Splat:
               Identity: Global
+              AllowPSTNUsersToBypassLobby: false
+          - Command: Set-CsTeamsMeetingPolicy
+            Splat:
+              Identity: Global
               AutoAdmittedUsers: OrganizerOnly
         Postconditions: []
         ExpectedResult: false

--- a/Testing/Functional/Products/TestPlans/teams.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/teams.testplan.yaml
@@ -78,7 +78,11 @@ TestPlan:
         ExpectedResult: false
       - TestDescription: MS.TEAMS.1.4v1 Non-compliant - AutoAdmittedUsers = Everyone
         Preconditions:
-          - Command: Set-CsTeamsMeetingPolicy
+        - Command: Set-CsTeamsMeetingPolicy
+            Splat:
+              Identity: Global
+              AllowPSTNUsersToBypassLobby: true
+        - Command: Set-CsTeamsMeetingPolicy
             Splat:
               Identity: Global
               AutoAdmittedUsers: EveryOne

--- a/Testing/Functional/Products/TestPlans/teams.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/teams.testplan.yaml
@@ -76,13 +76,13 @@ TestPlan:
               AutoAdmittedUsers: InvitedUsers
         Postconditions: []
         ExpectedResult: false
-      - TestDescription: MS.TEAMS.1.4v1 Non-compliant - AutoAdmittedUsers = Everyone
+      - TestDescription: MS.TEAMS.1.4v1 Non-compliant - AutoAdmittedUsers is Everyone
         Preconditions:
-        - Command: Set-CsTeamsMeetingPolicy
+          - Command: Set-CsTeamsMeetingPolicy
             Splat:
               Identity: Global
               AllowPSTNUsersToBypassLobby: true
-        - Command: Set-CsTeamsMeetingPolicy
+          - Command: Set-CsTeamsMeetingPolicy
             Splat:
               Identity: Global
               AutoAdmittedUsers: EveryOne


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

During nightly product functional testing, a few issues were found against some test cases - all these issues are while setting a config parameter. The attempted settings were either not allowed because of the config elements are not-editable or because the current tenant state does not allow the attempted config. 

This pull request updates the Teams test plan to fix the above issues. The Teams test cases 1.1, 1.2 and 1.5 were earlier attempting to edit Microsoft supplied non-custom meeting policies. But since these meeting policies were not editable - the test was failing with 'setting not possible' exception. Note that these meeting policies are redundant (Microsoft discontinued them and made them not assignable) and are expected to be deprecated soon. Test plan is fixed by filtering them out of meeting policies to be edited and tested. Teams test case 1.4 was earlier failing because the requested setting has a dependant pre-condition that was not met. Updated test case 1.4 to make explicit precondition to make the necessary config setting and test the non-complaint case.

## 💭 Motivation and context ##
Closes #804 
Closes #811 
Closes #855 

## 🧪 Testing ##
Tested Teams testplan on a E5 tenant - tested in a private user environment with necessary permissions. Also tested using a service principal. Tested the nightly product functional test work flow. All test cases passed.
Link for the nightly product functional test run: https://github.com/cisagov/ScubaGear/actions/runs/7671105576


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [x] Resolved all merge conflicts on branch
- [x] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [x] Feature branch deleted after merge to clean up repository.
- [x] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
