### PR TITLE
Add a UTC timestamp to the Provider JSON

### DIFF
--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -583,7 +583,7 @@ function Invoke-ProviderList {
             $ProviderJSON = $ProviderJSON.TrimEnd(",")
             $TimeZone = ""
             $CurrentDate = Get-Date -ErrorAction 'Stop'
-            $UTCTimestamp = $CurrentDate.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+            $UTCTimestamp = $CurrentDate.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
             $GetTimeZone = Get-TimeZone -ErrorAction 'Stop'
             if (($CurrentDate).IsDaylightSavingTime()) {
                 $TimeZone = ($GetTimeZone).DaylightName

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -814,6 +814,15 @@ function Merge-JsonOutput {
     )
     process {
         try {
+            # Files to delete at the end if no errors are encountered
+            $DeletionList = @()
+
+            # Load the raw provider output
+            $SettingsExportPath = Join-Path $OutFolderPath -ChildPath "$($OutProviderFileName).json"
+            $DeletionList += $SettingsExportPath
+            $SettingsExport =  Get-Content $SettingsExportPath -Raw
+            $TimestampZulu = $(ConvertFrom-Json $SettingsExport).timestamp_zulu
+
             # Extract the metadata
             $Results = [pscustomobject]@{}
             $Summary = [pscustomobject]@{}
@@ -824,10 +833,9 @@ function Merge-JsonOutput {
                 "Product" = "M365";
                 "Tool" = "ScubaGear";
                 "ToolVersion" = $ModuleVersion;
+                "TimestampZulu" = $TimestampZulu;
             }
 
-            # Files to delete at the end if no errors are encountered
-            $DeletionList = @()
 
             # Aggregate the report results and summaries
             $IndividualReportPath = Join-Path -Path $OutFolderPath $IndividualReportFolderName -ErrorAction 'Stop'
@@ -845,11 +853,6 @@ function Merge-JsonOutput {
                 $Summary | Add-Member -NotePropertyName $BaselineName `
                     -NotePropertyValue $IndividualResults.ReportSummary
             }
-
-            # Load the raw provider output
-            $SettingsFileName = Join-Path -Path $OutFolderPath -ChildPath "$($OutProviderFileName).json"
-            $DeletionList += $SettingsFileName
-            $SettingsExport =  Get-Content $SettingsFileName -Raw
 
             # Convert the output a json string
             $MetaData = ConvertTo-Json $MetaData

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -583,7 +583,7 @@ function Invoke-ProviderList {
             $ProviderJSON = $ProviderJSON.TrimEnd(",")
             $TimeZone = ""
             $CurrentDate = Get-Date -ErrorAction 'Stop'
-            $UTCTimestamp = $CurrentDate.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+            $TimestampZulu = $CurrentDate.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
             $GetTimeZone = Get-TimeZone -ErrorAction 'Stop'
             if (($CurrentDate).IsDaylightSavingTime()) {
                 $TimeZone = ($GetTimeZone).DaylightName
@@ -602,7 +602,7 @@ function Invoke-ProviderList {
                 "baseline_version": "1",
                 "module_version": "$ModuleVersion",
                 "date": "$($CurrentDate) $($TimeZone)",
-                "timestamp": "$($UTCTimestamp)",
+                "timestamp_zulu": "$($TimestampZulu)",
                 "tenant_details": $($TenantDetails),
                 "scuba_config": $($ConfigDetails),
 

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -583,6 +583,7 @@ function Invoke-ProviderList {
             $ProviderJSON = $ProviderJSON.TrimEnd(",")
             $TimeZone = ""
             $CurrentDate = Get-Date -ErrorAction 'Stop'
+            $UTCTimestamp = $CurrentDate.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
             $GetTimeZone = Get-TimeZone -ErrorAction 'Stop'
             if (($CurrentDate).IsDaylightSavingTime()) {
                 $TimeZone = ($GetTimeZone).DaylightName
@@ -601,6 +602,7 @@ function Invoke-ProviderList {
                 "baseline_version": "1",
                 "module_version": "$ModuleVersion",
                 "date": "$($CurrentDate) $($TimeZone)",
+                "timestamp": "$($UTCTimestamp)",
                 "tenant_details": $($TenantDetails),
                 "scuba_config": $($ConfigDetails),
 

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -875,7 +875,7 @@ function Merge-JsonOutput {
 
             # Save the file
             $JsonFileName = Join-Path -Path $OutFolderPath "$($OutJsonFileName).json" -ErrorAction 'Stop'
-            $ReportJson | Out-File $JsonFileName
+            $ReportJson | Set-Content -Path $JsonFileName -Encoding $(Get-FileEncoding) -ErrorAction 'Stop'
 
             # Delete the now redundant files
             foreach ($File in $DeletionList) {

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Merge-JsonOutput.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Merge-JsonOutput.Tests.ps1
@@ -6,6 +6,7 @@ InModuleScope Orchestrator {
         BeforeAll {
             Mock -CommandName Join-Path { "." }
             Mock -CommandName Out-File {}
+            Mock -CommandName Set-Content {}
             Mock -CommandName Remove-Item {}
             Mock -CommandName Get-Content { "" }
             Mock -CommandName ConvertFrom-Json { @{

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Merge-JsonOutput.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Merge-JsonOutput.Tests.ps1
@@ -8,7 +8,12 @@ InModuleScope Orchestrator {
             Mock -CommandName Out-File {}
             Mock -CommandName Remove-Item {}
             Mock -CommandName Get-Content { "" }
-            Mock -CommandName ConvertFrom-Json { @{"ReportSummary"=@{"Date"=""}; "Results"=@();} }
+            Mock -CommandName ConvertFrom-Json { @{
+                "ReportSummary"=@{"Date"=""}
+                "Results"=@();
+                "timestamp_zulu"="";
+            }
+            }
             Mock -CommandName Add-Member {}
             Mock -CommandName ConvertTo-Json { "" }
         }
@@ -28,7 +33,7 @@ InModuleScope Orchestrator {
                     ProductNames = @("aad")
                 }
                 { Merge-JsonOutput @JsonParameters} | Should -Not -Throw
-                Should -Invoke -CommandName ConvertFrom-Json -Exactly -Times 1
+                Should -Invoke -CommandName ConvertFrom-Json -Exactly -Times 2
                 $JsonParameters.ProductNames = @()
             }
             It 'Merge multiple results' {
@@ -36,7 +41,7 @@ InModuleScope Orchestrator {
                     ProductNames = @("aad", "teams")
                 }
                 { Merge-JsonOutput @JsonParameters} | Should -Not -Throw
-                Should -Invoke -CommandName ConvertFrom-Json -Exactly -Times 2
+                Should -Invoke -CommandName ConvertFrom-Json -Exactly -Times 3
                 $JsonParameters.ProductNames = @()
             }
             It 'Delete redundant files' {


### PR DESCRIPTION
## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->
- Had a request to add this timestamp into the JSON.
- PR Just adds a ISO 8601 compliant timestamp to the Provider JSON.
## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->
Closes #1002 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Just run ScubaGear normally and check if the `timestamp` key is within the JSON.
Compatible with all tenants of course. 

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- ~All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.~
Smoke test tests are failing due to expired licenses. 

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] PR passed smoke test check.
- [ ] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [ ] Resolved all merge conflicts on branch
- [ ] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
