### PR TITLE
Create a workflow for bumping the ScubaGear module version

### DIFF
--- a/.github/workflows/run_module_version_bump.yml
+++ b/.github/workflows/run_module_version_bump.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Bump ScubaGear Version Number
         env:

--- a/.github/workflows/run_module_version_bump.yml
+++ b/.github/workflows/run_module_version_bump.yml
@@ -33,9 +33,9 @@ jobs:
           (Get-Content -Path $ManifestPath) | ForEach-Object {
             $ModuleVersionRegex = $_ -match "ModuleVersion = $($VersionRegex)"
             if ($ModuleVersionRegex) {
-                $_ -match $VersionRegex
+                $_ -match $VersionRegex | Out-Null
                 $PreviousVersion = $matches[0] -replace "'", ""
-                $_ -replace $VersionRegex, '${env:NEW_VERSION_NUMBER}'
+                $_ -replace $VersionRegex, "'${env:NEW_VERSION_NUMBER}'"
             }
             else {
               $_

--- a/.github/workflows/run_module_version_bump.yml
+++ b/.github/workflows/run_module_version_bump.yml
@@ -1,0 +1,112 @@
+name: Module Version Bump
+
+on:
+  workflow_dispatch:
+    inputs:
+      newVersionNumber:
+        description: "New Version number (e.g., 1.2.4)"
+        required: true
+        type: string
+
+jobs:
+  module-version-bump:
+    runs-on: windows-latest
+    env: 
+      NEW_VERSION_NUMBER: ${{ inputs.newVersionNumber }}
+    permissions:
+      contents: write
+      pull-requests: write 
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Bump ScubaGear Version Number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          #
+          # Replace ScubaGear module version in the manifest.
+          # 
+          $ManifestPath = '.\PowerShell\ScubaGear\ScubaGear.psd1'
+          $VersionRegex = "\'\d+\.\d+\.\d+\'"
+          $PreviousVersion = ''
+          (Get-Content -Path $ManifestPath) | ForEach-Object {
+            $ModuleVersionRegex = $_ -match "ModuleVersion = $($VersionRegex)"
+            if ($ModuleVersionRegex) { 
+                $_ -match $VersionRegex
+                $PreviousVersion = $matches[0] -replace "'", ""
+                $_ -replace $VersionRegex, '${env:NEW_VERSION_NUMBER}'
+            } 
+           else {
+              $_
+             }
+          } | Set-Content -Path $ManifestPath
+
+          #
+          # Replace ScubaGear module version in the README
+          #
+          $READMEPath = '.\README.md'
+          $BadgeRegex = "ScubaGear-v\d+\.\d+\.\d+"
+          $ZipRegex = "ScubaGear-v\d+\-\d+\-\d+.zip"
+          $ZipVerReplace = "ScubaGear-v${env:NEW_VERSION_NUMBER}" -replace '\.', '-'
+          $ZipVerReplace = $ZipVerReplace + '.zip'
+          (Get-Content -Path $READMEPath) | ForEach-Object {
+             $BadgeVerMatch = $_ -match $BadgeRegex
+             $ZipVerMatch = $_ -match $ZipRegex
+             if ($BadgeVerMatch) {
+                $_ -replace $BadgeRegex, "ScubaGear-v${env:NEW_VERSION_NUMBER}"
+             } 
+             elseif ($ZipVerMatch) {
+                   $_ -replace $ZipRegex, $ZipVerReplace
+             }
+             else {
+                   $_
+             }
+          } | Set-Content -Path $READMEPath
+
+          # 
+          # Create the PR body
+          #
+          $PRTemplatePath = '.\.github\pull_request_template.md'
+
+          $Description = '<!-- Describe the "what" of your changes in detail. -->'
+          $Motivation = '<!-- Why is this change required\? -->'
+          $Testing = '<!-- see how your change affects other areas of the code, etc. -->'
+          $RemoveHeader = '# <!-- Use the title to describe PR changes in the imperative mood --> #'
+          
+          $NewDescription = "- This PR was create by a GitHub Action to bump ScubaGear's module version in the manifest and the README.`n - Please fill out the rest of the template that the Action did not cover. `n"
+          $NewMotivation = "- Bump ScubaGear's module version to v${env:NEW_VERSION_NUMBER} before the next release`n"
+          $NewTesting = "- A human should still check if the version bumping was successful by running ScubaGear.`n"
+
+          $Body = "This is a test body fear me"
+          $PRTemplateContent = (Get-Content -Path $PRTemplatePath) | ForEach-Object {
+            $DescriptionRegex = $_ -match $Description
+            $MotivationRegex = $_ -match $Motivation
+            $TestingRegex = $_ -match $Testing
+            $RemoveHeaderRegex = $_ -match $RemoveHeader # removes unneeded new line
+            if ($DescriptionRegex) {
+                  $_ -replace $Description, $NewDescription
+            } 
+            elseif ($MotivationRegex) {
+                  $_ -replace $Motivation, $NewMotivation
+            } 
+            elseif ($TestingRegex) {
+                $_ -replace $Testing, $NewTesting
+            }
+            elseif ($RemoveHeaderRegex) {
+               $_ -replace $RemoveHeader, ""
+            }
+            else {
+                   $_ + "`n"
+                 }
+          }
+          
+          # Create the PR
+          $ScubaGearVersionBumpBranch = "scubagear-version-bump-${env:NEW_VERSION_NUMBER}" 
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+          git checkout -b $ScubaGearVersionBumpBranch
+          git add .
+          git commit -m "Update ScubaGear version to ${env:NEW_VERSION_NUMBER}"
+          git push origin $ScubaGearVersionBumpBranch
+          gh pr create -B main -H $ScubaGearVersionBumpBranch --title "Bump ScubaGear module version from v$($PreviousVersion) to v${env:NEW_VERSION_NUMBER}" --body "${PRTemplateContent}" --label "version bump"

--- a/.github/workflows/run_module_version_bump.yml
+++ b/.github/workflows/run_module_version_bump.yml
@@ -78,7 +78,6 @@ jobs:
           $NewMotivation = "- Bump ScubaGear's module version to v${env:NEW_VERSION_NUMBER} before the next release`n"
           $NewTesting = "- A human should still check if the version bumping was successful by running ScubaGear.`n"
 
-          $Body = "This is a test body fear me"
           $PRTemplateContent = (Get-Content -Path $PRTemplatePath) | ForEach-Object {
             $DescriptionRegex = $_ -match $Description
             $MotivationRegex = $_ -match $Motivation

--- a/.github/workflows/run_module_version_bump.yml
+++ b/.github/workflows/run_module_version_bump.yml
@@ -11,11 +11,11 @@ on:
 jobs:
   module-version-bump:
     runs-on: windows-latest
-    env: 
+    env:
       NEW_VERSION_NUMBER: ${{ inputs.newVersionNumber }}
     permissions:
       contents: write
-      pull-requests: write 
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -26,20 +26,20 @@ jobs:
         run: |
           #
           # Replace ScubaGear module version in the manifest.
-          # 
+          #
           $ManifestPath = '.\PowerShell\ScubaGear\ScubaGear.psd1'
           $VersionRegex = "\'\d+\.\d+\.\d+\'"
           $PreviousVersion = ''
           (Get-Content -Path $ManifestPath) | ForEach-Object {
             $ModuleVersionRegex = $_ -match "ModuleVersion = $($VersionRegex)"
-            if ($ModuleVersionRegex) { 
+            if ($ModuleVersionRegex) {
                 $_ -match $VersionRegex
                 $PreviousVersion = $matches[0] -replace "'", ""
                 $_ -replace $VersionRegex, '${env:NEW_VERSION_NUMBER}'
-            } 
-           else {
+            }
+            else {
               $_
-             }
+            }
           } | Set-Content -Path $ManifestPath
 
           #
@@ -51,20 +51,20 @@ jobs:
           $ZipVerReplace = "ScubaGear-v${env:NEW_VERSION_NUMBER}" -replace '\.', '-'
           $ZipVerReplace = $ZipVerReplace + '.zip'
           (Get-Content -Path $READMEPath) | ForEach-Object {
-             $BadgeVerMatch = $_ -match $BadgeRegex
-             $ZipVerMatch = $_ -match $ZipRegex
-             if ($BadgeVerMatch) {
-                $_ -replace $BadgeRegex, "ScubaGear-v${env:NEW_VERSION_NUMBER}"
-             } 
-             elseif ($ZipVerMatch) {
-                   $_ -replace $ZipRegex, $ZipVerReplace
-             }
-             else {
-                   $_
-             }
+            $BadgeVerMatch = $_ -match $BadgeRegex
+            $ZipVerMatch = $_ -match $ZipRegex
+            if ($BadgeVerMatch) {
+              $_ -replace $BadgeRegex, "ScubaGear-v${env:NEW_VERSION_NUMBER}"
+            }
+            elseif ($ZipVerMatch) {
+              $_ -replace $ZipRegex, $ZipVerReplace
+            }
+            else {
+              $_
+            }
           } | Set-Content -Path $READMEPath
 
-          # 
+          #
           # Create the PR body
           #
           $PRTemplatePath = '.\.github\pull_request_template.md'
@@ -73,7 +73,7 @@ jobs:
           $Motivation = '<!-- Why is this change required\? -->'
           $Testing = '<!-- see how your change affects other areas of the code, etc. -->'
           $RemoveHeader = '# <!-- Use the title to describe PR changes in the imperative mood --> #'
-          
+
           $NewDescription = "- This PR was create by a GitHub Action to bump ScubaGear's module version in the manifest and the README.`n - Please fill out the rest of the template that the Action did not cover. `n"
           $NewMotivation = "- Bump ScubaGear's module version to v${env:NEW_VERSION_NUMBER} before the next release`n"
           $NewTesting = "- A human should still check if the version bumping was successful by running ScubaGear.`n"
@@ -86,23 +86,23 @@ jobs:
             $RemoveHeaderRegex = $_ -match $RemoveHeader # removes unneeded new line
             if ($DescriptionRegex) {
                   $_ -replace $Description, $NewDescription
-            } 
+            }
             elseif ($MotivationRegex) {
                   $_ -replace $Motivation, $NewMotivation
-            } 
+            }
             elseif ($TestingRegex) {
                 $_ -replace $Testing, $NewTesting
             }
             elseif ($RemoveHeaderRegex) {
-               $_ -replace $RemoveHeader, ""
+              $_ -replace $RemoveHeader, ""
             }
             else {
-                   $_ + "`n"
-                 }
+              $_ + "`n"
+            }
           }
