### PR TITLE
Fixes ScubaConfig.LoadConfig repeated invocations

### DIFF
--- a/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfig.psm1
+++ b/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfig.psm1
@@ -22,13 +22,12 @@ class ScubaConfig {
         if (-Not (Test-Path -PathType Leaf $Path)){
             throw [System.IO.FileNotFoundException]"Failed to load: $Path"
         }
-        elseif ($false -eq [ScubaConfig]::_IsLoaded){
-            $Content = Get-Content -Raw -Path $Path
-            $this.Configuration = $Content | ConvertFrom-Yaml
+        [ScubaConfig]::ResetInstance()
+        $Content = Get-Content -Raw -Path $Path
+        $this.Configuration = $Content | ConvertFrom-Yaml
 
-            $this.SetParameterDefaults()
-            [ScubaConfig]::_IsLoaded = $true
-        }
+        $this.SetParameterDefaults()
+        [ScubaConfig]::_IsLoaded = $true
 
         return [ScubaConfig]::_IsLoaded
     }

--- a/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfig.psm1
+++ b/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfig.psm1
@@ -38,7 +38,7 @@ class ScubaConfig {
     }
 
     hidden [Guid]$Uuid = [Guid]::NewGuid()
-    hidden [Object]$Configuration
+    hidden [hashtable]$Configuration
 
     hidden [void]SetParameterDefaults(){
         if (-Not $this.Configuration.ProductNames){

--- a/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfig.psm1
+++ b/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfig.psm1
@@ -1,4 +1,20 @@
 class ScubaConfig {
+    <#
+    .SYNOPSIS
+      This class stores Scuba config data loaded from a file.
+    .DESCRIPTION
+      This class is designed to function as a singleton. The singleton instance
+      is cached on the ScubaConfig type itself. In the context of tests, it may be
+      important to call `.ResetInstance` before and after tests as needed to
+      ensure any preexisting configs are not inadvertantly used for the test,
+      or left in place after the test is finished. The singleton will persist
+      for the life of the powershell session unless the ScubaConfig module is
+      removed. Note that `.LoadConfig` internally calls `.ResetInstance` to avoid
+      issues.
+    .EXAMPLE
+      $Config = [ScubaConfig]::GetInstance()
+      [ScubaConfig]::LoadConfig($SomePath)
+    #>
     hidden static [ScubaConfig]$_Instance = [ScubaConfig]::new()
     hidden static [Boolean]$_IsLoaded = $false
 

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfigLoadConfig.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfigLoadConfig.Tests.ps1
@@ -7,11 +7,11 @@ InModuleScope ScubaConfig {
                 $cfg = [ScubaConfig]::GetInstance()
 		# Load the first file and check the ProductNames value.
                 $file1 = Join-Path -Path $PSScriptRoot -ChildPath config_test_load_config1.json
-                $loaded1 = $cfg.LoadConfig($file1)
+                $cfg.LoadConfig($file1)
                 $products1 = $cfg.Configuration.ProductNames | Should -Be 'teams'
 		# Load the second file and verify that ProductNames has changed.
                 $file2 = Join-Path -Path $PSScriptRoot -ChildPath config_test_load_config2.json
-                $loaded2 = $cfg.LoadConfig($file2)
+                $cfg.LoadConfig($file2)
                 $products1 = $cfg.Configuration.ProductNames | Should -Be 'exo'
             }
             AfterAll {

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfigLoadConfig.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfigLoadConfig.Tests.ps1
@@ -8,11 +8,11 @@ InModuleScope ScubaConfig {
 		# Load the first file and check the ProductNames value.
                 $file1 = Join-Path -Path $PSScriptRoot -ChildPath config_test_load_config1.json
                 $cfg.LoadConfig($file1)
-                $products1 = $cfg.Configuration.ProductNames | Should -Be 'teams'
+                $cfg.Configuration.ProductNames | Should -Be 'teams'
 		# Load the second file and verify that ProductNames has changed.
                 $file2 = Join-Path -Path $PSScriptRoot -ChildPath config_test_load_config2.json
                 $cfg.LoadConfig($file2)
-                $products1 = $cfg.Configuration.ProductNames | Should -Be 'exo'
+                $cfg.Configuration.ProductNames | Should -Be 'exo'
             }
             AfterAll {
                 [ScubaConfig]::ResetInstance()

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfigLoadConfig.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfigLoadConfig.Tests.ps1
@@ -1,0 +1,22 @@
+using module '..\..\..\..\Modules\ScubaConfig\ScubaConfig.psm1'
+
+InModuleScope ScubaConfig {
+    Describe -tag "Utils" -name 'ScubaConfigLoadConfig' {
+        context 'Handling repeated LoadConfig invocations' {
+            It 'Load valid config file followed by another'{
+                $cfg = [ScubaConfig]::GetInstance()
+		# Load the first file and check the ProductNames value.
+                $file1 = Join-Path -Path $PSScriptRoot -ChildPath config_test_load_config1.json
+                $loaded1 = $cfg.LoadConfig($file1)
+                $products1 = $cfg.Configuration.ProductNames | Should -Be 'teams'
+		# Load the second file and verify that ProductNames has changed.
+                $file2 = Join-Path -Path $PSScriptRoot -ChildPath config_test_load_config2.json
+                $loaded2 = $cfg.LoadConfig($file2)
+                $products1 = $cfg.Configuration.ProductNames | Should -Be 'exo'
+            }
+            AfterAll {
+                [ScubaConfig]::ResetInstance()
+            }
+        }
+    }
+}

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/config_test_load_config1.json
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/config_test_load_config1.json
@@ -1,0 +1,5 @@
+{
+    "ProductNames": [
+      "teams"
+    ]
+}

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/config_test_load_config2.json
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/config_test_load_config2.json
@@ -1,0 +1,5 @@
+{
+    "ProductNames": [
+      "exo"
+    ]
+}


### PR DESCRIPTION
# Fixes ScubaConfig.LoadConfig repeated invocations #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 `.LoadConfig` now always calls `.ResetInstance` before loading config ##

This PR fixes #844, in which calling `.LoadConfig` more than once has no effect. The fix is trivial and just invokes `.ResetInstance` before loading a new file.

## 💭 Motivation and context ##

Primarily needed to avoid surprises during testing.

Also closes #845, added a comment-based help docstring to ScubaConfig, per discussion with team; simply easier to do that one here as well.

## 🧪 Testing ##

Added a unit test almost identical to the diagnostic test outlined in #844 

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [x] Resolved all merge conflicts on branch
- [x] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
