### PR TITLE
Add Policy Group Names to ScubaResults.json

### DIFF
--- a/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
+++ b/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
@@ -170,7 +170,7 @@ function New-Report {
         $MarkdownLink = "<a class='control_group' href=`"$($ScubaGitHubUrl)/blob/v$($SettingsExport.module_version)/PowerShell/ScubaGear/baselines/$($BaselineName.ToLower()).md$GroupAnchor`" target=`"_blank`">$Name</a>"
         $Fragments += $Fragment | ConvertTo-Html -PreContent "<h2>$Number $MarkdownLink</h2>" -Fragment
 
-        # Package
+        # Package HTML Report into Report JSON by Policy Group
         $ReportJson.Results += [pscustomobject]@{
             GroupName = $BaselineGroup.GroupName;
             GroupNumber = $BaselineGroup.GroupNumber;
@@ -184,7 +184,6 @@ function New-Report {
     # Craft the json report
     $ReportJson.ReportSummary = $ReportSummary
     $JsonFileName = Join-Path -Path $IndividualReportPath -ChildPath "$($BaselineName)Report.json"
-    #
     $ReportJson = ConvertTo-Json @($ReportJson) -Depth 5
 
     # ConvertTo-Json for some reason converts the <, >, and ' characters into unicode escape sequences.

--- a/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
+++ b/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
@@ -170,7 +170,7 @@ function New-Report {
         $MarkdownLink = "<a class='control_group' href=`"$($ScubaGitHubUrl)/blob/v$($SettingsExport.module_version)/PowerShell/ScubaGear/baselines/$($BaselineName.ToLower()).md$GroupAnchor`" target=`"_blank`">$Name</a>"
         $Fragments += $Fragment | ConvertTo-Html -PreContent "<h2>$Number $MarkdownLink</h2>" -Fragment
 
-        # Package HTML Report into Report JSON by Policy Group
+        # Package Assessment Report into Report JSON by Policy Group
         $ReportJson.Results += [pscustomobject]@{
             GroupName = $BaselineGroup.GroupName;
             GroupNumber = $BaselineGroup.GroupNumber;

--- a/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
+++ b/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
@@ -169,7 +169,13 @@ function New-Report {
         $GroupAnchor = New-MarkdownAnchor -GroupNumber $BaselineGroup.GroupNumber -GroupName $BaselineGroup.GroupName
         $MarkdownLink = "<a class='control_group' href=`"$($ScubaGitHubUrl)/blob/v$($SettingsExport.module_version)/PowerShell/ScubaGear/baselines/$($BaselineName.ToLower()).md$GroupAnchor`" target=`"_blank`">$Name</a>"
         $Fragments += $Fragment | ConvertTo-Html -PreContent "<h2>$Number $MarkdownLink</h2>" -Fragment
-        $ReportJson.Results += $Fragment
+
+        # Package
+        $ReportJson.Results += [pscustomobject]@{
+            GroupName = $BaselineGroup.GroupName;
+            GroupNumber = $BaselineGroup.GroupNumber;
+            Controls = $Fragment;
+        }
 
         # Regex will filter out any <table> tags without an id attribute (replace new fragments only, not <table> tags which have already been modified)
         $Fragments = $Fragments -replace ".*(<table(?![^>]+id)*>)", "<table class='policy-data' id='$Number'>"
@@ -178,7 +184,8 @@ function New-Report {
     # Craft the json report
     $ReportJson.ReportSummary = $ReportSummary
     $JsonFileName = Join-Path -Path $IndividualReportPath -ChildPath "$($BaselineName)Report.json"
-    $ReportJson = ConvertTo-Json @($ReportJson) -Depth 3
+    #
+    $ReportJson = ConvertTo-Json @($ReportJson) -Depth 5
 
     # ConvertTo-Json for some reason converts the <, >, and ' characters into unicode escape sequences.
     # Convert those back to ASCII.

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -823,6 +823,15 @@ function Merge-JsonOutput {
             $SettingsExport =  Get-Content $SettingsExportPath -Raw
             $TimestampZulu = $(ConvertFrom-Json $SettingsExport).timestamp_zulu
 
+            # Get a list of the fullnames of each product
+            $FullNames = @()
+            $ProductAbbreviationMapping = @{}
+            foreach ($ProductName in $ProductNames) {
+                $BaselineName = $ArgToProd[$ProductName]
+                $FullNames += $ProdToFullName[$BaselineName]
+                $ProductAbbreviationMapping[$ProdToFullName[$BaselineName]] = $BaselineName
+            }
+
             # Extract the metadata
             $Results = [pscustomobject]@{}
             $Summary = [pscustomobject]@{}
@@ -830,7 +839,9 @@ function Merge-JsonOutput {
                 "TenantId" = $TenantDetails.TenantId;
                 "DisplayName" = $TenantDetails.DisplayName;
                 "DomainName" = $TenantDetails.DomainName;
-                "Product" = "M365";
+                "ProductSuite" = "Microsoft 365";
+                "ProductsAssessed" = $FullNames;
+                "ProductAbbreviationMapping" = $ProductAbbreviationMapping
                 "Tool" = "ScubaGear";
                 "ToolVersion" = $ModuleVersion;
                 "TimestampZulu" = $TimestampZulu;
@@ -856,7 +867,7 @@ function Merge-JsonOutput {
             }
 
             # Convert the output a json string
-            $MetaData = ConvertTo-Json $MetaData
+            $MetaData = ConvertTo-Json $MetaData -Depth 3
             $Results = ConvertTo-Json $Results -Depth 5
             $Summary = ConvertTo-Json $Summary -Depth 3
             $ReportJson = @"

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -844,6 +844,7 @@ function Merge-JsonOutput {
                 $FileName = Join-Path $IndividualReportPath "$($BaselineName)Report.json"
                 $DeletionList += $FileName
                 $IndividualResults = Get-Content $FileName | ConvertFrom-Json
+
                 $Results | Add-Member -NotePropertyName $BaselineName `
                     -NotePropertyValue $IndividualResults.Results
 
@@ -856,7 +857,7 @@ function Merge-JsonOutput {
 
             # Convert the output a json string
             $MetaData = ConvertTo-Json $MetaData
-            $Results = ConvertTo-Json $Results -Depth 3
+            $Results = ConvertTo-Json $Results -Depth 5
             $Summary = ConvertTo-Json $Summary -Depth 3
             $ReportJson = @"
 {

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -823,7 +823,7 @@ function Merge-JsonOutput {
             $SettingsExport =  Get-Content $SettingsExportPath -Raw
             $TimestampZulu = $(ConvertFrom-Json $SettingsExport).timestamp_zulu
 
-            # Get a list of the fullnames of each product
+            # Get a list and abbreviation mapping of the products assessed
             $FullNames = @()
             $ProductAbbreviationMapping = @{}
             foreach ($ProductName in $ProductNames) {


### PR DESCRIPTION
## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->
- Another quick turn around request from our sibling team to include additional data in the `ScubaResults.json` 
- This PR includes adding the Policy Group Names to the `ScubaResults` JSON. 
- Also, includes another request to add the products assessed to the `Metadata` key in `ScubaResults.json`.


## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->
Closes #1039
Closes #1040 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Run ScubaGear against any tenant with the `MergeJSON` switch passed in. i.e `Invoke-SCuBA -MergeJSON`.
Look at the resulting `ScubaResults.json` and see if the correct keys and values are present. 


## 📷 Screenshots (if appropriate) ##


## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- ~[x] Changes are limited to two goals - *eschew scope creep!*~ Shh
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.


## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [x] Resolved all merge conflicts on branch
- [ ] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