-          
+
           # Create the PR
-          $ScubaGearVersionBumpBranch = "scubagear-version-bump-${env:NEW_VERSION_NUMBER}" 
+          $ScubaGearVersionBumpBranch = "scubagear-version-bump-${env:NEW_VERSION_NUMBER}"
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
           git checkout -b $ScubaGearVersionBumpBranch


### PR DESCRIPTION
## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->
- This PR adds a GitHub action for bumping the ScubaGear version in the manifest and the README and automatically create a PR. 
- The workflow has one input the module version we want to bump to. For example if we want ScubaGear to be version `1.2.0`. Then the input will be `1.2.0`. No `v`'s needed. 
- This PR is one of a series of dependency updates that are incoming. 

## 💭 Motivation and context ##
Closes #986 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Example PR that's created running the workflow [example PR](https://github.com/buidav/ScubaGear/pull/19).
You can also fork ScubaGear, specifically this branch, to test this PR or your own fork.

## 📷 Screenshots (if appropriate) ##
Note that this GitHub action requires write permissions to PRs.
You can configure the permissions for this on the repo settings under `Settings` => `Actions` => `General` => `Workflow permissions`. Ensure the options below are selected. 
<img width="495" alt="checkedTheseBoxes" src="https://github.com/cisagov/ScubaGear/assets/105074908/3f73f826-9595-4a66-bb03-73d04ca550c6">



## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] PR passed smoke test check.
- [ ] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [ ] Resolved all merge conflicts on branch
- [ ] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
