### PR TITLE
Add code to AAD provider and REGO for 7.6 through 7.9 to support PIM for Groups

### DIFF
--- a/PowerShell/ScubaGear/Modules/Connection/Connection.psm1
+++ b/PowerShell/ScubaGear/Modules/Connection/Connection.psm1
@@ -62,7 +62,9 @@ function Connect-Tenant {
                        'RoleManagement.Read.Directory',
                        'GroupMember.Read.All',
                        'Directory.Read.All',
-                       'PrivilegedEligibilitySchedule.Read.AzureADGroup'
+                       'PrivilegedEligibilitySchedule.Read.AzureADGroup',
+                       'PrivilegedAccess.Read.AzureADGroup',
+                       'RoleManagementPolicy.Read.AzureADGroup'
                    )
                    $GraphParams = @{
                        'ErrorAction' = 'Stop';

--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -405,7 +405,7 @@ function FindRulesForPimGroupsRoles{
                 if ($Role){
                     $RoleRules = $Role.psobject.Properties | Where-Object {$_.Name -eq 'Rules'}
                     if ($RoleRules){
-                        # Appending rules 
+                        # Appending rules
                         $Role.Rules += $MemberPolicyRules
                     }
                     else {

--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -424,7 +424,7 @@ function FindRulesForPimGroupsRoles{
                 if ($Role){
                     $RoleRules = $Role.psobject.Properties | Where-Object {$_.Name -eq 'Rules'}
                     if ($RoleRules){
-                        # Appending rules 
+                        # Appending rules
                         $Role.Rules += $MemberPolicyRules
                     }
                     else {

--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -424,7 +424,7 @@ function FindRulesForPimGroupsRoles{
                 if ($Role){
                     $RoleRules = $Role.psobject.Properties | Where-Object {$_.Name -eq 'Rules'}
                     if ($RoleRules){
-                        # Appending rules
+                        # Appending rules 
                         $Role.Rules += $MemberPolicyRules
                     }
                     else {

--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -405,7 +405,7 @@ function FindRulesForPimGroupsRoles{
                 if ($Role){
                     $RoleRules = $Role.psobject.Properties | Where-Object {$_.Name -eq 'Rules'}
                     if ($RoleRules){
-                        # Appending rules
+                        # Appending rules 
                         $Role.Rules += $MemberPolicyRules
                     }
                     else {

--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -410,7 +410,7 @@ function GetConfigurationsForPimGroups{
             else {
                 continue
             }
-            
+
             # Get all the configuration rules for the current PIM group - get member not owner configs
             $PolicyAssignment = Get-MgBetaPolicyRoleManagementPolicyAssignment -All -ErrorAction Stop -Filter "scopeId eq '$PrincipalId' and scopeType eq 'Group' and roleDefinitionId eq 'member'" |
                 Select-Object -Property PolicyId

--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -377,7 +377,7 @@ function IsPimGroup{
     )
 
     If ($null -eq [GroupType]::CheckedGroups[$GroupId]){
-        ($GroupEligibilitySchedule = Get-MgBetaIdentityGovernancePrivilegedAccessGroupEligibilitySchedule -Filter "groupId eq '$PrincipalId'") *> $null
+        ($GroupEligibilitySchedule = Get-MgBetaIdentityGovernancePrivilegedAccessGroupEligibilitySchedule -Filter "groupId eq '$GroupId'") *> $null
         [GroupType]::CheckedGroups.Add($GroupId, $GroupEligibilitySchedule.Count -eq 0)
     }
 

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -13,7 +13,6 @@ import data.utils.key.ConvertToSet
 import data.utils.aad.ReportFullDetailsArray
 import data.utils.aad.ReportDetailsArrayLicenseWarningCap
 import data.utils.aad.ReportDetailsArrayLicenseWarning
-import data.utils.aad.ReportDetailsBooleanLicenseWarning
 import data.utils.aad.UserExclusionsFullyExempt
 import data.utils.aad.GroupExclusionsFullyExempt
 import data.utils.aad.Aad2P2Licenses

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -901,7 +901,7 @@ tests contains {
     "ReportDetails": ReportDetailsArrayLicenseWarning(RolesWithoutApprovalRequired, DescriptionString),
     "RequirementMet": Status
 } if {
-    DescriptionString := "role(s) or group(s) allowing without approval found"
+    DescriptionString := "role(s) or group(s) allowing activation without approval found"
     Conditions := [
         count(Aad2P2Licenses) > 0,
         count(RolesWithoutApprovalRequired) == 0

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -378,7 +378,7 @@ PhishingResistantMFA contains CAPolicy.DisplayName if {
 tests contains {
     "PolicyId": "MS.AAD.3.6v1",
     "Criticality": "Shall",
-    "Commandlet": ["Get-MgBetaSubscribedSku", "Get-PrivilegedRole", "Get-MgBetaIdentityConditionalAccessPolicy"],
+    "Commandlet": ["Get-MgBetaIdentityConditionalAccessPolicy"],
     "ActualValue": PhishingResistantMFA,
     "ReportDetails": concat(". ", [ReportFullDetailsArray(PhishingResistantMFA, DescriptionString), CAPLINK]),
     "RequirementMet": Status

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Connection/Connect-Tenant.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Connection/Connect-Tenant.Tests.ps1
@@ -12,12 +12,13 @@ InModuleScope Connection {
             function Connect-MgGraph {throw 'this will be mocked'}
             Mock Connect-MgGraph -MockWith {}
             function Connect-PnPOnline {throw 'this will be mocked'}
+            function Connect-PnPOnline {throw 'this will be mocked'}
             Mock Connect-PnPOnline -MockWith {}
             function Connect-SPOService {throw 'this will be mocked'}
             Mock Connect-SPOService -MockWith {}
             function Connect-MicrosoftTeams{throw 'this will be mocked'}
             Mock Connect-MicrosoftTeams -MockWith {}
-            function Add-PowerAppsAccount {throw 'this will be mocked'}
+            function Add-PowerAppsAccount{throw 'this will be mocked'}
             Mock Add-PowerAppsAccount -MockWith {}
             function Connect-EXOHelper {throw 'this will be mocked'}
             Mock -ModuleName Connection Connect-EXOHelper -MockWith {}

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
@@ -2,7 +2,6 @@ package aad_test
 import rego.v1
 import data.aad
 import data.utils.aad.P2WARNINGSTR
-import data.utils.aad.ReportDetailsArrayLicenseWarning
 import data.utils.key.TestResult
 import data.utils.key.FAIL
 import data.utils.key.PASS

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
@@ -3,9 +3,6 @@ import rego.v1
 import data.aad
 import data.utils.aad.P2WARNINGSTR
 import data.utils.key.TestResult
-import data.utils.key.FAIL
-import data.utils.key.PASS
-
 
 #
 # Policy MS.AAD.7.1v1

--- a/README.md
+++ b/README.md
@@ -336,6 +336,8 @@ The following API permissions are required for Microsoft Graph Powershell:
 - RoleManagement.Read.Directory
 - User.Read.All
 - PrivilegedEligibilitySchedule.Read.AzureADGroup
+- PrivilegedAccess.Read.AzureADGroup
+- RoleManagementPolicy.Read.AzureADGroup
 
 ### Service Principal Application Permissions & Setup
 The minimum API permissions & user roles for each product that need to be assigned to a service principal application for ScubaGear app-only authentication are listed in the table below.
@@ -345,7 +347,9 @@ The minimum API permissions & user roles for each product that need to be assign
 | Azure Active Directory   | Directory.Read.All, GroupMember.Read.All,            |                                  |
 |                          | Organization.Read.All, Policy.Read.All,              |                                  |
 |                          | RoleManagement.Read.Directory, User.Read.All         |                                  |
-|                          | PrivilegedEligibilitySchedule.Read.AzureADGroup         |                                  |
+|                          | PrivilegedEligibilitySchedule.Read.AzureADGroup      |                                  |
+|                          | PrivilegedAccess.Read.AzureADGroup                   |                                  |
+|                          | RoleManagementPolicy.Read.AzureADGroup               |                                  |
 | Defender for Office 365  | Exchange.ManageAsApp                                 | Global Reader                    |
 | Exchange Online          | Exchange.ManageAsApp                                 | Global Reader                    |
 | Power Platform           | [See Power Platform App Registration](#power-platform-app-registration)|                |

--- a/Testing/Functional/Products/TestPlans/aad.g5.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/aad.g5.testplan.yaml
@@ -171,7 +171,7 @@ TestPlan:
   - PolicyId: MS.AAD.7.6v1
     TestDriver: RunCached
     Tests:
-      - TestDescription: MS.AAD.7.6v1 Non-Compliant case - Global admin activation does not require approval
+      - TestDescription: MS.AAD.7.6v1 Non-Compliant case - Global admin activation does not require approval (role)
         Preconditions:
           - Command: UpdateProviderExport
             Splat:
@@ -181,6 +181,8 @@ TestPlan:
                     RoleTemplateId: "62e90394-69f5-4237-9190-012177145e10"
                     Rules:
                       - Id: "Approval_EndUser_Assignment"
+                        RuleSource: "Global Administrator"
+                        RuleSourceType: "Directory Role"
                         AdditionalProperties:
                           setting:
                             isApprovalRequired: false
@@ -188,12 +190,14 @@ TestPlan:
                     RoleTemplateId: "fe930be7-5e62-47db-91af-98c3a49a38b1"
                     Rules:
                       - Id: "Approval_EndUser_Assignment"
+                        RuleSource: "User Administrator"
+                        RuleSourceType: "Directory Role"
                         AdditionalProperties:
                           setting:
                             isApprovalRequired: true
         Postconditions: []
         ExpectedResult: false
-      - TestDescription: MS.AAD.7.6v1 Compliant case - Global admin activation requires approval
+      - TestDescription: MS.AAD.7.6v1 Non-Compliant case - Global admin activation does not require approval (pim group)
         Preconditions:
           - Command: UpdateProviderExport
             Splat:
@@ -203,6 +207,34 @@ TestPlan:
                     RoleTemplateId: "62e90394-69f5-4237-9190-012177145e10"
                     Rules:
                       - Id: "Approval_EndUser_Assignment"
+                        RuleSource: "Teds PIM Group"
+                        RuleSourceType: "PIM Group"
+                        AdditionalProperties:
+                          setting:
+                            isApprovalRequired: false
+                  - DisplayName: User Administrator
+                    RoleTemplateId: "fe930be7-5e62-47db-91af-98c3a49a38b1"
+                    Rules:
+                      - Id: "Approval_EndUser_Assignment"
+                        RuleSource: "User Administrator"
+                        RuleSourceType: "Directory Role"
+                        AdditionalProperties:
+                          setting:
+                            isApprovalRequired: true
+        Postconditions: []
+        ExpectedResult: false        
+      - TestDescription: MS.AAD.7.6v1 Compliant case - Global admin activation requires approval (role)
+        Preconditions:
+          - Command: UpdateProviderExport
+            Splat:
+              Updates:
+                privileged_roles:
+                  - DisplayName: Global Administrator
+                    RoleTemplateId: "62e90394-69f5-4237-9190-012177145e10"
+                    Rules:
+                      - Id: "Approval_EndUser_Assignment"
+                        RuleSource: "Global Administrator"
+                        RuleSourceType: "Directory Role"
                         AdditionalProperties:
                           setting:
                             isApprovalRequired: true
@@ -210,6 +242,34 @@ TestPlan:
                     RoleTemplateId: "fe930be7-5e62-47db-91af-98c3a49a38b1"
                     Rules:
                       - Id: "Approval_EndUser_Assignment"
+                        RuleSource: "User Administrator"
+                        RuleSourceType: "Directory Role"
+                        AdditionalProperties:
+                          setting:
+                            isApprovalRequired: false
+        Postconditions: []
+        ExpectedResult: true
+      - TestDescription: MS.AAD.7.6v1 Compliant case - Global admin activation requires approval (pim group)
+        Preconditions:
+          - Command: UpdateProviderExport
+            Splat:
+              Updates:
+                privileged_roles:
+                  - DisplayName: Global Administrator
+                    RoleTemplateId: "62e90394-69f5-4237-9190-012177145e10"
+                    Rules:
+                      - Id: "Approval_EndUser_Assignment"
+                        RuleSource: "Teds PIM group"
+                        RuleSourceType: "PIM group"
+                        AdditionalProperties:
+                          setting:
+                            isApprovalRequired: true
+                  - DisplayName: User Administrator
+                    RoleTemplateId: "fe930be7-5e62-47db-91af-98c3a49a38b1"
+                    Rules:
+                      - Id: "Approval_EndUser_Assignment"
+                        RuleSource: "User Administrator"
+                        RuleSourceType: "Directory Role"
                         AdditionalProperties:
                           setting:
                             isApprovalRequired: false
@@ -219,7 +279,7 @@ TestPlan:
   - PolicyId: MS.AAD.7.7v1
     TestDriver: RunCached
     Tests:
-      - TestDescription: MS.AAD.7.7v1 Compliant case - Some roles with Eligible and Active assignments do NOT trigger an alert
+      - TestDescription: MS.AAD.7.7v1 Non-Compliant case - Roles with Eligible Active assignments without alert (role)
         Preconditions:
           - Command: UpdateProviderExport
             Splat:
@@ -229,15 +289,21 @@ TestPlan:
                     RoleTemplateId: "62e90394-69f5-4237-9190-012177145e10"
                     Rules:
                       - Id: "Notification_Admin_Admin_Assignment"
+                        RuleSource: "Global Administrator"
+                        RuleSourceType: "Directory Role"
                         AdditionalProperties:
                           notificationRecipients: []
                       - Id: "Notification_Admin_Admin_Eligibility"
+                        RuleSource: "Global Administrator"
+                        RuleSourceType: "Directory Role"
                         AdditionalProperties:
                           notificationRecipients: ["test@example.com"]
                   - DisplayName: User Administrator
                     RoleTemplateId: "fe930be7-5e62-47db-91af-98c3a49a38b1"
                     Rules:
                       - Id: "Notification_Admin_Admin_Assignment"
+                        RuleSource: "User Administrator"
+                        RuleSourceType: "Directory Role"
                         AdditionalProperties:
                           notificationRecipients:
                             [
@@ -246,12 +312,16 @@ TestPlan:
                               "test3@example.com",
                             ]
                       - Id: "Notification_Admin_Admin_Eligibility"
+                        RuleSource: "User Administrator"
+                        RuleSourceType: "Directory Role"
                         AdditionalProperties:
                           notificationRecipients: []
                   - DisplayName: Privileged Role Administrator
                     RoleTemplateId: "ae930be7-5e62-47db-91af-98c3a49a38ba"
                     Rules:
                       - Id: "Notification_Admin_Admin_Assignment"
+                        RuleSource: "Privileged Role Administrator"
+                        RuleSourceType: "Directory Role"
                         AdditionalProperties:
                           notificationRecipients:
                             [
@@ -260,11 +330,13 @@ TestPlan:
                               "test3@example.com",
                             ]
                       - Id: "Notification_Admin_Admin_Eligibility"
+                        RuleSource: "Privileged Role Administrator"
+                        RuleSourceType: "Directory Role"
                         AdditionalProperties:
                           notificationRecipients: ["test@example.org"]
         Postconditions: []
         ExpectedResult: false
-      - TestDescription: MS.AAD.7.7v1 Compliant case - Eligible and Active assignments trigger an alert
+      - TestDescription: MS.AAD.7.7v1 Non-Compliant case - Roles with Eligible Active assignments without alert (pim group)
         Preconditions:
           - Command: UpdateProviderExport
             Splat:
@@ -274,15 +346,21 @@ TestPlan:
                     RoleTemplateId: "62e90394-69f5-4237-9190-012177145e10"
                     Rules:
                       - Id: "Notification_Admin_Admin_Assignment"
+                        RuleSource: "Teds PIM group"
+                        RuleSourceType: "PIM Group"
                         AdditionalProperties:
-                          notificationRecipients: ["test@example.com"]
+                          notificationRecipients: []
                       - Id: "Notification_Admin_Admin_Eligibility"
+                        RuleSource: "Teds PIM group"
+                        RuleSourceType: "PIM Group"
                         AdditionalProperties:
                           notificationRecipients: ["test@example.com"]
                   - DisplayName: User Administrator
                     RoleTemplateId: "fe930be7-5e62-47db-91af-98c3a49a38b1"
                     Rules:
                       - Id: "Notification_Admin_Admin_Assignment"
+                        RuleSource: "User Administrator"
+                        RuleSourceType: "Directory Role"
                         AdditionalProperties:
                           notificationRecipients:
                             [
@@ -291,6 +369,105 @@ TestPlan:
                               "test3@example.com",
                             ]
                       - Id: "Notification_Admin_Admin_Eligibility"
+                        RuleSource: "User Administrator"
+                        RuleSourceType: "Directory Role"
+                        AdditionalProperties:
+                          notificationRecipients: []
+                  - DisplayName: Privileged Role Administrator
+                    RoleTemplateId: "ae930be7-5e62-47db-91af-98c3a49a38ba"
+                    Rules:
+                      - Id: "Notification_Admin_Admin_Assignment"
+                        RuleSource: "Teds PIM group 2"
+                        RuleSourceType: "PIM Group"
+                        AdditionalProperties:
+                          notificationRecipients:
+                            [
+                              "test@example.com",
+                              "test2@example.com",
+                              "test3@example.com",
+                            ]
+                      - Id: "Notification_Admin_Admin_Eligibility"
+                        RuleSource: "Teds PIM group 2"
+                        RuleSourceType: "PIM Group"
+                        AdditionalProperties:
+                          notificationRecipients: ["test@example.org"]
+        Postconditions: []
+        ExpectedResult: false
+      - TestDescription: MS.AAD.7.7v1 Compliant case - Roles with Eligible Active assignments with alert (role)
+        Preconditions:
+          - Command: UpdateProviderExport
+            Splat:
+              Updates:
+                privileged_roles:
+                  - DisplayName: Global Administrator
+                    RoleTemplateId: "62e90394-69f5-4237-9190-012177145e10"
+                    Rules:
+                      - Id: "Notification_Admin_Admin_Assignment"
+                        RuleSource: "Global Administrator"
+                        RuleSourceType: "Directory Role"
+                        AdditionalProperties:
+                          notificationRecipients: ["test@example.com"]
+                      - Id: "Notification_Admin_Admin_Eligibility"
+                        RuleSource: "Global Administrator"
+                        RuleSourceType: "Directory Role"
+                        AdditionalProperties:
+                          notificationRecipients: ["test@example.com"]
+                  - DisplayName: User Administrator
+                    RoleTemplateId: "fe930be7-5e62-47db-91af-98c3a49a38b1"
+                    Rules:
+                      - Id: "Notification_Admin_Admin_Assignment"
+                        RuleSource: "User Administrator"
+                        RuleSourceType: "Directory Role"
+                        AdditionalProperties:
+                          notificationRecipients:
+                            [
+                              "test@example.com",
+                              "test2@example.com",
+                              "test3@example.com",
+                            ]
+                      - Id: "Notification_Admin_Admin_Eligibility"
+                        RuleSource: "User Administrator"
+                        RuleSourceType: "Directory Role"
+                        AdditionalProperties:
+                          notificationRecipients:
+                            ["test@example.com", "test2@example.com"]
+        Postconditions: []
+        ExpectedResult: true
+      - TestDescription: MS.AAD.7.7v1 Compliant case - Roles with Eligible Active assignments with alert (pim group)
+        Preconditions:
+          - Command: UpdateProviderExport
+            Splat:
+              Updates:
+                privileged_roles:
+                  - DisplayName: Global Administrator
+                    RoleTemplateId: "62e90394-69f5-4237-9190-012177145e10"
+                    Rules:
+                      - Id: "Notification_Admin_Admin_Assignment"
+                        RuleSource: "Teds PIM group"
+                        RuleSourceType: "PIM Group"
+                        AdditionalProperties:
+                          notificationRecipients: ["test@example.com"]
+                      - Id: "Notification_Admin_Admin_Eligibility"
+                        RuleSource: "Teds PIM group"
+                        RuleSourceType: "PIM Group"
+                        AdditionalProperties:
+                          notificationRecipients: ["test@example.com"]
+                  - DisplayName: User Administrator
+                    RoleTemplateId: "fe930be7-5e62-47db-91af-98c3a49a38b1"
+                    Rules:
+                      - Id: "Notification_Admin_Admin_Assignment"
+                        RuleSource: "Teds PIM group 2"
+                        RuleSourceType: "PIM Group"
+                        AdditionalProperties:
+                          notificationRecipients:
+                            [
+                              "test@example.com",
+                              "test2@example.com",
+                              "test3@example.com",
+                            ]
+                      - Id: "Notification_Admin_Admin_Eligibility"
+                        RuleSource: "Teds PIM group"
+                        RuleSourceType: "PIM Group 2"
                         AdditionalProperties:
                           notificationRecipients:
                             ["test@example.com", "test2@example.com"]
@@ -300,7 +477,7 @@ TestPlan:
   - PolicyId: MS.AAD.7.8v1
     TestDriver: RunCached
     Tests:
-      - TestDescription: MS.AAD.7.8v1 Non-Compliant case - activation of Global Administrator does NOT triggers an alert
+      - TestDescription: MS.AAD.7.8v1 Non-Compliant case - activation Global Admin no alert (role)
         Preconditions:
           - Command: UpdateProviderExport
             Splat:
@@ -310,6 +487,8 @@ TestPlan:
                     RoleTemplateId: "62e90394-69f5-4237-9190-012177145e10"
                     Rules:
                       - Id: "Notification_Admin_EndUser_Assignment"
+                        RuleSource: "Global Administrator"
+                        RuleSourceType: "Directory Role"
                         AdditionalProperties:
                           notificationType: Email
                           notificationRecipients: []
@@ -317,13 +496,15 @@ TestPlan:
                     RoleTemplateId: "12e90394-69f5-4237-9190-012177145e11"
                     Rules:
                       - Id: "Notification_Admin_EndUser_Assignment"
+                        RuleSource: "Privileged Role Administrator"
+                        RuleSourceType: "Directory Role"
                         AdditionalProperties:
                           notificationType: Email
                           notificationRecipients:
                             ["test@example.com", "jack@beanstalk.com"]
         Postconditions: []
         ExpectedResult: false
-      - TestDescription: MS.AAD.7.8v1 Compliant case - activation of Global Administrator triggers an alert
+      - TestDescription: MS.AAD.7.8v1 Non-Compliant case - activation Global Admin no alert (pim group)
         Preconditions:
           - Command: UpdateProviderExport
             Splat:
@@ -333,6 +514,41 @@ TestPlan:
                     RoleTemplateId: "62e90394-69f5-4237-9190-012177145e10"
                     Rules:
                       - Id: "Notification_Admin_EndUser_Assignment"
+                        RuleSource: "Global Administrator"
+                        RuleSourceType: "Directory Role"
+                        AdditionalProperties:
+                          notificationType: Email
+                          notificationRecipients: ["test@example.com"]
+                      - Id: "Notification_Admin_EndUser_Assignment"
+                        RuleSource: "Teds PIM group"
+                        RuleSourceType: "PIM Group"
+                        AdditionalProperties:
+                          notificationType: Email
+                          notificationRecipients: []
+                  - DisplayName: Privileged Role Administrator
+                    RoleTemplateId: "12e90394-69f5-4237-9190-012177145e11"
+                    Rules:
+                      - Id: "Notification_Admin_EndUser_Assignment"
+                        RuleSource: "Privileged Role Administrator"
+                        RuleSourceType: "Directory Role"
+                        AdditionalProperties:
+                          notificationType: Email
+                          notificationRecipients:
+                            ["test@example.com", "jack@beanstalk.com"]
+        Postconditions: []
+        ExpectedResult: false
+      - TestDescription: MS.AAD.7.8v1 Compliant case - activation Global Admin triggers alert (role)
+        Preconditions:
+          - Command: UpdateProviderExport
+            Splat:
+              Updates:
+                privileged_roles:
+                  - DisplayName: Global Administrator
+                    RoleTemplateId: "62e90394-69f5-4237-9190-012177145e10"
+                    Rules:
+                      - Id: "Notification_Admin_EndUser_Assignment"
+                        RuleSource: "Global Administrator"
+                        RuleSourceType: "Directory Role"
                         AdditionalProperties:
                           notificationType: Email
                           notificationRecipients:
@@ -341,6 +557,42 @@ TestPlan:
                     RoleTemplateId: "12e90394-69f5-4237-9190-012177145e11"
                     Rules:
                       - Id: "Notification_Admin_EndUser_Assignment"
+                        RuleSource: "Privileged Role Administrator"
+                        RuleSourceType: "Directory Role"
+                        AdditionalProperties:
+                          notificationType: Email
+                          notificationRecipients: []
+        Postconditions: []
+        ExpectedResult: true
+      - TestDescription: MS.AAD.7.8v1 Compliant case - activation Global Admin triggers alert (pim group)
+        Preconditions:
+          - Command: UpdateProviderExport
+            Splat:
+              Updates:
+                privileged_roles:
+                  - DisplayName: Global Administrator
+                    RoleTemplateId: "62e90394-69f5-4237-9190-012177145e10"
+                    Rules:
+                      - Id: "Notification_Admin_EndUser_Assignment"
+                        RuleSource: "Global Administrator"
+                        RuleSourceType: "Directory Role"
+                        AdditionalProperties:
+                          notificationType: Email
+                          notificationRecipients:
+                            ["test@example.com", "jack@beanstalk.com"]
+                      - Id: "Notification_Admin_EndUser_Assignment"
+                        RuleSource: "Teds PIM group"
+                        RuleSourceType: "PIM Group"
+                        AdditionalProperties:
+                          notificationType: Email
+                          notificationRecipients:
+                            ["test@example.com", "jack@beanstalk.com"]
+                  - DisplayName: Privileged Role Administrator
+                    RoleTemplateId: "12e90394-69f5-4237-9190-012177145e11"
+                    Rules:
+                      - Id: "Notification_Admin_EndUser_Assignment"
+                        RuleSource: "Privileged Role Administrator"
+                        RuleSourceType: "Directory Role"
                         AdditionalProperties:
                           notificationType: Email
                           notificationRecipients: []
@@ -350,7 +602,7 @@ TestPlan:
   - PolicyId: MS.AAD.7.9v1
     TestDriver: RunCached
     Tests:
-      - TestDescription: MS.AAD.7.9v1 Non-Compliant case - activation of other highly privileged roles do NOT trigger an alert
+      - TestDescription: MS.AAD.7.9v1 Non-Compliant case - activation other roles do NOT trigger alert (role)
         Preconditions:
           - Command: UpdateProviderExport
             Splat:
@@ -360,6 +612,8 @@ TestPlan:
                     RoleTemplateId: "62e90394-69f5-4237-9190-012177145e10"
                     Rules:
                       - Id: "Notification_Admin_EndUser_Assignment"
+                        RuleSource: "Global Administrator"
+                        RuleSourceType: "Directory Role"
                         AdditionalProperties:
                           notificationType: Email
                           notificationRecipients:
@@ -368,6 +622,8 @@ TestPlan:
                     RoleTemplateId: "12e90394-69f5-4237-9190-012177145e11"
                     Rules:
                       - Id: "Notification_Admin_EndUser_Assignment"
+                        RuleSource: "Privileged Role Administrator"
+                        RuleSourceType: "Directory Role"
                         AdditionalProperties:
                           notificationType: Email
                           notificationRecipients:
@@ -376,6 +632,8 @@ TestPlan:
                     RoleTemplateId: "52e90394-69f5-4237-9190-012177145e15"
                     Rules:
                       - Id: "Notification_Admin_EndUser_Assignment"
+                        RuleSource: "User Administrator"
+                        RuleSourceType: "Directory Role"
                         AdditionalProperties:
                           notificationType: Email
                           notificationRecipients: []
@@ -383,12 +641,14 @@ TestPlan:
                     RoleTemplateId: "62e90394-69f5-4237-9190-012177145e16"
                     Rules:
                       - Id: "Notification_Admin_EndUser_Assignment"
+                        RuleSource: "Cloud Application Administrator"
+                        RuleSourceType: "Directory Role"
                         AdditionalProperties:
                           notificationType: Email
                           notificationRecipients: []
         Postconditions: []
         ExpectedResult: false
-      - TestDescription: MS.AAD.7.9v1 Compliant case - activation of other highly privileged roles trigger an alert
+      - TestDescription: MS.AAD.7.9v1 Non-Compliant case - activation other roles do NOT trigger alert (pim group)
         Preconditions:
           - Command: UpdateProviderExport
             Splat:
@@ -398,6 +658,43 @@ TestPlan:
                     RoleTemplateId: "62e90394-69f5-4237-9190-012177145e10"
                     Rules:
                       - Id: "Notification_Admin_EndUser_Assignment"
+                        RuleSource: "Global Administrator"
+                        RuleSourceType: "Directory Role"
+                        AdditionalProperties:
+                          notificationType: Email
+                          notificationRecipients:
+                            ["test@example.com", "jack@beanstalk.com"]
+                  - DisplayName: Privileged Role Administrator
+                    RoleTemplateId: "12e90394-69f5-4237-9190-012177145e11"
+                    Rules:
+                      - Id: "Notification_Admin_EndUser_Assignment"
+                        RuleSource: "Privileged Role Administrator"
+                        RuleSourceType: "Directory Role"
+                        AdditionalProperties:
+                          notificationType: Email
+                          notificationRecipients:
+                            ["test@example.com", "jack@beanstalk.com"]
+                      - Id: "Notification_Admin_EndUser_Assignment"
+                        RuleSource: "Teds PIM group"
+                        RuleSourceType: "PIM Group"
+                        AdditionalProperties:
+                          notificationType: Email
+                          notificationRecipients:
+                            []
+        Postconditions: []
+        ExpectedResult: false
+      - TestDescription: MS.AAD.7.9v1 Compliant case - activation other roles trigger alert (role)
+        Preconditions:
+          - Command: UpdateProviderExport
+            Splat:
+              Updates:
+                privileged_roles:
+                  - DisplayName: Global Administrator
+                    RoleTemplateId: "62e90394-69f5-4237-9190-012177145e10"
+                    Rules:
+                      - Id: "Notification_Admin_EndUser_Assignment"
+                        RuleSource: "Global Administrator"
+                        RuleSourceType: "Directory Role"
                         AdditionalProperties:
                           notificationType: Email
                           notificationRecipients: []
@@ -405,6 +702,8 @@ TestPlan:
                     RoleTemplateId: "12e90394-69f5-4237-9190-012177145e11"
                     Rules:
                       - Id: "Notification_Admin_EndUser_Assignment"
+                        RuleSource: "Privileged Role Administrator"
+                        RuleSourceType: "Directory Role"
                         AdditionalProperties:
                           notificationType: Email
                           notificationRecipients:
@@ -413,6 +712,45 @@ TestPlan:
                     RoleTemplateId: "52e90394-69f5-4237-9190-012177145e15"
                     Rules:
                       - Id: "Notification_Admin_EndUser_Assignment"
+                        RuleSource: "User Administrator"
+                        RuleSourceType: "Directory Role"
+                        AdditionalProperties:
+                          notificationType: Email
+                          notificationRecipients:
+                            ["stopit@example.com", "erase@beanstalk.com"]
+        Postconditions: []
+        ExpectedResult: true
+      - TestDescription: MS.AAD.7.9v1 Compliant case - activation other roles trigger alert (pim group)
+        Preconditions:
+          - Command: UpdateProviderExport
+            Splat:
+              Updates:
+                privileged_roles:
+                  - DisplayName: Global Administrator
+                    RoleTemplateId: "62e90394-69f5-4237-9190-012177145e10"
+                    Rules:
+                      - Id: "Notification_Admin_EndUser_Assignment"
+                        RuleSource: "Global Administrator"
+                        RuleSourceType: "Directory Role"
+                        AdditionalProperties:
+                          notificationType: Email
+                          notificationRecipients: []
+                  - DisplayName: Privileged Role Administrator
+                    RoleTemplateId: "12e90394-69f5-4237-9190-012177145e11"
+                    Rules:
+                      - Id: "Notification_Admin_EndUser_Assignment"
+                        RuleSource: "Privileged Role Administrator"
+                        RuleSourceType: "Directory Role"
+                        AdditionalProperties:
+                          notificationType: Email
+                          notificationRecipients:
+                            ["test@example.com", "jack@beanstalk.com"]
+                  - DisplayName: User Administrator
+                    RoleTemplateId: "52e90394-69f5-4237-9190-012177145e15"
+                    Rules:
+                      - Id: "Notification_Admin_EndUser_Assignment"
+                        RuleSource: "Teds PIM group"
+                        RuleSourceType: "PIM Group"
                         AdditionalProperties:
                           notificationType: Email
                           notificationRecipients:

--- a/Testing/Functional/Products/TestPlans/aad.g5.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/aad.g5.testplan.yaml
@@ -222,7 +222,7 @@ TestPlan:
                           setting:
                             isApprovalRequired: true
         Postconditions: []
-        ExpectedResult: false        
+        ExpectedResult: false
       - TestDescription: MS.AAD.7.6v1 Compliant case - Global admin activation requires approval (role)
         Preconditions:
           - Command: UpdateProviderExport


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##

Updated AAD Provider to add PIM configurations to the JSON for groups that are enrolled in PIM for Groups in the Get-PrivilegedRole function. Modified the Rego to support reporting on PIM group configurations in addition to role configurations. This affects AAD policies 7.6 - 7.9. 

closes #919 
closes #981 
closes #975 
closes #944 

Salient items changed:

- Added code to the AAD provider Get-PrivilegedRole to support PIM for groups
- Modified Rego policies to report on roles and PIM groups
- Added required permissions to the Connection object
- Modified existing functional tests for 7.6 through 7.9 and added new tests for PIM for groups scenarios


## 💭 Motivation and context ##

PIM Groups provide mechanism to give users privileged access.  This enhancement allows to make sure notifications/alerts are produced appropriately. 

## 🧪 Testing ##

- Updated and ran REGO Unit test
- Created test scenarios on E5 and G5 tenants to test. Tested on G3 as well.
- Tested using the updated functional tests as well. 

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [X] This PR has an informative and human-readable title.
- [X] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] Changes are sized such that they do not touch excessive number of files.
- [X] *All* future TODOs are captured in issues, which are referenced in code comments.
- [X] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [X] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [X] All relevant type-of-change labels added.
- [X] All relevant project fields are set.
- [X] All relevant repo and/or project documentation updated to reflect these changes.
- [X] Unit tests added/updated to cover PowerShell and Rego changes.
- [X] Functional tests added/updated to cover PowerShell and Rego changes. Except covered in #944 
- [X] All relevant functional tests passed.
- [X] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] PR passed smoke test check.
- [ ] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [ ] Resolved all merge conflicts on branch
- [ ] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
