### PR TITLE
Add scope attributes to tables in HTML Report

### DIFF
--- a/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
+++ b/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
@@ -170,6 +170,9 @@ function New-Report {
         $MarkdownLink = "<a class='control_group' href=`"$($ScubaGitHubUrl)/blob/v$($SettingsExport.module_version)/PowerShell/ScubaGear/baselines/$($BaselineName.ToLower()).md$GroupAnchor`" target=`"_blank`">$Name</a>"
         $Fragments += $Fragment | ConvertTo-Html -PreContent "<h2>$Number $MarkdownLink</h2>" -Fragment
         $ReportJson.Results += $Fragment
+
+        # Regex will filter out any <table> tags without an id attribute (replace new fragments only, not <table> tags which have already been modified)
+        $Fragments = $Fragments -replace ".*(<table(?![^>]+id)*>)", "<table class='policy-data' id='$Number' style = 'text-align:center;'>"
     }
 
     # Craft the json report

--- a/PowerShell/ScubaGear/Modules/CreateReport/scripts/ParentReport.js
+++ b/PowerShell/ScubaGear/Modules/CreateReport/scripts/ParentReport.js
@@ -1,3 +1,4 @@
 window.addEventListener('DOMContentLoaded', (event) => {
+    applyScopeAttributes();
     mountDarkMode("Parent Report");
 });

