### PR TITLE
Fix dark mode checkbox from being in incorrect state

### DIFF
--- a/PowerShell/ScubaGear/Modules/CreateReport/IndividualReport/IndividualReport.html
+++ b/PowerShell/ScubaGear/Modules/CreateReport/IndividualReport/IndividualReport.html
@@ -17,7 +17,7 @@
             </header>
             <p id="toggle-text">Light mode</p>
             <label class="switch">
-                <input id="toggle" type="checkbox" onclick="toggleDarkMode()">
+                <input id="toggle" type="checkbox" autocomplete="off" onclick="toggleDarkMode()">
                 <span class="slider round"></span>
               </label>
             <h1>{TITLE}</h1>

--- a/PowerShell/ScubaGear/Modules/CreateReport/ParentReport/ParentReport.html
+++ b/PowerShell/ScubaGear/Modules/CreateReport/ParentReport/ParentReport.html
@@ -18,7 +18,7 @@
             </header>
             <p id="toggle-text">Light mode</p>
             <label class="switch">
-                <input id="toggle" type="checkbox" onclick="toggleDarkMode()">
+                <input id="toggle" type="checkbox" autocomplete="off" onclick="toggleDarkMode()">
                 <span class="slider round"></span>
               </label>
             <h1>SCuBA M365 Security Baseline Conformance Reports</h1>


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

The dark mode checkbox is set to the incorrect state when navigating to/from the main and individual reports. 

Under the [Additional attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#additional_attributes) section, "Unlike other browsers, Firefox by default [persists the dynamic checked state](https://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing) of an <input> across page loads. Use the [autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#autocomplete) attribute to control this feature." As to whether Chrome and Edge also have dynamic checked state, it is not clear but adding the `autocomplete="off"` attribute fixes this bug.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

Part of https://github.com/cisagov/ScubaGear/issues/820
Closes #175 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

1. Turn on dark mode on the main report
2. Go to an individual report and turn off dark mode
3. Click the back button, the dark mode switch should not toggle.

Test on Edge and Chrome browsers.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] Changes are sized such that they do not touch excessive number of files.
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [ ] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] All relevant type-of-change labels added.
- [ ] All relevant project fields are set.
- [ ] All relevant repo and/or project documentation updated to reflect these changes.
- [ ] Unit tests added/updated to cover PowerShell and Rego changes.
- [ ] Functional tests added/updated to cover PowerShell and Rego changes.
- [ ] All relevant functional tests passed.
- [ ] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] PR passed smoke test check.
- [ ] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [ ] Resolved all merge conflicts on branch
- [ ] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
