### PR TITLE
Remove push trigger on nightly tests

### DIFF
--- a/.github/workflows/test_production_function.yaml
+++ b/.github/workflows/test_production_function.yaml
@@ -9,7 +9,6 @@ name: Nightly Product Functional Tests
 # Run this workflow at 12:15 am
 # on every Sun to Thr (b/c GMT -5)
 on:
-  push:
   schedule:
     - cron: "15 4 * * 0-4"
   workflow_dispatch:


### PR DESCRIPTION
## 🗣 Description ##

Removed the push trigger.
Closes #1007.

## 💭 Motivation and context ##

Nightly tests are supposed to run nightly.

## 🧪 Testing ##

Checked pipeline and nightly workflows.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

- [ ] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed
- [x] Resolved all merge conflicts on branch
- [x] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

- [x] Feature branch deleted after merge to clean up repository.
- [x] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