--- a/PowerShell/ScubaGear/Modules/CreateReport/scripts/main.js
+++ b/PowerShell/ScubaGear/Modules/CreateReport/scripts/main.js
@@ -97,6 +97,9 @@ const fillCAPTable = () => {
         table.setAttribute("class", "caps_table");
         capDiv.appendChild(table);
 
+        let tbody = document.createElement("tbody");
+        table.appendChild(tbody);
+
         let header = document.createElement("tr");
         for (let i = 0; i < capColNames.length; i++) {
             let th = document.createElement("th");
@@ -115,7 +118,7 @@ const fillCAPTable = () => {
             th.innerHTML = capColNames[i];
             header.appendChild(th);
         }
-        table.appendChild(header);
+        tbody.appendChild(header);
 
         for (let i = 0; i < caps.length; i++) {
             let tr = document.createElement("tr");
@@ -133,7 +136,7 @@ const fillCAPTable = () => {
             img.rowNumber = i;
             img.addEventListener("click", expandCAPRow);
             tr.querySelectorAll('td')[0].appendChild(img);
-            table.appendChild(tr);
+            tbody.appendChild(tr);
         }
     }
     catch (error) {
@@ -299,5 +302,6 @@ const expandCAPRow = (event) => {
 window.addEventListener('DOMContentLoaded', (event) => {
     colorRows();
     fillCAPTable();
+    applyScopeAttributes();
     mountDarkMode("Individual Report");
 });

--- a/PowerShell/ScubaGear/Modules/CreateReport/scripts/utils.js
+++ b/PowerShell/ScubaGear/Modules/CreateReport/scripts/utils.js
@@ -51,3 +51,49 @@ const toggleDarkMode = () => {
         setDarkMode('false');
     }
 }
+
+/**
+ * For each table present in a report, the function adds scope attributes for columns and rows. 
+ */
+const applyScopeAttributes = () => {
+    try {
+        const tables = document.querySelectorAll("table");
+        for(let i = 0; i < tables.length; i++) {
+            // each table has two children, <colgroup> and <tbody>
+            let tbody = tables[i].querySelector("tbody");
+            if(!tbody) throw new Error(
+                `Invalid HTML structure, <table id='${tables[i].getAttribute("id")}'> does not have a <tbody> tag.`
+            );
+            
+            /**
+             * the first <tr> in <tbody> represents columns. Label each nested <th> as scope="col"
+             * 
+             * second <tr> + ... are the rows
+             * for each <tr>, the first <td> should be labeled as scope="row", leave the rest
+             */
+            let cols, rows;
+            if(tbody.children && tbody.children.length > 1) {
+                cols = tbody.children[0].querySelectorAll("th");
+                for(let th = 0; th < cols.length; th++) {
+                    cols[th].setAttribute("scope", "col");
+                }
+
+                // change location of scope="row" if necessary (may have to adjust for structure of license info?)
+                let trIdx = (tables[i].classList.contains("caps_table")) ? 1 : 0;
+
+                // skip column <tr>; for each remaining <tr> set the scope 
+                rows = tbody.children;
+                for(let tr = 1; tr < rows.length; tr++) {
+                    rows[tr].querySelectorAll("td")[trIdx].setAttribute("scope", "row");
+                }
+            }
+            else throw new Error(
+                `Unable to apply scope attributes to columns/rows, 
+                <tbody> of <table id='${tables[i].getAttribute("id")}'> does not contain children or has no rows.`
+            );
+        }
+    }
+    catch (error) {
+        console.error(`Error in applyScopeAttributes, ${error}`);
+    }
+}

--- a/Testing/Functional/SmokeTest/SmokeTest002.Tests.ps1
+++ b/Testing/Functional/SmokeTest/SmokeTest002.Tests.ps1
@@ -109,6 +109,24 @@ Describe -Tag "UI","Chrome" -Name "Test Report with <Browser> for $OrganizationN
                     $TenantDataColumns = Get-SeElement -Target $Rows[1] -By TagName "td"
                     $Tenant = $TenantDataColumns[0].Text
                     $Tenant | Should -Be $OrganizationName -Because "Tenant is $Tenant"
+
+                    $RowHeaders = Get-SeElement -Element $Rows[0] -By TagName 'th'
+
+                    ForEach ($Header in $RowHeaders){
+                        $Header.GetAttribute("scope") | Should -Be "col" -Because 'Each <th> tag must have a scope attribute set to "col"'
+                    }
+
+                    For ($i = 1; $i -lt $Rows.length; $i++){
+                        $RowData = Get-SeElement -Element $Rows[$i] -By TagName 'td'
+                        For($j = 0; $j -lt $RowData.length; $j++){
+                            if($j -eq 0){
+                                $RowData[$j].GetAttribute("scope") | Should -Be "row" -Because "There should only be one scope attribute set for each data row"
+                            }
+                            else{
+                                $RowData[$j].GetAttribute("scope") | Should -Not -Be "row"
+                            }
+                        }
+                    }
                 }
                 # AAD detailed report has a Conditional Access Policy table
                 elseif ($Table.GetAttribute("class") -eq "caps_table"){
@@ -126,6 +144,22 @@ Describe -Tag "UI","Chrome" -Name "Test Report with <Browser> for $OrganizationN
 
                         if ($RowData.Count -gt 0){
                             $RowData.Count | Should -BeExactly 8
+                        }
+                    }
+
+                    ForEach ($Header in $RowHeaders){
+                        $Header.GetAttribute("scope") | Should -Be "col" -Because 'Each <th> tag must have a scope attribute set to "col"'
+                    }
+
+                    For ($i = 1; $i -lt $Rows.length; $i++){
+                        $RowData = Get-SeElement -Element $Rows[$i] -By TagName 'td'
+                        For($j = 0; $j -lt $RowData.length; $j++){
+                            if($j -eq 1){
+                                $RowData[$j].GetAttribute("scope") | Should -Be "row" -Because "There should only be one scope attribute set for each data row"
+                            }
+                            else{
+                                $RowData[$j].GetAttribute("scope") | Should -Not -Be "row"
+                            }
                         }
                     }
                 }
@@ -146,6 +180,22 @@ Describe -Tag "UI","Chrome" -Name "Test Report with <Browser> for $OrganizationN
                         if ($RowData.Count -gt 0){
                             $RowData.Count | Should -BeExactly 5
                             $RowData[2].text | Should -Not -BeLikeExactly "Error - Test results missing" -Because "All policies should have implementations: $($RowData[0].text)"
+                        }
+                    }
+
+                    ForEach ($Header in $RowHeaders){
+                        $Header.GetAttribute("scope") | Should -Be "col" -Because 'Each <th> tag must have a scope attribute set to "col"'
+                    }
+
+                    For ($i = 1; $i -lt $Rows.length; $i++){
+                        $RowData = Get-SeElement -Element $Rows[$i] -By TagName 'td'
+                        For($j = 0; $j -lt $RowData.length; $j++){
+                            if($j -eq 0){
+                                $RowData[$j].GetAttribute("scope") | Should -Be "row" -Because "There should only be one scope attribute set for each data row"
+                            }
+                            else{
+                                $RowData[$j].GetAttribute("scope") | Should -Not -Be "row"
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

- Adds a new function in utils.js of ScubaGear's CreateReport module. The function applies scope="col"/"row" to each \<table> in both parent and individual HTML reports.
- Slightly modify CAP table to contain a \<tbody> tag so the new function operates correctly. 
- In CreateReport.psm1, fragments for the policy control tables are modified with an id, e.g. AAD-1, for better error handling. 
- Modify SmokeTest002.Tests.ps1 to check if attributes are set correctly

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

Resolves #93 

The change is required for 508/WCAG conformance, primarily under [Guideline 1.3.1](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html).

A technique sufficient for meeting this guideline is [Technique H63](https://www.w3.org/WAI/WCAG21/Techniques/html/H63), Using the scope attribute to associate header cells and data cells in data tables.


## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

1. Create a new report 

```
Import-Module -Name .\PowerShell\ScubaGear `
Invoke-Scuba -ProductNames aad
```
2. Take a look at different tables throughout the report: tenant data, baseline conformance reports, policy control tables, etc. 
3. Check that scope="col" is applied to all \<th> in the first \<tr> of \<tbody>. 
4. Then for subsequent \<tr> tags check that scope="row"  is applied once, either to the Control ID column for the policy control tables, or the Name column for the CAP table. 
5. Check across multiple browsers such as Safari, Firefox, Edge, etc.

Run smoke test to verify Invoke-SCuBA creates a valid HTML report 

```
$TestContainer = New-PesterContainer -Path "SmokeTest002.Tests.ps1" `
-Data @{ 
    OrganizationDomain = "your-tenant.onmicrosoft.com"; 
    OrganizationName = "Cybersecurity and Infrastructure Security Agency" 
} 
Invoke-Pester -Container $TestContainer -Output Detailed
```


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [x] Resolved all merge conflicts on branch
- [ ] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
