### PR TITLE
Remove an unnecessary cmdlet from aad policy check 5.3 to improve performance of the provider

### DIFF
--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -102,11 +102,8 @@ function Export-AADProvider {
     # 5.1, 5.2, 8.1 & 8.3
     $AuthZPolicies = ConvertTo-Json @($Tracker.TryCommand("Get-MgBetaPolicyAuthorizationPolicy"))
 
-    # 5.4
+    # 5.3, 5.4
     $DirectorySettings = ConvertTo-Json -Depth 10 @($Tracker.TryCommand("Get-MgBetaDirectorySetting"))
-
-    # 5.3
-    $AdminConsentReqPolicies = ConvertTo-Json @($Tracker.TryCommand("Get-MgBetaPolicyAdminConsentRequestPolicy"))
 
     # Read the properties and relationships of an authentication method policy
     $AuthenticationMethodPolicy = ConvertTo-Json @($Tracker.TryCommand("Get-MgBetaPolicyAuthenticationMethodPolicy"))
@@ -122,7 +119,6 @@ function Export-AADProvider {
     "conditional_access_policies": $AllPolicies,
     "cap_table_data": $CapTableData,
     "authorization_policies": $AuthZPolicies,
-    "admin_consent_policies": $AdminConsentReqPolicies,
     "privileged_users": $PrivilegedUsers,
     "privileged_roles": $PrivilegedRoles,
     "service_plans": $ServicePlans,

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/CreateReport/CreateReportStubs/ProviderSettingsExport.json
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/CreateReport/CreateReportStubs/ProviderSettingsExport.json
@@ -11860,7 +11860,6 @@
     "Get-MgBetaPolicyAuthorizationPolicy",
     "Get-MgBetaSecuritySecureScore",
     "Get-MgBetaDirectorySetting",
-    "Get-MgBetaPolicyAdminConsentRequestPolicy",
     "Get-MgBetaPolicyAuthenticationMethodPolicy"
 ],
     "aad_unsuccessful_commands": [

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/AADProvider/Export-AADProvider.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/AADProvider/Export-AADProvider.Tests.ps1
@@ -63,11 +63,7 @@ InModuleScope -ModuleName ExportAADProvider {
                                 $this.SuccessfulCommands += $Command
                                 return [pscustomobject]@{}
                             }
-                            "Get-MgBetaPolicyAdminConsentRequestPolicy" {
-                                $this.SuccessfulCommands += $Command
-                                return [pscustomobject]@{}
-                            }
-                            "Get-MgBetaPolicyAuthenticationMethodPolicy" {
+                             "Get-MgBetaPolicyAuthenticationMethodPolicy" {
                                 $this.SuccessfulCommands += $Command
                                 return [pscustomobject]@{}
                             }

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_05_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_05_test.rego
@@ -140,10 +140,15 @@ test_PermissionGrantPolicyIdsAssignedToDefaultUserRole_Incorrect_V2 if {
 #--
 test_IsEnabled_Correct if {
     Output := aad.tests with input as {
-        "admin_consent_policies": [
+        "directory_settings": [
             {
-                "IsEnabled": true,
-                "Id": "policy ID"
+                "DisplayName": "Setting display name",
+                "Values": [
+                    {
+                        "Name":  "EnableAdminConsentRequests",
+                        "Value":  "true"
+                    }
+                ]
             }
         ]
     }
@@ -151,12 +156,35 @@ test_IsEnabled_Correct if {
     TestResult("MS.AAD.5.3v1", Output, PASS, true) == true
 }
 
+test_IsEnabled_Incorrect_Missing if {
+    Output := aad.tests with input as {
+        "directory_settings": [
+            {
+                "DisplayName": "Setting display name",
+                "Values": [
+                    {
+                        "Name":  "EnableGroupSpecificConsent",
+                        "Value":  "false"
+                    }
+                ]
+            }
+        ]
+    }
+
+    TestResult("MS.AAD.5.3v1", Output, FAIL, false) == true
+}
+
 test_IsEnabled_Incorrect if {
     Output := aad.tests with input as {
-        "admin_consent_policies": [
+        "directory_settings": [
             {
-                "IsEnabled": false,
-                "Id": null
+                "DisplayName": "Setting display name",
+                "Values": [
+                    {
+                        "Name":  "EnableAdminConsentRequests",
+                        "Value":  "false"
+                    }
+                ]
             }
         ]
     }

--- a/PowerShell/ScubaGear/baselines/aad.md
+++ b/PowerShell/ScubaGear/baselines/aad.md
@@ -441,7 +441,7 @@ Group owners SHALL NOT be allowed to consent to applications.
 
 2. Then in **Azure Active Directory** under **Manage**, select **Enterprise Applications.**
 
-3. Select **Admin consent settings**.
+3. Under **Security**, select **Consent and permissions**. Then select **User Consent Settings**.
 
 4. Under **Admin consent requests** > **Users can request admin consent to apps they are unable to consent to** select **Yes**.
 

--- a/Testing/Functional/Products/TestPlans/aad.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/aad.testplan.yaml
@@ -534,40 +534,39 @@ TestPlan:
         ExpectedResult: true
 
   - PolicyId: MS.AAD.5.3v1
-    TestDriver: RunScuba
+    TestDriver: RunCached
     Tests:
       - TestDescription: MS.AAD.5.3v1 Non-Compliant case - No Admin Consent workflow configured
         Preconditions:
-          - Command: UpdateDirectorySettingByName
+          - Command: UpdateProviderExport
             Splat:
-              DisplayName: Consent Policy Settings
-              Updates:
-                BodyParameter:
-                  Values:
-                    # Policy Template requires specific parameters to be set in PATCH request
-                    - Name: BlockUserConsentForRiskyApps
-                      Value: true
-                    - Name: EnableGroupSpecificConsent
-                      Value: true
-                    - Name: EnableAdminConsentRequests
-                      Value: false
+              updates:
+                directory_settings[0].DisplayName: Consent Policy Settings
+                directory_settings[0].Values:
+                  - Name: EnableAdminConsentRequests
+                    Value: ""
         Postconditions: []
         ExpectedResult: false
-      - TestDescription: MS.AAD.5.3v1 Compliant case - Admin Consent workflow is configured
+      - TestDescription: MS.AAD.5.3v1 Non-Compliant case - No Admin Consent workflow configured false
         Preconditions:
-          - Command: UpdateDirectorySettingByName
+          - Command: UpdateProviderExport
             Splat:
-              DisplayName: Consent Policy Settings
-              Updates:
-                BodyParameter:
-                  Values:
-                    # Policy Template requires specific parameters to be set in PATCH request
-                    - Name: BlockUserConsentForRiskyApps
-                      Value: true
-                    - Name: EnableGroupSpecificConsent
-                      Value: true
-                    - Name: EnableAdminConsentRequests
-                      Value: true
+              updates:
+                directory_settings[0].DisplayName: Consent Policy Settings
+                directory_settings[0].Values:
+                  - Name: EnableAdminConsentRequests
+                    Value: "false"
+        Postconditions: []
+        ExpectedResult: false
+      - TestDescription: MS.AAD.5.3v1 Compliant case - Admin Consent workflow is configured true
+        Preconditions:
+          - Command: UpdateProviderExport
+            Splat:
+              updates:
+                directory_settings[0].DisplayName: Consent Policy Settings
+                directory_settings[0].Values:
+                  - Name: EnableAdminConsentRequests
+                    Value: "true"
         Postconditions: []
         ExpectedResult: true
 

--- a/Testing/Functional/Products/TestPlans/aad.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/aad.testplan.yaml
@@ -534,22 +534,40 @@ TestPlan:
         ExpectedResult: true
 
   - PolicyId: MS.AAD.5.3v1
-    TestDriver: RunCached
+    TestDriver: RunScuba
     Tests:
       - TestDescription: MS.AAD.5.3v1 Non-Compliant case - No Admin Consent workflow configured
         Preconditions:
-          - Command: UpdateProviderExport
+          - Command: UpdateDirectorySettingByName
             Splat:
-              updates:
-                admin_consent_policies[0].IsEnabled: false
+              DisplayName: Consent Policy Settings
+              Updates:
+                BodyParameter:
+                  Values:
+                    # Policy Template requires specific parameters to be set in PATCH request
+                    - Name: BlockUserConsentForRiskyApps
+                      Value: true
+                    - Name: EnableGroupSpecificConsent
+                      Value: true
+                    - Name: EnableAdminConsentRequests
+                      Value: false
         Postconditions: []
         ExpectedResult: false
       - TestDescription: MS.AAD.5.3v1 Compliant case - Admin Consent workflow is configured
         Preconditions:
-          - Command: UpdateProviderExport
+          - Command: UpdateDirectorySettingByName
             Splat:
-              updates:
-                admin_consent_policies[0].IsEnabled: true
+              DisplayName: Consent Policy Settings
+              Updates:
+                BodyParameter:
+                  Values:
+                    # Policy Template requires specific parameters to be set in PATCH request
+                    - Name: BlockUserConsentForRiskyApps
+                      Value: true
+                    - Name: EnableGroupSpecificConsent
+                      Value: true
+                    - Name: EnableAdminConsentRequests
+                      Value: true
         Postconditions: []
         ExpectedResult: true
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##
For Rego policy check 5.3 we can replace Get-MgBetaPolicyAdminConsentRequestPolicy and use Get-MgBetaDirectorySetting instead. We already use Get-MgBetaDirectorySetting for policy 5.4 so we can remove the extra cmdlet Get-MgBetaPolicyAdminConsentRequestPolicy from the provider to make AAD run faster.
When developing the functional test cases for AAD I discovered that the Get-MgBetaDirectorySetting returns a field named EnableAdminConsentRequests that we can check to see if the admin consent workflow is enabled.

## 💭 Motivation and context ##

Increase performance of ScubaGear
closes #729 

## 🧪 Testing ##

- Ran UT, passed
- Ran FT for AAD, passed
- Ran Invoke-Scuba against tenant and got expected results. 

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [X] This PR has an informative and human-readable title.
- [X] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] Changes are sized such that they do not touch excessive number of files.
- [X] *All* future TODOs are captured in issues, which are referenced in code comments.
- [X] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [X] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [X] All relevant type-of-change labels added.
- [X] All relevant project fields are set.
- [X] All relevant repo and/or project documentation updated to reflect these changes.
- [X] Unit tests added/updated to cover PowerShell and Rego changes.
- [X] Functional tests added/updated to cover PowerShell and Rego changes.
- [X] All relevant functional tests passed.
- [X] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] PR passed smoke test check.
- [ ] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [ ] Resolved all merge conflicts on branch
- [ ] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
