### PR TITLE
Modify Sharepoint policies to only execute when applicable

### DIFF
--- a/PowerShell/ScubaGear/Rego/SharepointConfig.rego
+++ b/PowerShell/ScubaGear/Rego/SharepointConfig.rego
@@ -359,7 +359,7 @@ tests contains {
 }
 
 # This policy is only applicable if external sharing is set to "Anyone"
-# Both link types must be 2 & OneDrive_PnP_Flag must be false for policy to pass
+# Both link types must be 1 & OneDrive_PnP_Flag must be false for policy to pass
 tests contains {
     "PolicyId": "MS.SHAREPOINT.3.2v1",
     "Criticality": "Shall",
@@ -376,10 +376,10 @@ tests contains {
     FolderLinkType := TenantPolicy.FolderAnonymousLinkType
     input.OneDrive_PnP_Flag == false
     Conditions := [
-        FileLinkType == 2,
-        FolderLinkType == 2
+        FileLinkType == 1,
+        FolderLinkType == 1
     ]
-    Status := count(FilterArray(Conditions, true)) == 0
+    Status := count(FilterArray(Conditions, true)) == 2
 }
 
 tests contains {

--- a/PowerShell/ScubaGear/Rego/SharepointConfig.rego
+++ b/PowerShell/ScubaGear/Rego/SharepointConfig.rego
@@ -402,47 +402,11 @@ tests contains {
 # MS.SHAREPOINT.3.3v1
 #--
 
-VERIFICATION_STRING := "Expiration timer for 'People who use a verification code' NOT"
+VERIFICATION_STRING := "Expiration time for 'People who use a verification code' NOT"
 
-# If Sharing set to Only People In Org, pass
-#ExpirationTimersVerificationCode(TenantPolicy) := ["", true] if {
-#    TenantPolicy.SharingCapability == ONLYPEOPLEINORG
-#}
-
-# If Sharing NOT set to Only People In Org, reathentication enabled,
-# & reauth sent to <= 30 days, pass
-#ExpirationTimersVerificationCode(tenant) := [PASS, true] if {
-#    #TenantPolicy.SharingCapability != ONLYPEOPLEINORG
-#    tenant.EmailAttestationRequired == true
-#    tenant.EmailAttestationReAuthDays <= 30
-#}
-
-# If Sharing NOT set to Only People In Org & reathentication disbled,
-# fail
-#ExpirationTimersVerificationCode(tenant) := [ErrMsg, false] if {
-#    #TenantPolicy.SharingCapability != ONLYPEOPLEINORG
-#    tenant.EmailAttestationRequired == false
-#    tenant.EmailAttestationReAuthDays <= 30
-#    ErrMsg := concat(": ", [FAIL, concat(" ", [VERIFICATION_STRING, "enabled"])])
-#}
-
-# If Sharing NOT set to Only People In Org & reauth sent to > 30 days, fail
-#ExpirationTimersVerificationCode(tenant) := [ErrMsg, false] if {
-#    #TenantPolicy.SharingCapability != ONLYPEOPLEINORG
-#    tenant.EmailAttestationRequired == true
-#    tenant.EmailAttestationReAuthDays > 30
-#    ErrMsg := concat(": ", [FAIL, concat(" ", [VERIFICATION_STRING, "set to 30 days"])])
-#}
-
-# If Sharing NOT set to Only People In Org, reathentication disabled,
-# & reauth sent to > 30 days, fail
-#ExpirationTimersVerificationCode(tenant) := [ErrMsg, false] if {
-#    #TenantPolicy.SharingCapability != ONLYPEOPLEINORG
-#    tenant.EmailAttestationRequired == false
-#    tenant.EmailAttestationReAuthDays > 30
-#    ErrMsg := concat(": ", [FAIL, concat(" ", [VERIFICATION_STRING, "enabled and set to >30 days"])])
-#}
-
+# PolicyNotApplicable_Group3 handles the correct SharingCapability setting.
+# This ruleset only checks if verification code reauthentication is enabled,
+# and if the verification time is valid (less than or equal to 30 days)
 VerificationCodeReAuthExpiration(tenant) := [PASS, true] if {
     tenant.EmailAttestationRequired == true
     tenant.EmailAttestationReAuthDays <= 30

--- a/PowerShell/ScubaGear/Rego/SharepointConfig.rego
+++ b/PowerShell/ScubaGear/Rego/SharepointConfig.rego
@@ -449,15 +449,15 @@ VerificationCodeReAuthExpiration(tenant) := [PASS, true] if {
 } else := [ErrStr, false] if {
     tenant.EmailAttestationRequired == false
     tenant.EmailAttestationReAuthDays <= 30
-    ErrMsg := concat(": ", [FAIL, concat(" ", [VERIFICATION_STRING, "enabled"])])
+    ErrStr := concat(": ", [FAIL, concat(" ", [VERIFICATION_STRING, "enabled"])])
 } else := [ErrStr, false] if {
     tenant.EmailAttestationRequired == true
     tenant.EmailAttestationReAuthDays > 30
-    ErrMsg := concat(": ", [FAIL, concat(" ", [VERIFICATION_STRING, "set to 30 days or less"])])
+    ErrStr := concat(": ", [FAIL, concat(" ", [VERIFICATION_STRING, "set to 30 days or less"])])
 } else := [ErrStr, false] if {
     tenant.EmailAttestationRequired == false
     tenant.EmailAttestationReAuthDays > 30
-    ErrMsg := concat(": ", [FAIL, concat(" ", [VERIFICATION_STRING, "enabled and set to 30 days or more"])])
+    ErrStr := concat(": ", [FAIL, concat(" ", [VERIFICATION_STRING, "enabled and set to 30 days or more"])])
 }
 
 # Test for N/A case
@@ -478,11 +478,7 @@ tests contains {
         ]),
         "This policy is only applicable if External Sharing is set to Anyone, New and existing guests, or Existing guests. See %v for more info"
     ])
-    PolicyNotApplicable_Group3([
-        ONLY_PEOPLE_IN_ORG, 
-        EXISTING_GUESTS, 
-        NEW_AND_EXISTING_GUESTS
-    ]) == true
+    PolicyNotApplicable_Group3([ONLY_PEOPLE_IN_ORG]) == true
 }
 
 tests contains {
@@ -497,11 +493,8 @@ tests contains {
     "ReportDetails": ReportDetailsString(Status, ErrMsg),
     "RequirementMet": Status
 } if {
-    PolicyNotApplicable_Group3([
-        ONLY_PEOPLE_IN_ORG, 
-        EXISTING_GUESTS
-    ]) == false
-    SharingCapability in [ANYONE, NEW_AND_EXISTING_GUESTS]
+    PolicyNotApplicable_Group3([ONLY_PEOPLE_IN_ORG]) == false
+    SharingCapability in [ANYONE, NEW_AND_EXISTING_GUESTS, EXISTING_GUESTS]
 
     some tenant in input.SPO_tenant
     [ErrMsg, Status] := VerificationCodeReAuthExpiration(tenant)

--- a/PowerShell/ScubaGear/Rego/SharepointConfig.rego
+++ b/PowerShell/ScubaGear/Rego/SharepointConfig.rego
@@ -239,15 +239,9 @@ SharingCapability := Setting if {
 }
 
 # This policy is only applicable if external sharing is set to "Anyone"
-default PolicyNotApplicable3_1 := false
-PolicyNotApplicable3_1 := true if {
-    Conditions := [
-        SharingCapability == ONLY_PEOPLE_IN_ORG,
-        SharingCapability == EXISTING_GUESTS,
-        SharingCapability == NEW_AND_EXISTING_GUESTS
-    ]
-    count(FilterArray(Conditions, true)) == 1
-}
+PolicyNotApplicable_Group3(Conditions) := true if {
+    SharingCapability in Conditions
+} else := false
 
 ErrStr := concat(" ", [
     "External Sharing is set to",
@@ -283,7 +277,11 @@ tests contains {
         ]),
         "This policy is only applicable if External Sharing is set to Anyone. See %v for more info"
     ])
-    PolicyNotApplicable3_1 == true
+    PolicyNotApplicable_Group3([
+        ONLY_PEOPLE_IN_ORG, 
+        EXISTING_GUESTS, 
+        NEW_AND_EXISTING_GUESTS
+    ]) == true
 }
 
 # Standard test to compare against baseline
@@ -298,7 +296,11 @@ tests contains {
     "ReportDetails": ReportDetailsString(Status, ErrMsg),
     "RequirementMet": Status
 } if {
-    PolicyNotApplicable3_1 == false
+    PolicyNotApplicable_Group3([
+        ONLY_PEOPLE_IN_ORG, 
+        EXISTING_GUESTS, 
+        NEW_AND_EXISTING_GUESTS
+    ]) == false
     SharingCapability == ANYONE
     some tenant in input.SPO_tenant
     [ErrMsg, Status] = ExternalUserLinksExpireInDays(tenant)

--- a/PowerShell/ScubaGear/Rego/SharepointConfig.rego
+++ b/PowerShell/ScubaGear/Rego/SharepointConfig.rego
@@ -21,7 +21,7 @@ EXISTINGGUESTS := 3
 ONLY_PEOPLE_IN_ORG := 0      # "Disabled" in functional tests
 EXISTING_GUESTS := 3         # "ExistingExternalUserSharingOnly" in functional tests 
 NEW_AND_EXISTING_GUESTS := 1 # "ExternalUserSharingOnly" in functional tests 
-ANYONE := 2                  # "ExternalUserandGuestSharing" in functional tests 
+ANYONE := 2                  # "ExternalUserAndGuestSharing" in functional tests 
 
 ######################################
 # External sharing support functions #
@@ -44,11 +44,6 @@ SharingCapability := Setting if {
 
 CheckSharingCapability(InvalidConditions) := true if {
     SharingCapability in InvalidConditions
-} else := false
-
-
-PolicyNotApplicable_Group3(Conditions) := true if {
-    SharingCapability in Conditions
 } else := false
 
 # "This policy is only applicable if External Sharing is set to Anyone. See %v for more info"
@@ -396,6 +391,8 @@ tests contains {
     "RequirementMet": false
 } if {
     PolicyId := "MS.SHAREPOINT.3.2v1"
+    CheckPolicyNotApplicable([ONLY_PEOPLE_IN_ORG, EXISTING_GUESTS, NEW_AND_EXISTING_GUESTS], "") == false
+    SharingCapability == ANYONE
     input.OneDrive_PnP_Flag == true
 }
 #--
@@ -437,8 +434,8 @@ tests contains {
 } if {
     PolicyId := "MS.SHAREPOINT.3.3v1"
     [Reason, Result] := CheckPolicyNotApplicable(
-        [ONLY_PEOPLE_IN_ORG],
-        "This policy is only applicable if External Sharing is set to Anyone, New and existing guests, or Existing guests. See %v for more info"
+        [ONLY_PEOPLE_IN_ORG, EXISTING_GUESTS],
+        "This policy is only applicable if External Sharing is set to Anyone or New and existing guests. See %v for more info"
     )
     Result == true
 }
@@ -457,8 +454,8 @@ tests contains {
     "ReportDetails": ReportDetailsString(Status, ErrMsg),
     "RequirementMet": Status
 } if {
-    CheckPolicyNotApplicable([ONLY_PEOPLE_IN_ORG], "") == false
-    SharingCapability in [ANYONE, NEW_AND_EXISTING_GUESTS, EXISTING_GUESTS]
+    CheckPolicyNotApplicable([ONLY_PEOPLE_IN_ORG, EXISTING_GUESTS], "") == false
+    SharingCapability in [ANYONE, NEW_AND_EXISTING_GUESTS]
 
     some tenant in input.SPO_tenant
     [ErrMsg, Status] := VerificationCodeReAuthExpiration(tenant)

--- a/PowerShell/ScubaGear/Rego/SharepointConfig.rego
+++ b/PowerShell/ScubaGear/Rego/SharepointConfig.rego
@@ -172,11 +172,25 @@ tests contains {
     "ReportDetails": ReportDetailsBoolean(Status),
     "RequirementMet": Status
 } if {
-    Conditions := [
-        SharingCapability == ONLYPEOPLEINORG,
-        Tenant.RequireAcceptingAccountMatchInvitedAccount == true
-    ]
-    Status := count(FilterArray(Conditions, true)) >= 1
+    SharingCapability != ONLYPEOPLEINORG
+    Status := Tenant.RequireAcceptingAccountMatchInvitedAccount == true
+}
+
+tests contains {
+    "PolicyId": PolicyId,
+    "Criticality": "Shall/Not-Implemented",
+    "Commandlet": ["Get-SPOTenant", "Get-PnPTenant"],
+    "ActualValue": [],
+    "ReportDetails": CheckedSkippedDetails(PolicyId, Reason),
+    "RequirementMet": false
+} if {
+    SharingCapability == ONLYPEOPLEINORG
+    PolicyId := "MS.SHAREPOINT.1.4v1"
+    Reason := concat(" ", [
+        "This policy is only applicable if External Sharing",
+        "is set to any value other than Only People in your organization.",
+        "See %v for more info"
+        ])
 }
 #--
 

--- a/PowerShell/ScubaGear/Rego/SharepointConfig.rego
+++ b/PowerShell/ScubaGear/Rego/SharepointConfig.rego
@@ -221,6 +221,15 @@ tests contains {
 #
 # MS.SHAREPOINT.3.1v1
 #--
+SharepointSliderSettings(Value) := "ONLY_PEOPLE_IN_ORG" if {
+    Value == 0
+} else := "NEW_AND_EXISTING_GUESTS" if {
+    Value == 1
+} else := "ANYONE" if {
+    Value == 2
+} else := "EXISTING_GUESTS" if {
+    Value == 3
+} else := Value
 
 # If SharingCapability is set to Only People In Organization
 # OR Existing Guests, the policy should pass.

--- a/PowerShell/ScubaGear/Rego/SharepointConfig.rego
+++ b/PowerShell/ScubaGear/Rego/SharepointConfig.rego
@@ -241,6 +241,7 @@ SharingCapability := Setting if {
 # This policy is only applicable if external sharing is set to "Anyone"
 PolicyNotApplicable_Group3(Conditions) := true if {
     SharingCapability in Conditions
+    SharingCapability != ANYONE
 } else := false
 
 ErrStr := concat(" ", [
@@ -301,7 +302,7 @@ tests contains {
         EXISTING_GUESTS, 
         NEW_AND_EXISTING_GUESTS
     ]) == false
-    SharingCapability == ANYONE
+
     some tenant in input.SPO_tenant
     [ErrMsg, Status] = ExternalUserLinksExpireInDays(tenant)
 }
@@ -371,8 +372,8 @@ tests contains {
         EXISTING_GUESTS, 
         NEW_AND_EXISTING_GUESTS
     ]) == false
-    SharingCapability == ANYONE
     
+
     some TenantPolicy in input.SPO_tenant
     FileLinkType := TenantPolicy.FileAnonymousLinkType
     FolderLinkType := TenantPolicy.FolderAnonymousLinkType

--- a/PowerShell/ScubaGear/Rego/Utils/ReportDetails.rego
+++ b/PowerShell/ScubaGear/Rego/Utils/ReportDetails.rego
@@ -1,6 +1,7 @@
 package utils.report
 import rego.v1
 import data.utils.key.PASS
+import data.utils.key.FAIL
 
 
 #############
@@ -30,7 +31,6 @@ PolicyLink(PolicyId) := sprintf(
     [SCUBABASEURL, PolicyProduct(PolicyId), PolicyAnchor(PolicyId)]
 )
 
- 
 ###############################
 # Generic Reporting Functions #
 ###############################
@@ -67,6 +67,11 @@ DefenderMirrorDetails(PolicyId) := sprintf(
 ReportDetailsBoolean(true) := "Requirement met"
 
 ReportDetailsBoolean(false) := "Requirement not met"
+
+# Reporting methods passed Status and appends warning
+ReportDetailsBooleanWarning(true, Warning) := concat(": ", [PASS, Warning])
+
+ReportDetailsBooleanWarning(false, Warning) := concat(": ", [FAIL, Warning])
 
 # Returns specified string if Status is false (good for error msg)
 ReportDetailsString(true, _) := PASS

--- a/PowerShell/ScubaGear/Rego/Utils/ReportDetails.rego
+++ b/PowerShell/ScubaGear/Rego/Utils/ReportDetails.rego
@@ -30,7 +30,7 @@ PolicyLink(PolicyId) := sprintf(
     [SCUBABASEURL, PolicyProduct(PolicyId), PolicyAnchor(PolicyId)]
 )
 
-
+ 
 ###############################
 # Generic Reporting Functions #
 ###############################

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_01_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_01_test.rego
@@ -224,6 +224,42 @@ test_SharingDomainRestrictionMode_SharingCapability_NewExistingGuests_Incorrect 
     ])
     TestResult("MS.SHAREPOINT.1.3v1", Output, ReportDetailString, false) == true
 }
+
+test_SharingDomainRestrictionMode_SharingCapability_ExistingGuests_Incorrect if {
+    Output := sharepoint.tests with input as {
+        "SPO_tenant": [
+            {
+                "SharingCapability": 3,
+                "SharingDomainRestrictionMode": 0
+            }
+        ]
+    }
+
+    ReportDetailString := concat(" ", [
+        "Requirement not met: Note that we currently only check for approved external domains.",
+        "Approved security groups are currently not being checked,",
+        "see the baseline policy for instructions on a manual check."
+    ])
+    TestResult("MS.SHAREPOINT.1.3v1", Output, ReportDetailString, false) == true
+}
+
+test_SharingDomainRestrictionMode_SharingCapability_Anyone_Incorrect if {
+    Output := sharepoint.tests with input as {
+        "SPO_tenant": [
+            {
+                "SharingCapability": 2,
+                "SharingDomainRestrictionMode": 0
+            }
+        ]
+    }
+
+    ReportDetailString := concat(" ", [
+        "Requirement not met: Note that we currently only check for approved external domains.",
+        "Approved security groups are currently not being checked,",
+        "see the baseline policy for instructions on a manual check."
+    ])
+    TestResult("MS.SHAREPOINT.1.3v1", Output, ReportDetailString, false) == true
+}
 #--
 
 #

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_01_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_01_test.rego
@@ -2,6 +2,7 @@ package sharepoint_test
 import rego.v1
 import data.sharepoint
 import data.utils.report.NotCheckedDetails
+import data.utils.report.CheckedSkippedDetails
 import data.utils.key.TestResult
 import data.utils.key.FAIL
 import data.utils.key.PASS
@@ -133,7 +134,7 @@ test_OneDriveSharingCapability_Incorrect_V2 if {
 #
 # Policy MS.SHAREPOINT.1.3v1
 #--
-test_SharingDomainRestrictionMode_Correct_V1 if {
+test_SharingDomainRestrictionMode_SharingCapability_OnlyPeopleInOrg_NotApplicable if {
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
@@ -143,11 +144,33 @@ test_SharingDomainRestrictionMode_Correct_V1 if {
         ]
     }
 
-    ReportDetailString := "Requirement met: external sharing is set to Only People In Organization"
+    PolicyId := "MS.SHAREPOINT.1.3v1"
+    ReportDetailsString := concat(" ", [
+        "External Sharing is set to Only people in your organization.",
+        "This policy is only applicable if External Sharing is set to any value other than Only People in your organization. See %v for more info"
+    ])
+    TestResult("MS.SHAREPOINT.1.3v1", Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
+}
+
+test_SharingDomainRestrictionMode_SharingCapability_Anyone_Correct if {
+    Output := sharepoint.tests with input as {
+        "SPO_tenant": [
+            {
+                "SharingCapability": 2,
+                "SharingDomainRestrictionMode": 1
+            }
+        ]
+    }
+
+    ReportDetailString := concat(" ", [
+        "Requirement met: Note that we currently only check for approved external domains.",
+        "Approved security groups are currently not being checked,",
+        "see the baseline policy for instructions on a manual check."
+    ])
     TestResult("MS.SHAREPOINT.1.3v1", Output, ReportDetailString, true) == true
 }
 
-test_SharingDomainRestrictionMode_Correct_V2 if {
+test_SharingDomainRestrictionMode_SharingCapability_NewExistingGuests_Correct if {
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
@@ -165,7 +188,25 @@ test_SharingDomainRestrictionMode_Correct_V2 if {
     TestResult("MS.SHAREPOINT.1.3v1", Output, ReportDetailString, true) == true
 }
 
-test_SharingDomainRestrictionMode_Incorrect if {
+test_SharingDomainRestrictionMode_SharingCapability_ExistingGuests_Correct if {
+    Output := sharepoint.tests with input as {
+        "SPO_tenant": [
+            {
+                "SharingCapability": 3,
+                "SharingDomainRestrictionMode": 1
+            }
+        ]
+    }
+
+    ReportDetailString := concat(" ", [
+        "Requirement met: Note that we currently only check for approved external domains.",
+        "Approved security groups are currently not being checked,",
+        "see the baseline policy for instructions on a manual check."
+    ])
+    TestResult("MS.SHAREPOINT.1.3v1", Output, ReportDetailString, true) == true
+}
+
+test_SharingDomainRestrictionMode_SharingCapability_NewExistingGuests_Incorrect if {
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_01_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_01_test.rego
@@ -146,9 +146,10 @@ test_SharingDomainRestrictionMode_SharingCapability_OnlyPeopleInOrg_NotApplicabl
 
     PolicyId := "MS.SHAREPOINT.1.3v1"
     ReportDetailsString := concat(" ", [
-        "External Sharing is set to Only people in your organization.",
-        "This policy is only applicable if External Sharing is set to any value other than Only People in your organization. See %v for more info"
-    ])
+        "This policy is only applicable if External Sharing",
+        "is set to any value other than Only People in your organization.",
+        "See %v for more info"
+        ])
     TestResult("MS.SHAREPOINT.1.3v1", Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
 }
 

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_01_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_01_test.rego
@@ -229,7 +229,7 @@ test_SharingDomainRestrictionMode_SharingCapability_NewExistingGuests_Incorrect 
 #
 # Policy MS.SHAREPOINT.1.4v1
 #--
-test_SameAccount_Correct_V1 if {
+test_SameAccount_NotApplicable_V1 if {
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
@@ -239,10 +239,16 @@ test_SameAccount_Correct_V1 if {
         ]
     }
 
-    TestResult("MS.SHAREPOINT.1.4v1", Output, PASS, true) == true
+    PolicyId := "MS.SHAREPOINT.1.4v1"
+    ReportDetailsString := concat(" ", [
+        "This policy is only applicable if External Sharing",
+        "is set to any value other than Only People in your organization.",
+        "See %v for more info"
+        ])
+    TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
 }
 
-test_SameAccount_Correct_V3 if {
+test_SameAccount_NotApplicable_V2 if {
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
@@ -252,10 +258,16 @@ test_SameAccount_Correct_V3 if {
         ]
     }
 
-    TestResult("MS.SHAREPOINT.1.4v1", Output, PASS, true) == true
+    PolicyId := "MS.SHAREPOINT.1.4v1"
+    ReportDetailsString := concat(" ", [
+        "This policy is only applicable if External Sharing",
+        "is set to any value other than Only People in your organization.",
+        "See %v for more info"
+        ])
+    TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
 }
 
-test_SameAccount_Correct_V2 if {
+test_SameAccount_Correct_V1 if {
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_01_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_01_test.rego
@@ -147,10 +147,10 @@ test_SharingDomainRestrictionMode_SharingCapability_OnlyPeopleInOrg_NotApplicabl
     PolicyId := "MS.SHAREPOINT.1.3v1"
     ReportDetailsString := concat(" ", [
         "This policy is only applicable if External Sharing",
-        "is set to any value other than Only People in your organization.",
+        "is set to any value other than Only People In Your Organization.",
         "See %v for more info"
         ])
-    TestResult("MS.SHAREPOINT.1.3v1", Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
+    TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
 }
 
 test_SharingDomainRestrictionMode_SharingCapability_Anyone_Correct if {
@@ -242,7 +242,7 @@ test_SameAccount_NotApplicable_V1 if {
     PolicyId := "MS.SHAREPOINT.1.4v1"
     ReportDetailsString := concat(" ", [
         "This policy is only applicable if External Sharing",
-        "is set to any value other than Only People in your organization.",
+        "is set to any value other than Only People In Your Organization.",
         "See %v for more info"
         ])
     TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
@@ -261,7 +261,7 @@ test_SameAccount_NotApplicable_V2 if {
     PolicyId := "MS.SHAREPOINT.1.4v1"
     ReportDetailsString := concat(" ", [
         "This policy is only applicable if External Sharing",
-        "is set to any value other than Only People in your organization.",
+        "is set to any value other than Only People In Your Organization.",
         "See %v for more info"
         ])
     TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_03_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_03_test.rego
@@ -11,8 +11,6 @@ import data.utils.key.PASS
 # Policy MS.SHAREPOINT.3.1v1
 #--
 test_SharingCapability_Anyone_LinkExpirationValid_Correct_V1 if {
-    # Test if the Sharepoint external sharing slider is set to "Anyone".
-    # If true, then evaluate the value for expiration days.
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
@@ -50,14 +48,16 @@ test_SharingCapability_Anyone_LinkExpirationInvalid_Incorrect if {
 
     ReportDetailsString := concat(" ", [
         "Requirement not met:",
-        "External Sharing is set to Anyone and expiration date is not set to 30 days or less."
+        "External Sharing is set to",
+        "Anyone",
+        "and expiration date is not set to 30 days or less."
     ])
     TestResult("MS.SHAREPOINT.3.1v1", Output, ReportDetailsString, false) == true
 }
 
+# Test if the Sharepoint external sharing slider is set to "Only people in your organization".
+# The result must be N/A because the policy is not applicable unless external sharing is set to "Anyone".
 test_SharingCapability_OnlyPeopleInOrg_NotApplicable if {
-    # Test if the Sharepoint external sharing slider is set to "Only people in your organization".
-    # The result must be N/A because the policy is not applicable unless external sharing is set to "Anyone".
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
@@ -69,15 +69,15 @@ test_SharingCapability_OnlyPeopleInOrg_NotApplicable if {
 
     PolicyId := "MS.SHAREPOINT.3.1v1"
     ReportDetailsString := concat(" ", [
-        "External Sharing is set to Only people in your organization.",
-        "This policy is only applicable if External Sharing is set to Anyone. See %v for more info"
+        "This policy is only applicable if External Sharing is set to any value other than Anyone.",
+        "See %v for more info"
     ])
     TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
 }
 
+# Test if the Sharepoint external sharing slider is set to "Existing guests".
+# The result must be N/A because the policy is not applicable unless external sharing is set to "Anyone".
 test_SharingCapability_ExistingGuests_NotApplicable if {
-    # Test if the Sharepoint external sharing slider is set to "Existing guests".
-    # The result must be N/A because the policy is not applicable unless external sharing is set to "Anyone".
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
@@ -89,15 +89,15 @@ test_SharingCapability_ExistingGuests_NotApplicable if {
 
     PolicyId := "MS.SHAREPOINT.3.1v1"
     ReportDetailsString := concat(" ", [
-        "External Sharing is set to Existing guests.",
-        "This policy is only applicable if External Sharing is set to Anyone. See %v for more info"
+        "This policy is only applicable if External Sharing is set to any value other than Anyone.",
+        "See %v for more info"
     ])
     TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
 }
 
+# Test if the Sharepoint external sharing slider is set to "New and existing guests".
+# The result must be N/A because the policy is not applicable unless external sharing is set to "Anyone".
 test_SharingCapability_NewExistingGuests_NotApplicable if {
-    # Test if the Sharepoint external sharing slider is set to "New and existing guests".
-    # The result must be N/A because the policy is not applicable unless external sharing is set to "Anyone".
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
@@ -109,8 +109,8 @@ test_SharingCapability_NewExistingGuests_NotApplicable if {
 
     PolicyId := "MS.SHAREPOINT.3.1v1"
     ReportDetailsString := concat(" ", [
-        "External Sharing is set to New and existing guests.",
-        "This policy is only applicable if External Sharing is set to Anyone. See %v for more info"
+        "This policy is only applicable if External Sharing is set to any value other than Anyone.",
+        "See %v for more info"
     ])
     TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
 }
@@ -213,8 +213,8 @@ test_File_Folder_AnonymousLinkType_SharingCapability_OnlyPeopleInOrg_NotApplicab
 
     PolicyId := "MS.SHAREPOINT.3.2v1"
     ReportDetailsString := concat(" ", [
-        "External Sharing is set to Only people in your organization.",
-        "This policy is only applicable if External Sharing is set to Anyone. See %v for more info"
+        "This policy is only applicable if External Sharing is set to any value other than Anyone.",
+        "See %v for more info"
     ])
     TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
 }
@@ -233,8 +233,8 @@ test_File_Folder_AnonymousLinkType_SharingCapability_ExistingGuests_NotApplicabl
 
     PolicyId := "MS.SHAREPOINT.3.2v1"
     ReportDetailsString := concat(" ", [
-        "External Sharing is set to Existing guests.",
-        "This policy is only applicable if External Sharing is set to Anyone. See %v for more info"
+        "This policy is only applicable if External Sharing is set to any value other than Anyone.",
+        "See %v for more info"
     ])
     TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
 }
@@ -253,8 +253,8 @@ test_File_Folder_AnonymousLinkType_SharingCapability_NewExistingGuests_NotApplic
 
     PolicyId := "MS.SHAREPOINT.3.2v1"
     ReportDetailsString := concat(" ", [
-        "External Sharing is set to New and existing guests.",
-        "This policy is only applicable if External Sharing is set to Anyone. See %v for more info"
+        "This policy is only applicable if External Sharing is set to any value other than Anyone.",
+        "See %v for more info"
     ])
     TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
 }
@@ -366,8 +366,9 @@ test_EmailAttestationReAuthDays_SharingCapability_OnlyPeopleInOrg_NotApplicable 
 
     PolicyId := "MS.SHAREPOINT.3.3v1"
     ReportDetailsString := concat(" ", [
-        "External Sharing is set to Only people in your organization.",
-        "This policy is only applicable if External Sharing is set to Anyone or New and existing guests. See %v for more info"
+        "External Sharing is set to Only People In Your Organization.",
+        "This policy is only applicable if External Sharing is set to any value other than Only People In Your Organization",
+        "or Existing Guests. See %v for more info"
     ])
     TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
 }
@@ -385,8 +386,9 @@ test_EmailAttestationReAuthDays_SharingCapability_ExistingGuests_NotApplicable i
 
     PolicyId := "MS.SHAREPOINT.3.3v1"
     ReportDetailsString := concat(" ", [
-        "External Sharing is set to Existing guests.",
-        "This policy is only applicable if External Sharing is set to Anyone or New and existing guests. See %v for more info"
+        "External Sharing is set to Existing Guests.",
+        "This policy is only applicable if External Sharing is set to any value other than Only People In Your Organization",
+        "or Existing Guests. See %v for more info"
     ])
     TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
 }

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_03_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_03_test.rego
@@ -10,6 +10,8 @@ import data.utils.key.PASS
 # Policy MS.SHAREPOINT.3.1v1
 #--
 test_ExternalUserExpireInDays_Correct_V1 if {
+    # Test if the Sharepoint external sharing slider is set to "Only people in your organization".
+    # The result must be N/A because the policy is not applicable unless external sharing is set to "Anyone".
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
@@ -61,7 +63,22 @@ test_ExternalUserExpireInDays_Correct_V4 if {
     TestResult("MS.SHAREPOINT.3.1v1", Output, PASS, true) == true
 }
 
-test_ExternalUserExpireInDays_Incorrect if {
+test_ExternalUserSharingCapability_Correct_V1 if {
+    # Test if the Sharepoint external sharing slider is set to "Only people in your organization".
+    # The result must be N/A because the policy is not applicable unless external sharing is set to "Anyone".
+    Output := sharepoint.tests with input as {
+        "SPO_tenant": [
+            {
+                "SharingCapability": 0,
+                "RequireAnonymousLinksExpireInDays": 30
+            }
+        ]
+    }
+
+    TestResult("MS.SHAREPOINT.3.1v1", Output, PASS, false) == true
+}
+
+test_ExternalUserExpireInDays_Incorrect_V1 if {
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_03_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_03_test.rego
@@ -10,7 +10,52 @@ import data.utils.key.PASS
 #
 # Policy MS.SHAREPOINT.3.1v1
 #--
-test_SharingCapability_LinkExpirationInvalid_NotApplicable_V1 if {
+test_SharingCapability_Anyone_LinkExpirationValid_Correct_V1 if {
+    # Test if the Sharepoint external sharing slider is set to "Anyone".
+    # If true, then evaluate the value for expiration days.
+    Output := sharepoint.tests with input as {
+        "SPO_tenant": [
+            {
+                "SharingCapability": 2,
+                "RequireAnonymousLinksExpireInDays": 30
+            }
+        ]
+    }
+
+    TestResult("MS.SHAREPOINT.3.1v1", Output, PASS, true) == true
+}
+
+test_SharingCapability_Anyone_LinkExpirationValid_Correct_V2 if {
+    Output := sharepoint.tests with input as {
+        "SPO_tenant": [
+            {
+                "SharingCapability": 2,
+                "RequireAnonymousLinksExpireInDays": 29
+            }
+        ]
+    }
+
+    TestResult("MS.SHAREPOINT.3.1v1", Output, PASS, true) == true
+}
+
+test_SharingCapability_Anyone_LinkExpirationInvalid_Incorrect if {
+    Output := sharepoint.tests with input as {
+        "SPO_tenant": [
+            {
+                "SharingCapability": 2,
+                "RequireAnonymousLinksExpireInDays": 31
+            }
+        ]
+    }
+
+    ReportDetailsString := concat(" ", [
+        "Requirement not met:",
+        "External Sharing is set to Anyone and expiration date is not set to 30 days or less."
+    ])
+    TestResult("MS.SHAREPOINT.3.1v1", Output, ReportDetailsString, false) == true
+}
+
+test_SharingCapability_OnlyPeopleInOrg_NotApplicable if {
     # Test if the Sharepoint external sharing slider is set to "Only people in your organization".
     # The result must be N/A because the policy is not applicable unless external sharing is set to "Anyone".
     Output := sharepoint.tests with input as {
@@ -30,7 +75,7 @@ test_SharingCapability_LinkExpirationInvalid_NotApplicable_V1 if {
     TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
 }
 
-test_SharingCapability_LinkExpirationInvalid_NotApplicable_V2 if {
+test_SharingCapability_ExistingGuests_NotApplicable if {
     # Test if the Sharepoint external sharing slider is set to "Existing guests".
     # The result must be N/A because the policy is not applicable unless external sharing is set to "Anyone".
     Output := sharepoint.tests with input as {
@@ -50,7 +95,7 @@ test_SharingCapability_LinkExpirationInvalid_NotApplicable_V2 if {
     TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
 }
 
-test_SharingCapability_LinkExpirationInvalid_NotApplicable_V3 if {
+test_SharingCapability_NewExistingGuests_NotApplicable if {
     # Test if the Sharepoint external sharing slider is set to "New and existing guests".
     # The result must be N/A because the policy is not applicable unless external sharing is set to "Anyone".
     Output := sharepoint.tests with input as {
@@ -69,57 +114,12 @@ test_SharingCapability_LinkExpirationInvalid_NotApplicable_V3 if {
     ])
     TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
 }
-
-test_SharingCapability_LinkExpirationValid_Correct_V4 if {
-    # Test if the Sharepoint external sharing slider is set to "Anyone".
-    # If true, then evaluate the value for expiration days.
-    Output := sharepoint.tests with input as {
-        "SPO_tenant": [
-            {
-                "SharingCapability": 2,
-                "RequireAnonymousLinksExpireInDays": 30
-            }
-        ]
-    }
-
-    TestResult("MS.SHAREPOINT.3.1v1", Output, PASS, true) == true
-}
-
-test_SharingCapability_LinkExpirationValid_Correct_V5 if {
-    Output := sharepoint.tests with input as {
-        "SPO_tenant": [
-            {
-                "SharingCapability": 2,
-                "RequireAnonymousLinksExpireInDays": 29
-            }
-        ]
-    }
-
-    TestResult("MS.SHAREPOINT.3.1v1", Output, PASS, true) == true
-}
-
-test_SharingCapability_LinkExpirationInvalid_Incorrect_V6 if {
-    Output := sharepoint.tests with input as {
-        "SPO_tenant": [
-            {
-                "SharingCapability": 2,
-                "RequireAnonymousLinksExpireInDays": 31
-            }
-        ]
-    }
-
-    ReportDetailsString := concat(" ", [
-        "Requirement not met:",
-        "External Sharing is set to Anyone and expiration date is not set to 30 days or less."
-    ])
-    TestResult("MS.SHAREPOINT.3.1v1", Output, ReportDetailsString, false) == true
-}
 #--
 
 #
 # Policy MS.SHAREPOINT.3.2v1
 #--
-test_AnonymousLinkType_Correct if {
+test_File_Folder_AnonymousLinkType_Correct if {
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
@@ -133,7 +133,7 @@ test_AnonymousLinkType_Correct if {
     TestResult("MS.SHAREPOINT.3.2v1", Output, PASS, true) == true
 }
 
-test_AnonymousLinkType_Incorrect_V1 if {
+test_File_Folder_AnonymousLinkType_Incorrect if {
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
@@ -148,7 +148,7 @@ test_AnonymousLinkType_Incorrect_V1 if {
     TestResult("MS.SHAREPOINT.3.2v1", Output, ReportDetailString, false) == true
 }
 
-test_AnonymousLinkType_Incorrect_V2 if {
+test_Folder_AnonymousLinkType_Incorrect if {
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
@@ -163,7 +163,7 @@ test_AnonymousLinkType_Incorrect_V2 if {
     TestResult("MS.SHAREPOINT.3.2v1", Output, ReportDetailString, false) == true
 }
 
-test_AnonymousLinkType_Incorrect_V3 if {
+test_File_AnonymousLinkType_Incorrect if {
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
@@ -178,7 +178,7 @@ test_AnonymousLinkType_Incorrect_V3 if {
     TestResult("MS.SHAREPOINT.3.2v1", Output, ReportDetailString, false) == true
 }
 
-test_UsingServicePrincipal if {
+test_AnonymousLinkType_UsingServicePrincipal if {
     PolicyId := "MS.SHAREPOINT.3.2v1"
 
     Output := sharepoint.tests with input as {
@@ -192,6 +192,66 @@ test_UsingServicePrincipal if {
     }
 
     TestResult(PolicyId, Output, NotCheckedDetails(PolicyId), false) == true
+}
+
+test_File_Folder_AnonymousLinkType_SharingCapability_OnlyPeopleInOrg_NotApplicable if {
+    Output := sharepoint.tests with input as {
+        "SPO_tenant": [
+            {
+                "FileAnonymousLinkType": 2,
+                "FolderAnonymousLinkType": 2,
+                "SharingCapability": 0
+            }
+        ],
+        "OneDrive_PnP_Flag": false
+    }
+
+    PolicyId := "MS.SHAREPOINT.3.2v1"
+    ReportDetailsString := concat(" ", [
+        "External Sharing is set to Only people in your organization.",
+        "This policy is only applicable if External Sharing is set to Anyone. See %v for more info"
+    ])
+    TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
+}
+
+test_File_Folder_AnonymousLinkType_SharingCapability_ExistingGuests_NotApplicable if {
+    Output := sharepoint.tests with input as {
+        "SPO_tenant": [
+            {
+                "FileAnonymousLinkType": 2,
+                "FolderAnonymousLinkType": 2,
+                "SharingCapability": 3
+            }
+        ],
+        "OneDrive_PnP_Flag": false
+    }
+
+    PolicyId := "MS.SHAREPOINT.3.2v1"
+    ReportDetailsString := concat(" ", [
+        "External Sharing is set to Existing guests.",
+        "This policy is only applicable if External Sharing is set to Anyone. See %v for more info"
+    ])
+    TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
+}
+
+test_File_Folder_AnonymousLinkType_SharingCapability_NewExistingGuests_NotApplicable if {
+    Output := sharepoint.tests with input as {
+        "SPO_tenant": [
+            {
+                "FileAnonymousLinkType": 2,
+                "FolderAnonymousLinkType": 2,
+                "SharingCapability": 1
+            }
+        ],
+        "OneDrive_PnP_Flag": false
+    }
+
+    PolicyId := "MS.SHAREPOINT.3.2v1"
+    ReportDetailsString := concat(" ", [
+        "External Sharing is set to New and existing guests.",
+        "This policy is only applicable if External Sharing is set to Anyone. See %v for more info"
+    ])
+    TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
 }
 
 #

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_03_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_03_test.rego
@@ -2,6 +2,7 @@ package sharepoint_test
 import rego.v1
 import data.sharepoint
 import data.utils.report.NotCheckedDetails
+import data.utils.report.CheckedSkippedDetails
 import data.utils.key.TestResult
 import data.utils.key.PASS
 
@@ -21,10 +22,61 @@ test_ExternalUserExpireInDays_Correct_V1 if {
         ]
     }
 
-    TestResult("MS.SHAREPOINT.3.1v1", Output, PASS, true) == true
+    PolicyId := "MS.SHAREPOINT.3.1v1"
+    ReportDetailsString := "This policy is only applicable if External Sharing is set to Anybody. See %v for more info"
+    TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
 }
 
 test_ExternalUserExpireInDays_Correct_V2 if {
+    # Test if the Sharepoint external sharing slider is set to "Existing guests".
+    # The result must be N/A because the policy is not applicable unless external sharing is set to "Anyone".
+    Output := sharepoint.tests with input as {
+        "SPO_tenant": [
+            {
+                "SharingCapability": 3,
+                "RequireAnonymousLinksExpireInDays": 30
+            }
+        ]
+    }
+
+    PolicyId := "MS.SHAREPOINT.3.1v1"
+    ReportDetailsString := "This policy is only applicable if External Sharing is set to Anybody. See %v for more info"
+    TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
+}
+
+test_ExternalUserExpireInDays_Correct_V3 if {
+    # Test if the Sharepoint external sharing slider is set to "New and existing guests".
+    # The result must be N/A because the policy is not applicable unless external sharing is set to "Anyone".
+    Output := sharepoint.tests with input as {
+        "SPO_tenant": [
+            {
+                "SharingCapability": 1,
+                "RequireAnonymousLinksExpireInDays": 30
+            }
+        ]
+    }
+
+    PolicyId := "MS.SHAREPOINT.3.1v1"
+    ReportDetailsString := "This policy is only applicable if External Sharing is set to Anybody. See %v for more info"
+    TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
+}
+
+test_ExternalUserExpireInDays_Correct_V4 if {
+    # Test if the Sharepoint external sharing slider is set to "Anybody".
+    # If true, then evaluate the value for expiration days.
+    Output := sharepoint.tests with input as {
+        "SPO_tenant": [
+            {
+                "SharingCapability": 2,
+                "RequireAnonymousLinksExpireInDays": 30
+            }
+        ]
+    }
+
+    TestResult("MS.SHAREPOINT.3.1v1", Output, PASS, true) == true
+}
+
+test_ExternalUserExpireInDays_Correct_V5 if {
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
@@ -37,7 +89,7 @@ test_ExternalUserExpireInDays_Correct_V2 if {
     TestResult("MS.SHAREPOINT.3.1v1", Output, PASS, true) == true
 }
 
-test_ExternalUserExpireInDays_Correct_V3 if {
+test_ExternalUserExpireInDays_Correct_V6 if {
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
@@ -50,7 +102,7 @@ test_ExternalUserExpireInDays_Correct_V3 if {
     TestResult("MS.SHAREPOINT.3.1v1", Output, PASS, true) == true
 }
 
-test_ExternalUserExpireInDays_Correct_V4 if {
+test_ExternalUserExpireInDays_Correct_V7 if {
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
@@ -61,21 +113,6 @@ test_ExternalUserExpireInDays_Correct_V4 if {
     }
 
     TestResult("MS.SHAREPOINT.3.1v1", Output, PASS, true) == true
-}
-
-test_ExternalUserSharingCapability_Correct_V1 if {
-    # Test if the Sharepoint external sharing slider is set to "Only people in your organization".
-    # The result must be N/A because the policy is not applicable unless external sharing is set to "Anyone".
-    Output := sharepoint.tests with input as {
-        "SPO_tenant": [
-            {
-                "SharingCapability": 0,
-                "RequireAnonymousLinksExpireInDays": 30
-            }
-        ]
-    }
-
-    TestResult("MS.SHAREPOINT.3.1v1", Output, PASS, false) == true
 }
 
 test_ExternalUserExpireInDays_Incorrect_V1 if {

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_03_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_03_test.rego
@@ -189,7 +189,8 @@ test_AnonymousLinkType_UsingServicePrincipal if {
         "SPO_tenant": [
             {
                 "FileAnonymousLinkType": 2,
-                "FolderAnonymousLinkType": 1
+                "FolderAnonymousLinkType": 1,
+                "SharingCapability": 2
             }
         ],
         "OneDrive_PnP_Flag": true
@@ -261,20 +262,6 @@ test_File_Folder_AnonymousLinkType_SharingCapability_NewExistingGuests_NotApplic
 #
 # Policy MS.SHAREPOINT.3.3v1
 #--
-test_EmailAttestationReAuthDays_SharingCapability_ExistingGuests_Correct if {
-    Output := sharepoint.tests with input as {
-        "SPO_tenant": [
-            {
-                "SharingCapability": 3,
-                "EmailAttestationRequired": true,
-                "EmailAttestationReAuthDays": 30
-            }
-        ]
-    }
-
-    TestResult("MS.SHAREPOINT.3.3v1", Output, PASS, true) == true
-}
-
 test_EmailAttestationReAuthDays_SharingCapability_NewExistingGuests_Correct if {
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
@@ -380,7 +367,26 @@ test_EmailAttestationReAuthDays_SharingCapability_OnlyPeopleInOrg_NotApplicable 
     PolicyId := "MS.SHAREPOINT.3.3v1"
     ReportDetailsString := concat(" ", [
         "External Sharing is set to Only people in your organization.",
-        "This policy is only applicable if External Sharing is set to Anyone, New and existing guests, or Existing guests. See %v for more info"
+        "This policy is only applicable if External Sharing is set to Anyone or New and existing guests. See %v for more info"
+    ])
+    TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
+}
+
+test_EmailAttestationReAuthDays_SharingCapability_ExistingGuests_NotApplicable if {
+    Output := sharepoint.tests with input as {
+        "SPO_tenant": [
+            {
+                "SharingCapability": 3,
+                "EmailAttestationRequired": true,
+                "EmailAttestationReAuthDays": 29
+            }
+        ]
+    }
+
+    PolicyId := "MS.SHAREPOINT.3.3v1"
+    ReportDetailsString := concat(" ", [
+        "External Sharing is set to Existing guests.",
+        "This policy is only applicable if External Sharing is set to Anyone or New and existing guests. See %v for more info"
     ])
     TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
 }

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_03_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_03_test.rego
@@ -124,7 +124,8 @@ test_File_Folder_AnonymousLinkType_Correct if {
         "SPO_tenant": [
             {
                 "FileAnonymousLinkType": 1,
-                "FolderAnonymousLinkType": 1
+                "FolderAnonymousLinkType": 1,
+                "SharingCapability": 2
             }
         ],
         "OneDrive_PnP_Flag": false
@@ -138,7 +139,8 @@ test_File_Folder_AnonymousLinkType_Incorrect if {
         "SPO_tenant": [
             {
                 "FileAnonymousLinkType": 2,
-                "FolderAnonymousLinkType": 2
+                "FolderAnonymousLinkType": 2,
+                "SharingCapability": 2
             }
         ],
         "OneDrive_PnP_Flag": false
@@ -153,7 +155,8 @@ test_Folder_AnonymousLinkType_Incorrect if {
         "SPO_tenant": [
             {
                 "FileAnonymousLinkType": 1,
-                "FolderAnonymousLinkType": 2
+                "FolderAnonymousLinkType": 2,
+                "SharingCapability": 2
             }
         ],
         "OneDrive_PnP_Flag": false
@@ -168,7 +171,8 @@ test_File_AnonymousLinkType_Incorrect if {
         "SPO_tenant": [
             {
                 "FileAnonymousLinkType": 2,
-                "FolderAnonymousLinkType": 1
+                "FolderAnonymousLinkType": 1,
+                "SharingCapability": 2
             }
         ],
         "OneDrive_PnP_Flag": false
@@ -257,11 +261,11 @@ test_File_Folder_AnonymousLinkType_SharingCapability_NewExistingGuests_NotApplic
 #
 # Policy MS.SHAREPOINT.3.3v1
 #--
-test_SharingCapability_Correct if {
+test_EmailAttestationReAuthDays_SharingCapability_ExistingGuests_Correct if {
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
-                "SharingCapability": 0,
+                "SharingCapability": 3,
                 "EmailAttestationRequired": true,
                 "EmailAttestationReAuthDays": 30
             }
@@ -271,11 +275,25 @@ test_SharingCapability_Correct if {
     TestResult("MS.SHAREPOINT.3.3v1", Output, PASS, true) == true
 }
 
-test_SharingCapability_Correct_V4 if {
+test_EmailAttestationReAuthDays_SharingCapability_NewExistingGuests_Correct if {
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
                 "SharingCapability": 1,
+                "EmailAttestationRequired": true,
+                "EmailAttestationReAuthDays": 30
+            }
+        ]
+    }
+
+    TestResult("MS.SHAREPOINT.3.3v1", Output, PASS, true) == true
+}
+
+test_EmailAttestationReAuthDays_SharingCapability_Anyone_Correct if {
+    Output := sharepoint.tests with input as {
+        "SPO_tenant": [
+            {
+                "SharingCapability": 2,
                 "EmailAttestationRequired": true,
                 "EmailAttestationReAuthDays": 30
             }
@@ -299,7 +317,7 @@ test_EmailAttestationReAuthDays_Correct if {
     TestResult("MS.SHAREPOINT.3.3v1", Output, PASS, true) == true
 }
 
-test_Multi_Incorrect_V1 if {
+test_EmailAttestationReAuthDays_Incorrect_V1 if {
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
@@ -316,22 +334,7 @@ test_Multi_Incorrect_V1 if {
     TestResult("MS.SHAREPOINT.3.3v1", Output, ReportDetailString, false) == true
 }
 
-test_EmailAttestationRequired_Incorrect_V2 if {
-    Output := sharepoint.tests with input as {
-        "SPO_tenant": [
-            {
-                "SharingCapability": 1,
-                "EmailAttestationRequired": false,
-                "EmailAttestationReAuthDays": 29
-            }
-        ]
-    }
-
-    ReportDetailString := "Requirement not met: Expiration timer for 'People who use a verification code' NOT enabled"
-    TestResult("MS.SHAREPOINT.3.3v1", Output, ReportDetailString, false) == true
-}
-
-test_EmailAttestationReAuthDays_Incorrect_V3 if {
+test_EmailAttestationReAuthDays_Incorrect_V2 if {
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
@@ -346,5 +349,39 @@ test_EmailAttestationReAuthDays_Incorrect_V3 if {
         "Requirement not met: Expiration timer for 'People who use a verification code' NOT set to 30 days"
 
     TestResult("MS.SHAREPOINT.3.3v1", Output, ReportDetailString, false) == true
+}
+
+test_EmailAttestationRequired_Incorrect if {
+    Output := sharepoint.tests with input as {
+        "SPO_tenant": [
+            {
+                "SharingCapability": 1,
+                "EmailAttestationRequired": false,
+                "EmailAttestationReAuthDays": 29
+            }
+        ]
+    }
+
+    ReportDetailString := "Requirement not met: Expiration timer for 'People who use a verification code' NOT enabled"
+    TestResult("MS.SHAREPOINT.3.3v1", Output, ReportDetailString, false) == true
+}
+
+test_EmailAttestationReAuthDays_SharingCapability_OnlyPeopleInOrg_NotApplicable if {
+    Output := sharepoint.tests with input as {
+        "SPO_tenant": [
+            {
+                "SharingCapability": 0,
+                "EmailAttestationRequired": true,
+                "EmailAttestationReAuthDays": 29
+            }
+        ]
+    }
+
+    PolicyId := "MS.SHAREPOINT.3.3v1"
+    ReportDetailsString := concat(" ", [
+        "External Sharing is set to Only people in your organization.",
+        "This policy is only applicable if External Sharing is set to Anyone, New and existing guests, or Existing guests. See %v for more info"
+    ])
+    TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
 }
 #--

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_03_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_03_test.rego
@@ -328,10 +328,10 @@ test_EmailAttestationReAuthDays_Incorrect_V1 if {
         ]
     }
 
-    ReportDetailString :=
-        "Requirement not met: Expiration timer for 'People who use a verification code' NOT enabled and set to >30 days"
+    ReportDetailsString :=
+        "Requirement not met: Expiration time for 'People who use a verification code' NOT enabled and set to 30 days or more"
 
-    TestResult("MS.SHAREPOINT.3.3v1", Output, ReportDetailString, false) == true
+    TestResult("MS.SHAREPOINT.3.3v1", Output, ReportDetailsString, false) == true
 }
 
 test_EmailAttestationReAuthDays_Incorrect_V2 if {
@@ -346,7 +346,7 @@ test_EmailAttestationReAuthDays_Incorrect_V2 if {
     }
 
     ReportDetailString :=
-        "Requirement not met: Expiration timer for 'People who use a verification code' NOT set to 30 days"
+        "Requirement not met: Expiration time for 'People who use a verification code' NOT set to 30 days or less"
 
     TestResult("MS.SHAREPOINT.3.3v1", Output, ReportDetailString, false) == true
 }
@@ -362,7 +362,7 @@ test_EmailAttestationRequired_Incorrect if {
         ]
     }
 
-    ReportDetailString := "Requirement not met: Expiration timer for 'People who use a verification code' NOT enabled"
+    ReportDetailString := "Requirement not met: Expiration time for 'People who use a verification code' NOT enabled"
     TestResult("MS.SHAREPOINT.3.3v1", Output, ReportDetailString, false) == true
 }
 

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_03_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_03_test.rego
@@ -23,7 +23,10 @@ test_ExternalUserExpireInDays_Correct_V1 if {
     }
 
     PolicyId := "MS.SHAREPOINT.3.1v1"
-    ReportDetailsString := "This policy is only applicable if External Sharing is set to Anybody. See %v for more info"
+    ReportDetailsString := concat(" ", [
+        "External Sharing is set to Only people in your organization.",
+        "This policy is only applicable if External Sharing is set to Anyone. See %v for more info"
+    ])
     TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
 }
 
@@ -40,7 +43,10 @@ test_ExternalUserExpireInDays_Correct_V2 if {
     }
 
     PolicyId := "MS.SHAREPOINT.3.1v1"
-    ReportDetailsString := "This policy is only applicable if External Sharing is set to Anybody. See %v for more info"
+    ReportDetailsString := concat(" ", [
+        "External Sharing is set to Existing guests.",
+        "This policy is only applicable if External Sharing is set to Anyone. See %v for more info"
+    ])
     TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
 }
 
@@ -57,44 +63,21 @@ test_ExternalUserExpireInDays_Correct_V3 if {
     }
 
     PolicyId := "MS.SHAREPOINT.3.1v1"
-    ReportDetailsString := "This policy is only applicable if External Sharing is set to Anybody. See %v for more info"
+    ReportDetailsString := concat(" ", [
+        "External Sharing is set to New and existing guests.",
+        "This policy is only applicable if External Sharing is set to Anyone. See %v for more info"
+    ])
     TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
 }
 
 test_ExternalUserExpireInDays_Correct_V4 if {
-    # Test if the Sharepoint external sharing slider is set to "Anybody".
+    # Test if the Sharepoint external sharing slider is set to "Anyone".
     # If true, then evaluate the value for expiration days.
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
                 "SharingCapability": 2,
                 "RequireAnonymousLinksExpireInDays": 30
-            }
-        ]
-    }
-
-    TestResult("MS.SHAREPOINT.3.1v1", Output, PASS, true) == true
-}
-
-test_ExternalUserExpireInDays_Correct_V5 if {
-    Output := sharepoint.tests with input as {
-        "SPO_tenant": [
-            {
-                "SharingCapability": 3,
-                "RequireAnonymousLinksExpireInDays": 30
-            }
-        ]
-    }
-
-    TestResult("MS.SHAREPOINT.3.1v1", Output, PASS, true) == true
-}
-
-test_ExternalUserExpireInDays_Correct_V6 if {
-    Output := sharepoint.tests with input as {
-        "SPO_tenant": [
-            {
-                "SharingCapability": 1,
-                "RequireAnonymousLinksExpireInDays": 29
             }
         ]
     }
@@ -119,16 +102,13 @@ test_ExternalUserExpireInDays_Incorrect_V1 if {
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
-                "SharingCapability": 1,
+                "SharingCapability": 2,
                 "RequireAnonymousLinksExpireInDays": 31
             }
         ]
     }
 
-    ReportDetailString := concat(" ", [
-        "Requirement not met: External Sharing is set to New",
-        "and Existing Guests and expiration date is not 30 days or less"
-    ])
+    ReportDetailString := "Anyone links expiration date is not set to 30 days or less"
     TestResult("MS.SHAREPOINT.3.1v1", Output, ReportDetailString, false) == true
 }
 
@@ -142,9 +122,7 @@ test_ExternalUserExpireInDays_Incorrect_V2 if {
         ]
     }
 
-    ReportDetailString :=
-        "Requirement not met: External Sharing is set to Anyone and expiration date is not 30 days or less"
-
+    ReportDetailString := "Anyone links expiration date is not set to 30 days or less"
     TestResult("MS.SHAREPOINT.3.1v1", Output, ReportDetailString, false) == true
 }
 #--

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_03_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_03_test.rego
@@ -10,14 +10,14 @@ import data.utils.key.PASS
 #
 # Policy MS.SHAREPOINT.3.1v1
 #--
-test_ExternalUserExpireInDays_Correct_V1 if {
+test_SharingCapability_RequireAnonymousLinksExpireInDays_NotApplicable_V1 if {
     # Test if the Sharepoint external sharing slider is set to "Only people in your organization".
     # The result must be N/A because the policy is not applicable unless external sharing is set to "Anyone".
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
                 "SharingCapability": 0,
-                "RequireAnonymousLinksExpireInDays": 30
+                "RequireAnonymousLinksExpireInDays": 31
             }
         ]
     }
@@ -30,14 +30,14 @@ test_ExternalUserExpireInDays_Correct_V1 if {
     TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
 }
 
-test_ExternalUserExpireInDays_Correct_V2 if {
+test_SharingCapability_RequireAnonymousLinksExpireInDays_NotApplicable_V2 if {
     # Test if the Sharepoint external sharing slider is set to "Existing guests".
     # The result must be N/A because the policy is not applicable unless external sharing is set to "Anyone".
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
                 "SharingCapability": 3,
-                "RequireAnonymousLinksExpireInDays": 30
+                "RequireAnonymousLinksExpireInDays": 31
             }
         ]
     }
@@ -50,14 +50,14 @@ test_ExternalUserExpireInDays_Correct_V2 if {
     TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
 }
 
-test_ExternalUserExpireInDays_Correct_V3 if {
+test_SharingCapability_RequireAnonymousLinksExpireInDays_NotApplicable_V3 if {
     # Test if the Sharepoint external sharing slider is set to "New and existing guests".
     # The result must be N/A because the policy is not applicable unless external sharing is set to "Anyone".
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
                 "SharingCapability": 1,
-                "RequireAnonymousLinksExpireInDays": 30
+                "RequireAnonymousLinksExpireInDays": 31
             }
         ]
     }
@@ -70,7 +70,7 @@ test_ExternalUserExpireInDays_Correct_V3 if {
     TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
 }
 
-test_ExternalUserExpireInDays_Correct_V4 if {
+test_SharingCapability_RequireAnonymousLinksExpireInDays_Correct_V4 if {
     # Test if the Sharepoint external sharing slider is set to "Anyone".
     # If true, then evaluate the value for expiration days.
     Output := sharepoint.tests with input as {
@@ -85,7 +85,7 @@ test_ExternalUserExpireInDays_Correct_V4 if {
     TestResult("MS.SHAREPOINT.3.1v1", Output, PASS, true) == true
 }
 
-test_ExternalUserExpireInDays_Correct_V5 if {
+test_SharingCapability_RequireAnonymousLinksExpireInDays_Correct_V5 if {
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
@@ -98,24 +98,7 @@ test_ExternalUserExpireInDays_Correct_V5 if {
     TestResult("MS.SHAREPOINT.3.1v1", Output, PASS, true) == true
 }
 
-test_ExternalUserExpireInDays_Incorrect_V1 if {
-    Output := sharepoint.tests with input as {
-        "SPO_tenant": [
-            {
-                "SharingCapability": 2,
-                "RequireAnonymousLinksExpireInDays": 31
-            }
-        ]
-    }
-
-    ReportDetailsString := concat(" ", [
-        "Requirement not met:",
-        "External Sharing is set to Anyone and expiration date is not set to 30 days or less."
-    ])
-    TestResult("MS.SHAREPOINT.3.1v1", Output, ReportDetailsString, false) == true
-}
-
-test_ExternalUserExpireInDays_Incorrect_V2 if {
+test_SharingCapability_RequireAnonymousLinksExpireInDays_Incorrect_V6 if {
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_03_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_03_test.rego
@@ -10,7 +10,7 @@ import data.utils.key.PASS
 #
 # Policy MS.SHAREPOINT.3.1v1
 #--
-test_SharingCapability_RequireAnonymousLinksExpireInDays_NotApplicable_V1 if {
+test_SharingCapability_LinkExpirationInvalid_NotApplicable_V1 if {
     # Test if the Sharepoint external sharing slider is set to "Only people in your organization".
     # The result must be N/A because the policy is not applicable unless external sharing is set to "Anyone".
     Output := sharepoint.tests with input as {
@@ -30,7 +30,7 @@ test_SharingCapability_RequireAnonymousLinksExpireInDays_NotApplicable_V1 if {
     TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
 }
 
-test_SharingCapability_RequireAnonymousLinksExpireInDays_NotApplicable_V2 if {
+test_SharingCapability_LinkExpirationInvalid_NotApplicable_V2 if {
     # Test if the Sharepoint external sharing slider is set to "Existing guests".
     # The result must be N/A because the policy is not applicable unless external sharing is set to "Anyone".
     Output := sharepoint.tests with input as {
@@ -50,7 +50,7 @@ test_SharingCapability_RequireAnonymousLinksExpireInDays_NotApplicable_V2 if {
     TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
 }
 
-test_SharingCapability_RequireAnonymousLinksExpireInDays_NotApplicable_V3 if {
+test_SharingCapability_LinkExpirationInvalid_NotApplicable_V3 if {
     # Test if the Sharepoint external sharing slider is set to "New and existing guests".
     # The result must be N/A because the policy is not applicable unless external sharing is set to "Anyone".
     Output := sharepoint.tests with input as {
@@ -70,7 +70,7 @@ test_SharingCapability_RequireAnonymousLinksExpireInDays_NotApplicable_V3 if {
     TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
 }
 
-test_SharingCapability_RequireAnonymousLinksExpireInDays_Correct_V4 if {
+test_SharingCapability_LinkExpirationValid_Correct_V4 if {
     # Test if the Sharepoint external sharing slider is set to "Anyone".
     # If true, then evaluate the value for expiration days.
     Output := sharepoint.tests with input as {
@@ -85,7 +85,7 @@ test_SharingCapability_RequireAnonymousLinksExpireInDays_Correct_V4 if {
     TestResult("MS.SHAREPOINT.3.1v1", Output, PASS, true) == true
 }
 
-test_SharingCapability_RequireAnonymousLinksExpireInDays_Correct_V5 if {
+test_SharingCapability_LinkExpirationValid_Correct_V5 if {
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
@@ -98,7 +98,7 @@ test_SharingCapability_RequireAnonymousLinksExpireInDays_Correct_V5 if {
     TestResult("MS.SHAREPOINT.3.1v1", Output, PASS, true) == true
 }
 
-test_SharingCapability_RequireAnonymousLinksExpireInDays_Incorrect_V6 if {
+test_SharingCapability_LinkExpirationInvalid_Incorrect_V6 if {
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_03_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_03_test.rego
@@ -57,7 +57,7 @@ test_SharingCapability_Anyone_LinkExpirationInvalid_Incorrect if {
 
 # Test if the Sharepoint external sharing slider is set to "Only people in your organization".
 # The result must be N/A because the policy is not applicable unless external sharing is set to "Anyone".
-test_SharingCapability_OnlyPeopleInOrg_NotApplicable if {
+test_SharingCapability_OnlyPeopleInOrg_NotApplicable_V1 if {
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
@@ -77,7 +77,7 @@ test_SharingCapability_OnlyPeopleInOrg_NotApplicable if {
 
 # Test if the Sharepoint external sharing slider is set to "Existing guests".
 # The result must be N/A because the policy is not applicable unless external sharing is set to "Anyone".
-test_SharingCapability_ExistingGuests_NotApplicable if {
+test_SharingCapability_ExistingGuests_NotApplicable_V1 if {
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
@@ -97,12 +97,72 @@ test_SharingCapability_ExistingGuests_NotApplicable if {
 
 # Test if the Sharepoint external sharing slider is set to "New and existing guests".
 # The result must be N/A because the policy is not applicable unless external sharing is set to "Anyone".
-test_SharingCapability_NewExistingGuests_NotApplicable if {
+test_SharingCapability_NewExistingGuests_NotApplicable_V1 if {
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
                 "SharingCapability": 1,
                 "RequireAnonymousLinksExpireInDays": 31
+            }
+        ]
+    }
+
+    PolicyId := "MS.SHAREPOINT.3.1v1"
+    ReportDetailsString := concat(" ", [
+        "This policy is only applicable if External Sharing is set to any value other than Anyone.",
+        "See %v for more info"
+    ])
+    TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
+}
+
+# Test if the Sharepoint external sharing slider is set to "Only people in your organization".
+# The result must be N/A because the policy is not applicable unless external sharing is set to "Anyone".
+test_SharingCapability_OnlyPeopleInOrg_NotApplicable_V2 if {
+    Output := sharepoint.tests with input as {
+        "SPO_tenant": [
+            {
+                "SharingCapability": 0,
+                "RequireAnonymousLinksExpireInDays": 29
+            }
+        ]
+    }
+
+    PolicyId := "MS.SHAREPOINT.3.1v1"
+    ReportDetailsString := concat(" ", [
+        "This policy is only applicable if External Sharing is set to any value other than Anyone.",
+        "See %v for more info"
+    ])
+    TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
+}
+
+# Test if the Sharepoint external sharing slider is set to "Existing guests".
+# The result must be N/A because the policy is not applicable unless external sharing is set to "Anyone".
+test_SharingCapability_ExistingGuests_NotApplicable_V2 if {
+    Output := sharepoint.tests with input as {
+        "SPO_tenant": [
+            {
+                "SharingCapability": 3,
+                "RequireAnonymousLinksExpireInDays": 29
+            }
+        ]
+    }
+
+    PolicyId := "MS.SHAREPOINT.3.1v1"
+    ReportDetailsString := concat(" ", [
+        "This policy is only applicable if External Sharing is set to any value other than Anyone.",
+        "See %v for more info"
+    ])
+    TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), false) == true
+}
+
+# Test if the Sharepoint external sharing slider is set to "New and existing guests".
+# The result must be N/A because the policy is not applicable unless external sharing is set to "Anyone".
+test_SharingCapability_NewExistingGuests_NotApplicable_V2 if {
+    Output := sharepoint.tests with input as {
+        "SPO_tenant": [
+            {
+                "SharingCapability": 1,
+                "RequireAnonymousLinksExpireInDays": 29
             }
         ]
     }

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_03_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_03_test.rego
@@ -85,7 +85,7 @@ test_ExternalUserExpireInDays_Correct_V4 if {
     TestResult("MS.SHAREPOINT.3.1v1", Output, PASS, true) == true
 }
 
-test_ExternalUserExpireInDays_Correct_V7 if {
+test_ExternalUserExpireInDays_Correct_V5 if {
     Output := sharepoint.tests with input as {
         "SPO_tenant": [
             {
@@ -108,8 +108,11 @@ test_ExternalUserExpireInDays_Incorrect_V1 if {
         ]
     }
 
-    ReportDetailString := "Anyone links expiration date is not set to 30 days or less"
-    TestResult("MS.SHAREPOINT.3.1v1", Output, ReportDetailString, false) == true
+    ReportDetailsString := concat(" ", [
+        "Requirement not met:",
+        "External Sharing is set to Anyone and expiration date is not set to 30 days or less."
+    ])
+    TestResult("MS.SHAREPOINT.3.1v1", Output, ReportDetailsString, false) == true
 }
 
 test_ExternalUserExpireInDays_Incorrect_V2 if {
@@ -122,8 +125,11 @@ test_ExternalUserExpireInDays_Incorrect_V2 if {
         ]
     }
 
-    ReportDetailString := "Anyone links expiration date is not set to 30 days or less"
-    TestResult("MS.SHAREPOINT.3.1v1", Output, ReportDetailString, false) == true
+    ReportDetailsString := concat(" ", [
+        "Requirement not met:",
+        "External Sharing is set to Anyone and expiration date is not set to 30 days or less."
+    ])
+    TestResult("MS.SHAREPOINT.3.1v1", Output, ReportDetailsString, false) == true
 }
 #--
 

--- a/Testing/Functional/Products/TestPlans/sharepoint.pnp.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/sharepoint.pnp.testplan.yaml
@@ -45,7 +45,7 @@ TestPlan:
   - PolicyId: MS.SHAREPOINT.1.3v1
     TestDriver: RunScuba
     Tests:
-      - TestDescription: MS.SHAREPOINT.1.3v1 Non-compliant - SharingCapability ExternalUserSharingOnly (New and existing guests) SharingDomainRestrictionMode = BlockList
+      - TestDescription: MS.SHAREPOINT.1.3v1 Non-compliant - SharingCapability = ExternalUserSharingOnly (New and existing guests); SharingDomainRestrictionMode = BlockList
         Preconditions:
           - Command: Set-PnPTenant
             Splat:
@@ -54,7 +54,7 @@ TestPlan:
               SharingBlockedDomainList: nefarious.com evil.is.us
         Postconditions: []
         ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.1.3v1 Compliant -  SharingCapability ExternalUserSharingOnly (New and existing guests) SharingDomainRestrictionMode = AllowList
+      - TestDescription: MS.SHAREPOINT.1.3v1 Compliant -  SharingCapability = ExternalUserSharingOnly (New and existing guests); SharingDomainRestrictionMode = AllowList
         Preconditions:
           - Command: Set-PnPTenant
             Splat:
@@ -63,7 +63,7 @@ TestPlan:
               SharingAllowedDomainList: good.org admirable.us
         Postconditions: []
         ExpectedResult: true
-      - TestDescription: MS.SHAREPOINT.1.3v1 Compliant -  SharingCapability = ExternalUserAndGuestSharing (Anyone) SharingDomainRestrictionMode = AllowList
+      - TestDescription: MS.SHAREPOINT.1.3v1 Compliant -  SharingCapability = ExternalUserAndGuestSharing (Anyone); SharingDomainRestrictionMode = AllowList
         Preconditions:
           - Command: Set-PnPTenant
             Splat:
@@ -72,7 +72,7 @@ TestPlan:
               SharingAllowedDomainList: good.org admirable.us
         Postconditions: []
         ExpectedResult: true
-      - TestDescription: MS.SHAREPOINT.1.3v1 Non-Applicable - SharingCapability = Disabled (Only people in organization)
+      - TestDescription: MS.SHAREPOINT.1.3v1 Non-Applicable - SharingCapability = Disabled (Only people in organization);
         Preconditions:
           - Command: Set-PnPTenant
             Splat:
@@ -81,7 +81,7 @@ TestPlan:
         Postconditions: []
         IsNotChecked: true
         ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.1.3v1 Non-Applicable - SharingCapability = Disabled (Only people in organization) SharingDomainRestrictionMode = AllowList
+      - TestDescription: MS.SHAREPOINT.1.3v1 Non-Applicable - SharingCapability = Disabled (Only people in organization); SharingDomainRestrictionMode = AllowList
         Preconditions:
           - Command: Set-PnPTenant
             Splat:
@@ -95,7 +95,7 @@ TestPlan:
   - PolicyId: MS.SHAREPOINT.1.4v1
     TestDriver: RunScuba
     Tests:
-      - TestDescription: MS.SHAREPOINT.1.4v1 Non-compliant - SharingCapability Not Disabled RequireAcceptingAccountMatchInvitedAccount = false
+      - TestDescription: MS.SHAREPOINT.1.4v1 Non-compliant - SharingCapability = ExternalUserSharingOnly (New and existing guests); RequireAcceptingAccountMatchInvitedAccount = false
         Preconditions:
           - Command: Set-PnPTenant
             Splat:
@@ -103,23 +103,23 @@ TestPlan:
               RequireAcceptingAccountMatchInvitedAccount: false
         Postconditions: []
         ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.1.4v1 Compliant - SharingCapability Disabled RequireAcceptingAccountMatchInvitedAccount = false
+      - TestDescription: MS.SHAREPOINT.1.4v1 Compliant - SharingCapability = ExternalUserAndGuestSharing (Anyone); RequireAcceptingAccountMatchInvitedAccount = true
         Preconditions:
           - Command: Set-PnPTenant
             Splat:
-              SharingCapability: Disabled
-              RequireAcceptingAccountMatchInvitedAccount: false
-        Postconditions: []
-        ExpectedResult: true
-      - TestDescription: MS.SHAREPOINT.1.4v1 Compliant - SharingCapability Disabled RequireAcceptingAccountMatchInvitedAccount = true
-        Preconditions:
-          - Command: Set-PnPTenant
-            Splat:
-              SharingCapability: Disabled
+              SharingCapability: ExternalUserAndGuestSharing
               RequireAcceptingAccountMatchInvitedAccount: true
         Postconditions: []
         ExpectedResult: true
-      - TestDescription: MS.SHAREPOINT.1.4v1 Compliant - SharingCapability Not Disabled RequireAcceptingAccountMatchInvitedAccount = true
+      - TestDescription: MS.SHAREPOINT.1.4v1 Compliant - SharingCapability = ExistingExternalUserSharingOnly (Existing guests); RequireAcceptingAccountMatchInvitedAccount = true
+        Preconditions:
+          - Command: Set-PnPTenant
+            Splat:
+              SharingCapability: ExistingExternalUserSharingOnly
+              RequireAcceptingAccountMatchInvitedAccount: true
+        Postconditions: []
+        ExpectedResult: true
+      - TestDescription: MS.SHAREPOINT.1.4v1 Compliant - SharingCapability = ExternalUserSharingOnly (New and existing guests); RequireAcceptingAccountMatchInvitedAccount = true
         Preconditions:
           - Command: Set-PnPTenant
             Splat:
@@ -127,6 +127,24 @@ TestPlan:
               RequireAcceptingAccountMatchInvitedAccount: true
         Postconditions: []
         ExpectedResult: true
+      - TestDescription: MS.SHAREPOINT.1.4v1 Non-Applicable - SharingCapability = Disabled (Only people in organization); RequireAcceptingAccountMatchInvitedAccount = true
+        Preconditions:
+          - Command: Set-PnPTenant
+            Splat:
+              SharingCapability: Disabled
+              RequireAcceptingAccountMatchInvitedAccount: true
+        Postconditions: []
+        IsNotChecked: true
+        ExpectedResult: false
+      - TestDescription: MS.SHAREPOINT.1.4v1 Non-Applicable - SharingCapability = Disabled (Only people in organization); RequireAcceptingAccountMatchInvitedAccount = false
+        Preconditions:
+          - Command: Set-PnPTenant
+            Splat:
+              SharingCapability: Disabled
+              RequireAcceptingAccountMatchInvitedAccount: false
+        Postconditions: []
+        IsNotChecked: true
+        ExpectedResult: false
 
   - PolicyId: MS.SHAREPOINT.2.1v1
     TestDriver: RunScuba
@@ -231,6 +249,36 @@ TestPlan:
         IsNotChecked: true
         ExpectedResult: false
       - TestDescription: MS.SHAREPOINT.3.1v1 Non-Compliant - SharingCapability = Disabled (Only people in your organization); RequireAnonymousLinksExpireInDays = 30
+        Preconditions:
+          - Command: Set-PnPTenant
+            Splat:
+              RequireAnonymousLinksExpireInDays: 30
+              DefaultSharingLinkType: AnonymousAccess
+              SharingCapability: Disabled
+        Postconditions: []
+        IsNotChecked: true
+        ExpectedResult: false
+      - TestDescription: MS.SHAREPOINT.3.1v1 Non-Applicable - SharingCapability = ExternalUserSharingOnly (New and existing guests); RequireAnonymousLinksExpireInDays = 30
+        Preconditions:
+          - Command: Set-PnPTenant
+            Splat:
+              RequireAnonymousLinksExpireInDays: 30
+              DefaultSharingLinkType: AnonymousAccess
+              SharingCapability: ExternalUserSharingOnly
+        Postconditions: []
+        IsNotChecked: true
+        ExpectedResult: false
+      - TestDescription: MS.SHAREPOINT.3.1v1 Non-Applicable - SharingCapability = ExistingExternalUserSharingOnly (Existing guests); RequireAnonymousLinksExpireInDays = 30
+        Preconditions:
+          - Command: Set-PnPTenant
+            Splat:
+              RequireAnonymousLinksExpireInDays: 30
+              DefaultSharingLinkType: AnonymousAccess
+              SharingCapability: ExistingExternalUserSharingOnly
+        Postconditions: []
+        IsNotChecked: true
+        ExpectedResult: false
+      - TestDescription: MS.SHAREPOINT.3.1v1 Non-Applicable - SharingCapability = Disabled (Only people in your organization); RequireAnonymousLinksExpireInDays = 30
         Preconditions:
           - Command: Set-PnPTenant
             Splat:

--- a/Testing/Functional/Products/TestPlans/sharepoint.pnp.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/sharepoint.pnp.testplan.yaml
@@ -172,7 +172,7 @@ TestPlan:
               SharingCapability: ExternalUserAndGuestSharing
         Postconditions: []
         ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.3.1v1 Compliant - SharingCapability = ExternalUserAndGuestSharing; RequireAnonymousLinksExpireInDays < 30
+      - TestDescription: MS.SHAREPOINT.3.1v1 Compliant - SharingCapability = ExternalUserAndGuestSharing (Anyone); RequireAnonymousLinksExpireInDays < 30
         Preconditions:
           - Command: Set-PnPTenant
             Splat:
@@ -181,7 +181,7 @@ TestPlan:
               SharingCapability: ExternalUserAndGuestSharing
         Postconditions: []
         ExpectedResult: true
-      - TestDescription: MS.SHAREPOINT.3.1v1 Compliant - SharingCapability = ExternalUserAndGuestSharing; RequireAnonymousLinksExpireInDays = 30
+      - TestDescription: MS.SHAREPOINT.3.1v1 Compliant - SharingCapability = ExternalUserAndGuestSharing (Anyone); RequireAnonymousLinksExpireInDays = 30
         Preconditions:
           - Command: Set-PnPTenant
             Splat:
@@ -190,28 +190,36 @@ TestPlan:
               SharingCapability: ExternalUserAndGuestSharing
         Postconditions: []
         ExpectedResult: true
-      - TestDescription: MS.SHAREPOINT.3.1v1 Compliant - SharingCapability = ExternalUserSharingOnly; RequireAnonymousLinksExpireInDays = 30
-        ToDo: Check if support anonymous access
+      - TestDescription: MS.SHAREPOINT.3.1v1 Non-Compliant - SharingCapability = ExternalUserSharingOnly (New and existing guests); RequireAnonymousLinksExpireInDays = 30
         Preconditions:
           - Command: Set-PnPTenant
             Splat:
+              RequireAnonymousLinksExpireInDays: 30
+              DefaultSharingLinkType: AnonymousAccess
               SharingCapability: ExternalUserSharingOnly
         Postconditions: []
-        ExpectedResult: true
-      - TestDescription: MS.SHAREPOINT.3.1v1 Compliant - SharingCapability = ExistingExternalUserSharingOnly
+        IsNotChecked: true
+        ExpectedResult: false
+      - TestDescription: MS.SHAREPOINT.3.1v1 Non-Compliant - SharingCapability = ExistingExternalUserSharingOnly (Existing guests); RequireAnonymousLinksExpireInDays = 30
         Preconditions:
           - Command: Set-PnPTenant
             Splat:
+              RequireAnonymousLinksExpireInDays: 30
+              DefaultSharingLinkType: AnonymousAccess
               SharingCapability: ExistingExternalUserSharingOnly
         Postconditions: []
-        ExpectedResult: true
-      - TestDescription: MS.SHAREPOINT.3.1v1 Compliant - SharingCapability = Disabled
+        IsNotChecked: true
+        ExpectedResult: false
+      - TestDescription: MS.SHAREPOINT.3.1v1 Non-Compliant - SharingCapability = Disabled (Only people in your organization); RequireAnonymousLinksExpireInDays = 30
         Preconditions:
           - Command: Set-PnPTenant
             Splat:
+              RequireAnonymousLinksExpireInDays: 30
+              DefaultSharingLinkType: AnonymousAccess
               SharingCapability: Disabled
         Postconditions: []
-        ExpectedResult: true
+        IsNotChecked: true
+        ExpectedResult: false
 
   - PolicyId: MS.SHAREPOINT.3.2v1
     TestDriver: RunScuba

--- a/Testing/Functional/Products/TestPlans/sharepoint.pnp.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/sharepoint.pnp.testplan.yaml
@@ -45,7 +45,7 @@ TestPlan:
   - PolicyId: MS.SHAREPOINT.1.3v1
     TestDriver: RunScuba
     Tests:
-      - TestDescription: MS.SHAREPOINT.1.3v1 Non-compliant - SharingCapability Not Disabled SharingDomainRestrictionMode = BlockList
+      - TestDescription: MS.SHAREPOINT.1.3v1 Non-compliant - SharingCapability ExternalUserSharingOnly (New and existing guests) SharingDomainRestrictionMode = BlockList
         Preconditions:
           - Command: Set-PnPTenant
             Splat:
@@ -54,7 +54,7 @@ TestPlan:
               SharingBlockedDomainList: nefarious.com evil.is.us
         Postconditions: []
         ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.1.3v1 Compliant -  SharingCapability Not Disabled SharingDomainRestrictionMode = AllowList
+      - TestDescription: MS.SHAREPOINT.1.3v1 Compliant -  SharingCapability ExternalUserSharingOnly (New and existing guests) SharingDomainRestrictionMode = AllowList
         Preconditions:
           - Command: Set-PnPTenant
             Splat:
@@ -63,14 +63,34 @@ TestPlan:
               SharingAllowedDomainList: good.org admirable.us
         Postconditions: []
         ExpectedResult: true
-      - TestDescription: MS.SHAREPOINT.1.3v1 Compliant - SharingCapability = Disabled
+      - TestDescription: MS.SHAREPOINT.1.3v1 Compliant -  SharingCapability = ExternalUserAndGuestSharing (Anyone) SharingDomainRestrictionMode = AllowList
+        Preconditions:
+          - Command: Set-PnPTenant
+            Splat:
+              SharingCapability: ExternalUserAndGuestSharing
+              SharingDomainRestrictionMode: AllowList
+              SharingAllowedDomainList: good.org admirable.us
+        Postconditions: []
+        ExpectedResult: true
+      - TestDescription: MS.SHAREPOINT.1.3v1 Non-Applicable - SharingCapability = Disabled (Only people in organization)
         Preconditions:
           - Command: Set-PnPTenant
             Splat:
               SharingCapability: Disabled
               SharingDomainRestrictionMode: None
         Postconditions: []
-        ExpectedResult: true
+        IsNotChecked: true
+        ExpectedResult: false
+      - TestDescription: MS.SHAREPOINT.1.3v1 Non-Applicable - SharingCapability = Disabled (Only people in organization) SharingDomainRestrictionMode = AllowList
+        Preconditions:
+          - Command: Set-PnPTenant
+            Splat:
+              SharingCapability: Disabled
+              SharingDomainRestrictionMode: AllowList
+              SharingAllowedDomainList: good.org admirable.us
+        Postconditions: []
+        IsNotChecked: true
+        ExpectedResult: false
 
   - PolicyId: MS.SHAREPOINT.1.4v1
     TestDriver: RunScuba

--- a/Testing/Functional/Products/TestPlans/sharepoint.pnp.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/sharepoint.pnp.testplan.yaml
@@ -183,14 +183,14 @@ TestPlan:
   - PolicyId: MS.SHAREPOINT.2.2v1
     TestDriver: RunScuba
     Tests:
-      - TestDescription: MS.SHAREPOINT.2.2v1 Non-compliant - DefaultSharingLinkType = Edit
+      - TestDescription: MS.SHAREPOINT.2.2v1 Non-compliant - DefaultLinkPermission = Edit
         Preconditions:
           - Command: Set-PnPTenant
             Splat:
               DefaultLinkPermission: Edit
         Postconditions: []
         ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.2.2v1 Compliant - DefaultSharingLinkType = View
+      - TestDescription: MS.SHAREPOINT.2.2v1 Compliant - DefaultLinkPermission = View
         Preconditions:
           - Command: Set-PnPTenant
             Splat:

--- a/Testing/Functional/Products/TestPlans/sharepoint.pnp.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/sharepoint.pnp.testplan.yaml
@@ -233,7 +233,7 @@ TestPlan:
   - PolicyId: MS.SHAREPOINT.3.3v1
     TestDriver: RunScuba
     Tests:
-      - TestDescription: MS.SHAREPOINT.3.3v1 Non-compliant - SharingCapability = ExistingExternalUserSharingOnly; EmailAttestationRequired = false; EmailAttestationReAuthDays = 30
+      - TestDescription: MS.SHAREPOINT.3.3v1 Non-Applicable - SharingCapability = ExistingExternalUserSharingOnly (Existing guests); EmailAttestationRequired = false; EmailAttestationReAuthDays = 30
         Preconditions:
           - Command: Set-PnPTenant
             Splat:
@@ -241,8 +241,9 @@ TestPlan:
               EmailAttestationRequired: false
               EmailAttestationReAuthDays: 30
         Postconditions: []
+        IsNotChecked: true
         ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.3.3v1 Non-compliant - SharingCapability = ExternalUserSharingOnly; EmailAttestationRequired = false; EmailAttestationReAuthDays = 30
+      - TestDescription: MS.SHAREPOINT.3.3v1 Non-compliant - SharingCapability = ExternalUserSharingOnly (New and existing guests); EmailAttestationRequired = false; EmailAttestationReAuthDays = 30
         Preconditions:
           - Command: Set-PnPTenant
             Splat:
@@ -251,7 +252,7 @@ TestPlan:
               EmailAttestationReAuthDays: 30
         Postconditions: []
         ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.3.3v1 Non-compliant - SharingCapability = ExternalUserAndGuestSharing; EmailAttestationRequired = false; EmailAttestationReAuthDays = 30
+      - TestDescription: MS.SHAREPOINT.3.3v1 Non-compliant - SharingCapability = ExternalUserAndGuestSharing (Anyone); EmailAttestationRequired = false; EmailAttestationReAuthDays = 30
         Preconditions:
           - Command: Set-PnPTenant
             Splat:
@@ -260,7 +261,7 @@ TestPlan:
               EmailAttestationReAuthDays: 30
         Postconditions: []
         ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.3.3v1 Non-compliant - SharingCapability = ExistingExternalUserSharingOnly; EmailAttestationRequired = true; EmailAttestationReAuthDays > 30
+      - TestDescription: MS.SHAREPOINT.3.3v1 Non-Applicable - SharingCapability = ExistingExternalUserSharingOnly (Existing guests); EmailAttestationRequired = true; EmailAttestationReAuthDays > 30
         Preconditions:
           - Command: Set-PnPTenant
             Splat:
@@ -268,8 +269,9 @@ TestPlan:
               EmailAttestationRequired: true
               EmailAttestationReAuthDays: 31
         Postconditions: []
+        IsNotChecked: true
         ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.3.3v1 Non-compliant - SharingCapability = ExternalUserSharingOnly; EmailAttestationRequired = true; EmailAttestationReAuthDays > 30
+      - TestDescription: MS.SHAREPOINT.3.3v1 Non-compliant - SharingCapability = ExternalUserSharingOnly (New and existing guests); EmailAttestationRequired = true; EmailAttestationReAuthDays > 30
         Preconditions:
           - Command: Set-PnPTenant
             Splat:
@@ -278,7 +280,7 @@ TestPlan:
               EmailAttestationReAuthDays: 31
         Postconditions: []
         ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.3.3v1 Non-compliant - SharingCapability = ExternalUserAndGuestSharing; EmailAttestationRequired = true; EmailAttestationReAuthDays > 30
+      - TestDescription: MS.SHAREPOINT.3.3v1 Non-compliant - SharingCapability = ExternalUserAndGuestSharing (Anyone); EmailAttestationRequired = true; EmailAttestationReAuthDays > 30
         Preconditions:
           - Command: Set-PnPTenant
             Splat:
@@ -287,7 +289,7 @@ TestPlan:
               EmailAttestationReAuthDays: 31
         Postconditions: []
         ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.3.3v1 Compliant - SharingCapability = ExistingExternalUserSharingOnly; EmailAttestationRequired = true; EmailAttestationReAuthDays = 30
+      - TestDescription: MS.SHAREPOINT.3.3v1 Non-Applicable - SharingCapability = ExistingExternalUserSharingOnly (Existing guests); EmailAttestationRequired = true; EmailAttestationReAuthDays = 30
         Preconditions:
           - Command: Set-PnPTenant
             Splat:
@@ -295,8 +297,9 @@ TestPlan:
               EmailAttestationRequired: true
               EmailAttestationReAuthDays: 30
         Postconditions: []
-        ExpectedResult: true
-      - TestDescription: MS.SHAREPOINT.3.3v1 Compliant - SharingCapability = ExternalUserSharingOnly; EmailAttestationRequired = true; EmailAttestationReAuthDays = 30
+        IsNotChecked: true
+        ExpectedResult: false
+      - TestDescription: MS.SHAREPOINT.3.3v1 Compliant - SharingCapability = ExternalUserSharingOnly (New and existing guests); EmailAttestationRequired = true; EmailAttestationReAuthDays = 30
         Preconditions:
           - Command: Set-PnPTenant
             Splat:
@@ -305,7 +308,7 @@ TestPlan:
               EmailAttestationReAuthDays: 30
         Postconditions: []
         ExpectedResult: true
-      - TestDescription: MS.SHAREPOINT.3.3v1 Compliant - SharingCapability = ExternalUserAndGuestSharing; EmailAttestationRequired = true; EmailAttestationReAuthDays = 30
+      - TestDescription: MS.SHAREPOINT.3.3v1 Compliant - SharingCapability = ExternalUserAndGuestSharing (Anyone); EmailAttestationRequired = true; EmailAttestationReAuthDays = 30
         Preconditions:
           - Command: Set-PnPTenant
             Splat:
@@ -314,13 +317,16 @@ TestPlan:
               EmailAttestationReAuthDays: 30
         Postconditions: []
         ExpectedResult: true
-      - TestDescription: MS.SHAREPOINT.3.3v1 Compliant - SharingCapability = Disabled
+      - TestDescription: MS.SHAREPOINT.3.3v1 Non-Applicable - SharingCapability = Disabled (Only people in organization)
         Preconditions:
           - Command: Set-PnPTenant
             Splat:
               SharingCapability: Disabled
+              EmailAttestationRequired: true
+              EmailAttestationReAuthDays: 29
         Postconditions: []
-        ExpectedResult: true
+        IsNotChecked: true
+        ExpectedResult: false
 
   - PolicyId: MS.SHAREPOINT.4.1v1
     TestDriver: RunScuba

--- a/Testing/Functional/Products/TestPlans/sharepoint.pnp.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/sharepoint.pnp.testplan.yaml
@@ -206,7 +206,6 @@ TestPlan:
           - Command: Set-PnPTenant
             Splat:
               RequireAnonymousLinksExpireInDays: 31
-              DefaultSharingLinkType: AnonymousAccess
               SharingCapability: ExternalUserAndGuestSharing
         Postconditions: []
         ExpectedResult: false
@@ -215,7 +214,6 @@ TestPlan:
           - Command: Set-PnPTenant
             Splat:
               RequireAnonymousLinksExpireInDays: 7
-              DefaultSharingLinkType: AnonymousAccess
               SharingCapability: ExternalUserAndGuestSharing
         Postconditions: []
         ExpectedResult: true
@@ -224,7 +222,6 @@ TestPlan:
           - Command: Set-PnPTenant
             Splat:
               RequireAnonymousLinksExpireInDays: 30
-              DefaultSharingLinkType: AnonymousAccess
               SharingCapability: ExternalUserAndGuestSharing
         Postconditions: []
         ExpectedResult: true
@@ -233,7 +230,6 @@ TestPlan:
           - Command: Set-PnPTenant
             Splat:
               RequireAnonymousLinksExpireInDays: 30
-              DefaultSharingLinkType: AnonymousAccess
               SharingCapability: ExternalUserSharingOnly
         Postconditions: []
         IsNotChecked: true
@@ -243,7 +239,6 @@ TestPlan:
           - Command: Set-PnPTenant
             Splat:
               RequireAnonymousLinksExpireInDays: 30
-              DefaultSharingLinkType: AnonymousAccess
               SharingCapability: ExistingExternalUserSharingOnly
         Postconditions: []
         IsNotChecked: true
@@ -253,7 +248,6 @@ TestPlan:
           - Command: Set-PnPTenant
             Splat:
               RequireAnonymousLinksExpireInDays: 30
-              DefaultSharingLinkType: AnonymousAccess
               SharingCapability: Disabled
         Postconditions: []
         IsNotChecked: true
@@ -263,7 +257,6 @@ TestPlan:
           - Command: Set-PnPTenant
             Splat:
               RequireAnonymousLinksExpireInDays: 30
-              DefaultSharingLinkType: AnonymousAccess
               SharingCapability: ExternalUserSharingOnly
         Postconditions: []
         IsNotChecked: true
@@ -273,7 +266,6 @@ TestPlan:
           - Command: Set-PnPTenant
             Splat:
               RequireAnonymousLinksExpireInDays: 30
-              DefaultSharingLinkType: AnonymousAccess
               SharingCapability: ExistingExternalUserSharingOnly
         Postconditions: []
         IsNotChecked: true
@@ -283,7 +275,6 @@ TestPlan:
           - Command: Set-PnPTenant
             Splat:
               RequireAnonymousLinksExpireInDays: 30
-              DefaultSharingLinkType: AnonymousAccess
               SharingCapability: Disabled
         Postconditions: []
         IsNotChecked: true

--- a/Testing/Functional/Products/TestPlans/sharepoint.spo.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/sharepoint.spo.testplan.yaml
@@ -190,7 +190,7 @@ TestPlan:
   - PolicyId: MS.SHAREPOINT.3.1v1
     TestDriver: RunScuba
     Tests:
-      - TestDescription: MS.SHAREPOINT.3.1v1 Non-compliant - SharingCapability = ExternalUserAndGuestSharing; RequireAnonymousLinksExpireInDays > 30
+      - TestDescription: MS.SHAREPOINT.3.1v1 Non-compliant - SharingCapability = ExternalUserAndGuestSharing (Anyone); RequireAnonymousLinksExpireInDays > 30
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
@@ -199,7 +199,7 @@ TestPlan:
               SharingCapability: ExternalUserAndGuestSharing
         Postconditions: []
         ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.3.1v1 Compliant - SharingCapability = ExternalUserAndGuestSharing; RequireAnonymousLinksExpireInDays < 30
+      - TestDescription: MS.SHAREPOINT.3.1v1 Compliant - SharingCapability = ExternalUserAndGuestSharing (Anyone); RequireAnonymousLinksExpireInDays < 30
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
@@ -208,7 +208,7 @@ TestPlan:
               SharingCapability: ExternalUserAndGuestSharing
         Postconditions: []
         ExpectedResult: true
-      - TestDescription: MS.SHAREPOINT.3.1v1 Compliant - SharingCapability = ExternalUserAndGuestSharing; RequireAnonymousLinksExpireInDays = 30
+      - TestDescription: MS.SHAREPOINT.3.1v1 Compliant - SharingCapability = ExternalUserAndGuestSharing (Anyone); RequireAnonymousLinksExpireInDays = 30
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
@@ -217,28 +217,37 @@ TestPlan:
               SharingCapability: ExternalUserAndGuestSharing
         Postconditions: []
         ExpectedResult: true
-      - TestDescription: MS.SHAREPOINT.3.1v1 Compliant - SharingCapability = ExternalUserSharingOnly; RequireAnonymousLinksExpireInDays = 30
-        ToDo: Check if support anonymous access
+
+      - TestDescription: MS.SHAREPOINT.3.1v1 Non-Compliant - SharingCapability = ExternalUserSharingOnly (New and existing guests); RequireAnonymousLinksExpireInDays = 30
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
+              RequireAnonymousLinksExpireInDays: 30
+              DefaultSharingLinkType: AnonymousAccess
               SharingCapability: ExternalUserSharingOnly
         Postconditions: []
-        ExpectedResult: true
-      - TestDescription: MS.SHAREPOINT.3.1v1 Compliant - SharingCapability = ExistingExternalUserSharingOnly
+        IsNotChecked: true
+        ExpectedResult: false
+      - TestDescription: MS.SHAREPOINT.3.1v1 Non-Compliant - SharingCapability = ExistingExternalUserSharingOnly (Existing guests); RequireAnonymousLinksExpireInDays = 30
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
+              RequireAnonymousLinksExpireInDays: 30
+              DefaultSharingLinkType: AnonymousAccess
               SharingCapability: ExistingExternalUserSharingOnly
         Postconditions: []
-        ExpectedResult: true
-      - TestDescription: MS.SHAREPOINT.3.1v1 Compliant - SharingCapability = Disabled
+        IsNotChecked: true
+        ExpectedResult: false
+      - TestDescription: MS.SHAREPOINT.3.1v1 Non-Compliant - SharingCapability = Disabled (Only people in your organization); RequireAnonymousLinksExpireInDays = 30
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
+              RequireAnonymousLinksExpireInDays: 30
+              DefaultSharingLinkType: AnonymousAccess
               SharingCapability: Disabled
         Postconditions: []
-        ExpectedResult: true
+        IsNotChecked: true
+        ExpectedResult: false
 
   - PolicyId: MS.SHAREPOINT.3.2v1
     TestDriver: RunScuba

--- a/Testing/Functional/Products/TestPlans/sharepoint.spo.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/sharepoint.spo.testplan.yaml
@@ -218,7 +218,7 @@ TestPlan:
         Postconditions: []
         ExpectedResult: true
 
-      - TestDescription: MS.SHAREPOINT.3.1v1 Non-Compliant - SharingCapability = ExternalUserSharingOnly (New and existing guests); RequireAnonymousLinksExpireInDays = 30
+      - TestDescription: MS.SHAREPOINT.3.1v1 Non-Applicable - SharingCapability = ExternalUserSharingOnly (New and existing guests); RequireAnonymousLinksExpireInDays = 30
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
@@ -228,7 +228,7 @@ TestPlan:
         Postconditions: []
         IsNotChecked: true
         ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.3.1v1 Non-Compliant - SharingCapability = ExistingExternalUserSharingOnly (Existing guests); RequireAnonymousLinksExpireInDays = 30
+      - TestDescription: MS.SHAREPOINT.3.1v1 Non-Applicable - SharingCapability = ExistingExternalUserSharingOnly (Existing guests); RequireAnonymousLinksExpireInDays = 30
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
@@ -238,7 +238,7 @@ TestPlan:
         Postconditions: []
         IsNotChecked: true
         ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.3.1v1 Non-Compliant - SharingCapability = Disabled (Only people in your organization); RequireAnonymousLinksExpireInDays = 30
+      - TestDescription: MS.SHAREPOINT.3.1v1 Non-Applicable - SharingCapability = Disabled (Only people in your organization); RequireAnonymousLinksExpireInDays = 30
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
@@ -252,6 +252,16 @@ TestPlan:
   - PolicyId: MS.SHAREPOINT.3.2v1
     TestDriver: RunScuba
     Tests:
+      - TestDescription: MS.SHAREPOINT.3.2v1 Compliant FileAnonymousLinkType = View; FolderAnonymousLinkType = View
+        Preconditions: 
+          - Command: Set-SPOTenant
+            Splat: 
+              SharingCapability: ExternalUserAndGuestSharing
+              FileAnonymousLinkType: View
+              FolderAnonymousLinkType: View
+              DefaultSharingLinkType: AnonymousAccess
+        Postconditions: []
+        ExpectedResult: true
       - TestDescription: MS.SHAREPOINT.3.2v1 Non-compliant FileAnonymousLinkType = Edit; FolderAnonymousLinkType = Edit
         Preconditions:
           - Command: Set-SPOTenant
@@ -275,24 +285,15 @@ TestPlan:
           - Command: Set-SPOTenant
             Splat:
               SharingCapability: ExternalUserAndGuestSharing
-              FileAnonymousLinkType: Edit
-              FolderAnonymousLinkType: View
+              FileAnonymousLinkType: View
+              FolderAnonymousLinkType: Edit
         Postconditions: []
         ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.3.2v1 Non-compliant FileAnonymousLinkType = View; FolderAnonymousLinkType = View
-        Preconditions:
-          - Command: Set-SPOTenant
-            Splat:
-              SharingCapability: ExternalUserAndGuestSharing
-              FileAnonymousLinkType: View
-              FolderAnonymousLinkType: View
-        Postconditions: []
-        ExpectedResult: true
 
   - PolicyId: MS.SHAREPOINT.3.3v1
     TestDriver: RunScuba
     Tests:
-      - TestDescription: MS.SHAREPOINT.3.3v1 Non-compliant - SharingCapability = ExistingExternalUserSharingOnly; EmailAttestationRequired = false; EmailAttestationReAuthDays = 30
+      - TestDescription: MS.SHAREPOINT.3.3v1 Non-Applicable - SharingCapability = ExistingExternalUserSharingOnly (Existing guests); EmailAttestationRequired = false; EmailAttestationReAuthDays = 30
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
@@ -300,8 +301,9 @@ TestPlan:
               EmailAttestationRequired: false
               EmailAttestationReAuthDays: 30
         Postconditions: []
+        IsNotChecked: true
         ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.3.3v1 Non-compliant - SharingCapability = ExternalUserSharingOnly; EmailAttestationRequired = false; EmailAttestationReAuthDays = 30
+      - TestDescription: MS.SHAREPOINT.3.3v1 Non-compliant - SharingCapability = ExternalUserSharingOnly (New and existing guests); EmailAttestationRequired = false; EmailAttestationReAuthDays = 30
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
@@ -310,7 +312,7 @@ TestPlan:
               EmailAttestationReAuthDays: 30
         Postconditions: []
         ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.3.3v1 Non-compliant - SharingCapability = ExternalUserAndGuestSharing; EmailAttestationRequired = false; EmailAttestationReAuthDays = 30
+      - TestDescription: MS.SHAREPOINT.3.3v1 Non-compliant - SharingCapability = ExternalUserAndGuestSharing (Anyone); EmailAttestationRequired = false; EmailAttestationReAuthDays = 30
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
@@ -319,7 +321,7 @@ TestPlan:
               EmailAttestationReAuthDays: 30
         Postconditions: []
         ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.3.3v1 Non-compliant - SharingCapability = ExistingExternalUserSharingOnly; EmailAttestationRequired = true; EmailAttestationReAuthDays > 30
+      - TestDescription: MS.SHAREPOINT.3.3v1 Non-Applicable - SharingCapability = ExistingExternalUserSharingOnly (Existing guests); EmailAttestationRequired = true; EmailAttestationReAuthDays > 30
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
@@ -327,8 +329,9 @@ TestPlan:
               EmailAttestationRequired: true
               EmailAttestationReAuthDays: 31
         Postconditions: []
+        IsNotChecked: true
         ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.3.3v1 Non-compliant - SharingCapability = ExternalUserSharingOnly; EmailAttestationRequired = true; EmailAttestationReAuthDays > 30
+      - TestDescription: MS.SHAREPOINT.3.3v1 Non-compliant - SharingCapability = ExternalUserSharingOnly (New and existing guests); EmailAttestationRequired = true; EmailAttestationReAuthDays > 30
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
@@ -337,7 +340,7 @@ TestPlan:
               EmailAttestationReAuthDays: 31
         Postconditions: []
         ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.3.3v1 Non-compliant - SharingCapability = ExternalUserAndGuestSharing; EmailAttestationRequired = true; EmailAttestationReAuthDays > 30
+      - TestDescription: MS.SHAREPOINT.3.3v1 Non-compliant - SharingCapability = ExternalUserAndGuestSharing (Anyone); EmailAttestationRequired = true; EmailAttestationReAuthDays > 30
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
@@ -346,7 +349,7 @@ TestPlan:
               EmailAttestationReAuthDays: 31
         Postconditions: []
         ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.3.3v1 Compliant - SharingCapability = ExistingExternalUserSharingOnly; EmailAttestationRequired = true; EmailAttestationReAuthDays = 30
+      - TestDescription: MS.SHAREPOINT.3.3v1 Non-Applicable - SharingCapability = ExistingExternalUserSharingOnly (Existing guests); EmailAttestationRequired = true; EmailAttestationReAuthDays = 30
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
@@ -354,8 +357,9 @@ TestPlan:
               EmailAttestationRequired: true
               EmailAttestationReAuthDays: 30
         Postconditions: []
-        ExpectedResult: true
-      - TestDescription: MS.SHAREPOINT.3.3v1 Compliant - SharingCapability = ExternalUserSharingOnly; EmailAttestationRequired = true; EmailAttestationReAuthDays = 30
+        IsNotChecked: true
+        ExpectedResult: false
+      - TestDescription: MS.SHAREPOINT.3.3v1 Compliant - SharingCapability = ExternalUserSharingOnly (New and existing guests); EmailAttestationRequired = true; EmailAttestationReAuthDays = 30
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
@@ -364,7 +368,7 @@ TestPlan:
               EmailAttestationReAuthDays: 30
         Postconditions: []
         ExpectedResult: true
-      - TestDescription: MS.SHAREPOINT.3.3v1 Compliant - SharingCapability = ExternalUserAndGuestSharing; EmailAttestationRequired = true; EmailAttestationReAuthDays = 30
+      - TestDescription: MS.SHAREPOINT.3.3v1 Compliant - SharingCapability = ExternalUserAndGuestSharing (Anyone); EmailAttestationRequired = true; EmailAttestationReAuthDays = 30
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
@@ -373,13 +377,16 @@ TestPlan:
               EmailAttestationReAuthDays: 30
         Postconditions: []
         ExpectedResult: true
-      - TestDescription: MS.SHAREPOINT.3.3v1 Compliant - SharingCapability = Disabled
+      - TestDescription: MS.SHAREPOINT.3.3v1 Non-Applicable - SharingCapability = Disabled (Only people in organization)
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
               SharingCapability: Disabled
+              EmailAttestationRequired: true
+              EmailAttestationReAuthDays: 29
         Postconditions: []
-        ExpectedResult: true
+        IsNotChecked: true
+        ExpectedResult: false
 
   - PolicyId: MS.SHAREPOINT.4.1v1
     TestDriver: RunScuba

--- a/Testing/Functional/Products/TestPlans/sharepoint.spo.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/sharepoint.spo.testplan.yaml
@@ -233,7 +233,6 @@ TestPlan:
           - Command: Set-SPOTenant
             Splat:
               RequireAnonymousLinksExpireInDays: 31
-              DefaultSharingLinkType: AnonymousAccess
               SharingCapability: ExternalUserAndGuestSharing
         Postconditions: []
         ExpectedResult: false
@@ -242,7 +241,6 @@ TestPlan:
           - Command: Set-SPOTenant
             Splat:
               RequireAnonymousLinksExpireInDays: 7
-              DefaultSharingLinkType: AnonymousAccess
               SharingCapability: ExternalUserAndGuestSharing
         Postconditions: []
         ExpectedResult: true
@@ -251,7 +249,6 @@ TestPlan:
           - Command: Set-SPOTenant
             Splat:
               RequireAnonymousLinksExpireInDays: 30
-              DefaultSharingLinkType: AnonymousAccess
               SharingCapability: ExternalUserAndGuestSharing
         Postconditions: []
         ExpectedResult: true
@@ -260,7 +257,6 @@ TestPlan:
           - Command: Set-SPOTenant
             Splat:
               RequireAnonymousLinksExpireInDays: 30
-              DefaultSharingLinkType: AnonymousAccess
               SharingCapability: ExternalUserSharingOnly
         Postconditions: []
         IsNotChecked: true
@@ -270,7 +266,6 @@ TestPlan:
           - Command: Set-SPOTenant
             Splat:
               RequireAnonymousLinksExpireInDays: 30
-              DefaultSharingLinkType: AnonymousAccess
               SharingCapability: ExistingExternalUserSharingOnly
         Postconditions: []
         IsNotChecked: true
@@ -280,7 +275,6 @@ TestPlan:
           - Command: Set-SPOTenant
             Splat:
               RequireAnonymousLinksExpireInDays: 30
-              DefaultSharingLinkType: AnonymousAccess
               SharingCapability: Disabled
         Postconditions: []
         IsNotChecked: true

--- a/Testing/Functional/Products/TestPlans/sharepoint.spo.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/sharepoint.spo.testplan.yaml
@@ -210,14 +210,14 @@ TestPlan:
   - PolicyId: MS.SHAREPOINT.2.2v1
     TestDriver: RunScuba
     Tests:
-      - TestDescription: MS.SHAREPOINT.2.2v1 Non-compliant - DefaultSharingLinkType = Edit
+      - TestDescription: MS.SHAREPOINT.2.2v1 Non-compliant - DefaultLinkPermission = Edit
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
               DefaultLinkPermission: Edit
         Postconditions: []
         ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.2.2v1 Compliant - DefaultSharingLinkType = View
+      - TestDescription: MS.SHAREPOINT.2.2v1 Compliant - DefaultLinkPermission = View
         Preconditions:
           - Command: Set-SPOTenant
             Splat:

--- a/Testing/Functional/Products/TestPlans/sharepoint.spo.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/sharepoint.spo.testplan.yaml
@@ -253,9 +253,9 @@ TestPlan:
     TestDriver: RunScuba
     Tests:
       - TestDescription: MS.SHAREPOINT.3.2v1 Compliant FileAnonymousLinkType = View; FolderAnonymousLinkType = View
-        Preconditions: 
+        Preconditions:
           - Command: Set-SPOTenant
-            Splat: 
+            Splat:
               SharingCapability: ExternalUserAndGuestSharing
               FileAnonymousLinkType: View
               FolderAnonymousLinkType: View

--- a/Testing/Functional/Products/TestPlans/sharepoint.spo.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/sharepoint.spo.testplan.yaml
@@ -72,7 +72,7 @@ TestPlan:
   - PolicyId: MS.SHAREPOINT.1.3v1
     TestDriver: RunScuba
     Tests:
-      - TestDescription: MS.SHAREPOINT.1.3v1 Non-compliant - SharingCapability Not Disabled SharingDomainRestrictionMode = BlockList
+      - TestDescription: MS.SHAREPOINT.1.3v1 Non-compliant - SharingCapability = ExternalUserSharingOnly (New and existing guests) SharingDomainRestrictionMode = BlockList
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
@@ -81,7 +81,7 @@ TestPlan:
               SharingBlockedDomainList: nefarious.com evil.is.us
         Postconditions: []
         ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.1.3v1 Compliant -  SharingCapability Not Disabled SharingDomainRestrictionMode = AllowList
+      - TestDescription: MS.SHAREPOINT.1.3v1 Compliant -  SharingCapability = ExternalUserSharingOnly (New and existing guests) SharingDomainRestrictionMode = AllowList
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
@@ -90,14 +90,34 @@ TestPlan:
               SharingAllowedDomainList: good.org admirable.us
         Postconditions: []
         ExpectedResult: true
-      - TestDescription: MS.SHAREPOINT.1.3v1 Compliant - SharingCapability = Disabled
+      - TestDescription: MS.SHAREPOINT.1.3v1 Compliant -  SharingCapability = ExternalUserAndGuestSharing (Anyone) SharingDomainRestrictionMode = AllowList
+        Preconditions:
+          - Command: Set-SPOTenant
+            Splat:
+              SharingCapability: ExternalUserAndGuestSharing
+              SharingDomainRestrictionMode: AllowList
+              SharingAllowedDomainList: good.org admirable.us
+        Postconditions: []
+        ExpectedResult: true
+      - TestDescription: MS.SHAREPOINT.1.3v1 Non-Applicable - SharingCapability = Disabled (Only people in organization)
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
               SharingCapability: Disabled
               SharingDomainRestrictionMode: None
         Postconditions: []
-        ExpectedResult: true
+        IsNotChecked: true
+        ExpectedResult: false
+      - TestDescription: MS.SHAREPOINT.1.3v1 Non-Applicable - SharingCapability = Disabled (Only people in organization) SharingDomainRestrictionMode = AllowList
+        Preconditions:
+          - Command: Set-SPOTenant
+            Splat:
+              SharingCapability: Disabled
+              SharingDomainRestrictionMode: AllowList
+              SharingAllowedDomainList: good.org admirable.us
+        Postconditions: []
+        IsNotChecked: true
+        ExpectedResult: false
 
   - PolicyId: MS.SHAREPOINT.1.4v1
     TestDriver: RunScuba

--- a/Testing/Functional/Products/TestPlans/sharepoint.spo.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/sharepoint.spo.testplan.yaml
@@ -259,7 +259,6 @@ TestPlan:
               SharingCapability: ExternalUserAndGuestSharing
               FileAnonymousLinkType: View
               FolderAnonymousLinkType: View
-              DefaultSharingLinkType: AnonymousAccess
         Postconditions: []
         ExpectedResult: true
       - TestDescription: MS.SHAREPOINT.3.2v1 Non-compliant FileAnonymousLinkType = Edit; FolderAnonymousLinkType = Edit

--- a/Testing/Functional/Products/TestPlans/sharepoint.spo.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/sharepoint.spo.testplan.yaml
@@ -36,7 +36,7 @@ TestPlan:
   - PolicyId: MS.SHAREPOINT.1.2v1
     TestDriver: RunScuba
     Tests:
-      - TestDescription: MS.SHAREPOINT.1.2v1 Non-compliant - SharingCapability = ExternalUserSharingOnly (1)
+      - TestDescription: MS.SHAREPOINT.1.2v1 Non-compliant - SharingCapability = ExternalUserSharingOnly (New and existing guests)
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
@@ -60,7 +60,7 @@ TestPlan:
           - Command: 'Set-SPOSite -Identity $(Get-SpoSite -Filter "Url -like ''-my.sharepoint.''") -SharingCapability Disabled'
         Postconditions: []
         ExpectedResult: true
-      - TestDescription: MS.SHAREPOINT.1.2v1 SharingCapability = ExistingExternalUserSharingOnly (3)
+      - TestDescription: MS.SHAREPOINT.1.2v1 SharingCapability = ExistingExternalUserSharingOnly (New and existing guests)
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
@@ -72,7 +72,7 @@ TestPlan:
   - PolicyId: MS.SHAREPOINT.1.3v1
     TestDriver: RunScuba
     Tests:
-      - TestDescription: MS.SHAREPOINT.1.3v1 Non-compliant - SharingCapability = ExternalUserSharingOnly (New and existing guests) SharingDomainRestrictionMode = BlockList
+      - TestDescription: MS.SHAREPOINT.1.3v1 Non-compliant - SharingCapability = ExternalUserSharingOnly (New and existing guests); SharingDomainRestrictionMode = BlockList
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
@@ -81,7 +81,7 @@ TestPlan:
               SharingBlockedDomainList: nefarious.com evil.is.us
         Postconditions: []
         ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.1.3v1 Compliant -  SharingCapability = ExternalUserSharingOnly (New and existing guests) SharingDomainRestrictionMode = AllowList
+      - TestDescription: MS.SHAREPOINT.1.3v1 Compliant -  SharingCapability = ExternalUserSharingOnly (New and existing guests); SharingDomainRestrictionMode = AllowList
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
@@ -90,7 +90,7 @@ TestPlan:
               SharingAllowedDomainList: good.org admirable.us
         Postconditions: []
         ExpectedResult: true
-      - TestDescription: MS.SHAREPOINT.1.3v1 Compliant -  SharingCapability = ExternalUserAndGuestSharing (Anyone) SharingDomainRestrictionMode = AllowList
+      - TestDescription: MS.SHAREPOINT.1.3v1 Compliant -  SharingCapability = ExternalUserAndGuestSharing (Anyone); SharingDomainRestrictionMode = AllowList
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
@@ -99,7 +99,7 @@ TestPlan:
               SharingAllowedDomainList: good.org admirable.us
         Postconditions: []
         ExpectedResult: true
-      - TestDescription: MS.SHAREPOINT.1.3v1 Non-Applicable - SharingCapability = Disabled (Only people in organization)
+      - TestDescription: MS.SHAREPOINT.1.3v1 Non-Applicable - SharingCapability = Disabled (Only people in organization);
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
@@ -108,7 +108,7 @@ TestPlan:
         Postconditions: []
         IsNotChecked: true
         ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.1.3v1 Non-Applicable - SharingCapability = Disabled (Only people in organization) SharingDomainRestrictionMode = AllowList
+      - TestDescription: MS.SHAREPOINT.1.3v1 Non-Applicable - SharingCapability = Disabled (Only people in organization); SharingDomainRestrictionMode = AllowList
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
@@ -122,7 +122,7 @@ TestPlan:
   - PolicyId: MS.SHAREPOINT.1.4v1
     TestDriver: RunScuba
     Tests:
-      - TestDescription: MS.SHAREPOINT.1.4v1 Non-compliant - SharingCapability Not Disabled RequireAcceptingAccountMatchInvitedAccount = false
+      - TestDescription: MS.SHAREPOINT.1.4v1 Non-compliant - SharingCapability = ExternalUserSharingOnly (New and existing guests); RequireAcceptingAccountMatchInvitedAccount = false
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
@@ -130,23 +130,23 @@ TestPlan:
               RequireAcceptingAccountMatchInvitedAccount: false
         Postconditions: []
         ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.1.4v1 Compliant - SharingCapability Disabled RequireAcceptingAccountMatchInvitedAccount = false
+      - TestDescription: MS.SHAREPOINT.1.4v1 Compliant - SharingCapability = ExternalUserAndGuestSharing (Anyone); RequireAcceptingAccountMatchInvitedAccount = true
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
-              SharingCapability: Disabled
-              RequireAcceptingAccountMatchInvitedAccount: false
-        Postconditions: []
-        ExpectedResult: true
-      - TestDescription: MS.SHAREPOINT.1.4v1 Compliant - SharingCapability Disabled RequireAcceptingAccountMatchInvitedAccount = true
-        Preconditions:
-          - Command: Set-SPOTenant
-            Splat:
-              SharingCapability: Disabled
+              SharingCapability: ExternalUserAndGuestSharing
               RequireAcceptingAccountMatchInvitedAccount: true
         Postconditions: []
         ExpectedResult: true
-      - TestDescription: MS.SHAREPOINT.1.4v1 Compliant - SharingCapability Not Disabled RequireAcceptingAccountMatchInvitedAccount = true
+      - TestDescription: MS.SHAREPOINT.1.4v1 Compliant - SharingCapability = ExistingExternalUserSharingOnly (Existing guests); RequireAcceptingAccountMatchInvitedAccount = true
+        Preconditions:
+          - Command: Set-SPOTenant
+            Splat:
+              SharingCapability: ExistingExternalUserSharingOnly
+              RequireAcceptingAccountMatchInvitedAccount: true
+        Postconditions: []
+        ExpectedResult: true
+      - TestDescription: MS.SHAREPOINT.1.4v1 Compliant - SharingCapability = ExternalUserSharingOnly (New and existing guests); RequireAcceptingAccountMatchInvitedAccount = true
         Preconditions:
           - Command: Set-SPOTenant
             Splat:
@@ -154,6 +154,24 @@ TestPlan:
               RequireAcceptingAccountMatchInvitedAccount: true
         Postconditions: []
         ExpectedResult: true
+      - TestDescription: MS.SHAREPOINT.1.4v1 Non-Applicable - SharingCapability = Disabled (Only people in organization); RequireAcceptingAccountMatchInvitedAccount = true
+        Preconditions:
+          - Command: Set-SPOTenant
+            Splat:
+              SharingCapability: Disabled
+              RequireAcceptingAccountMatchInvitedAccount: true
+        Postconditions: []
+        IsNotChecked: true
+        ExpectedResult: false
+      - TestDescription: MS.SHAREPOINT.1.4v1 Non-Applicable - SharingCapability = Disabled (Only people in organization); RequireAcceptingAccountMatchInvitedAccount = false
+        Preconditions:
+          - Command: Set-SPOTenant
+            Splat:
+              SharingCapability: Disabled
+              RequireAcceptingAccountMatchInvitedAccount: false
+        Postconditions: []
+        IsNotChecked: true
+        ExpectedResult: false
 
   - PolicyId: MS.SHAREPOINT.2.1v1
     TestDriver: RunScuba
@@ -237,7 +255,6 @@ TestPlan:
               SharingCapability: ExternalUserAndGuestSharing
         Postconditions: []
         ExpectedResult: true
-
       - TestDescription: MS.SHAREPOINT.3.1v1 Non-Applicable - SharingCapability = ExternalUserSharingOnly (New and existing guests); RequireAnonymousLinksExpireInDays = 30
         Preconditions:
           - Command: Set-SPOTenant
@@ -307,6 +324,36 @@ TestPlan:
               FileAnonymousLinkType: View
               FolderAnonymousLinkType: Edit
         Postconditions: []
+        ExpectedResult: false
+      - TestDescription: MS.SHAREPOINT.3.2v1 Non-Applicable - SharingCapability = Disabled (Only people in your organization); FileAnonymousLinkType = View; FolderAnonymousLinkType = View
+        Preconditions:
+          - Command: Set-SPOTenant
+            Splat:
+              SharingCapability: Disabled
+              FileAnonymousLinkType: View
+              FolderAnonymousLinkType: View
+        Postconditions: []
+        IsNotChecked: true
+        ExpectedResult: false
+      - TestDescription: MS.SHAREPOINT.3.2v1 Non-Applicable - SharingCapability = ExistingExternalUserSharingOnly (Existing guests); FileAnonymousLinkType = View; FolderAnonymousLinkType = View
+        Preconditions:
+          - Command: Set-SPOTenant
+            Splat:
+              SharingCapability: ExistingExternalUserSharingOnly
+              FileAnonymousLinkType: View
+              FolderAnonymousLinkType: View
+        Postconditions: []
+        IsNotChecked: true
+        ExpectedResult: false
+      - TestDescription: MS.SHAREPOINT.3.2v1 Non-Applicable - SharingCapability = ExternalUserSharingOnly (New and existing guests); FileAnonymousLinkType = View; FolderAnonymousLinkType = View
+        Preconditions:
+          - Command: Set-SPOTenant
+            Splat:
+              SharingCapability: ExternalUserSharingOnly
+              FileAnonymousLinkType: View
+              FolderAnonymousLinkType: View
+        Postconditions: []
+        IsNotChecked: true
         ExpectedResult: false
 
   - PolicyId: MS.SHAREPOINT.3.3v1


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

Several of the Sharepoint policies execute even in cases when they are not applicable. The policies for Sharepoint 1.3, 3,1, 3.2, and 3.3 have been updated to produce N/A messages when warranted. If the configuration settings apply, then the policy executes normally. 

**Policy 1.3**
- Executes normally when the external sharing slider is set to any value other than Only people in your organization.
- Produces N/A message when set to Only People in your organization. 
- Unit tests updated.
- Functional tests updated.

**Policy 1.4**
- Executes normally when the external sharing slider is set to any value other than Only people in your organization.
- Produces N/A message when set to Only People in your organization. 
- Unit tests updated.
- Functional tests updated.

**Policy 3.1**
- Executes normally when the external sharing slider is set to Anyone. 
- Produces N/A message when set to Only people in your organization, Existing guests, or New and existing guests.
- Unit tests updated.
- Functional tests updated.

**Policy 3.2**
- Executes normally when the external sharing slider is set to Anyone. 
- Checks that both file and folder link types equal 1 (View)
- Produces N/A message when set to Only people in your organization, Existing guests, or New and existing guests.
- Unit tests updated.
- Functional tests not complete, they currently fail because `input.OneDrive_PnP_Flag` == false is checked in the configuration code which can't be pulled from Set-SPOTenant cmdlet.

**Policy 3.3**
- Executes normally when the external sharing slider is set to Anyone or New and existing guests.
- Produces N/A message when set to Only people in your organization or Existing guests.
- Unit tests updated.
- Functional tests updated.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

Epic: https://github.com/cisagov/ScubaGear/issues/1064

closes https://github.com/cisagov/ScubaGear/issues/1062
closes https://github.com/cisagov/ScubaGear/issues/952
closes https://github.com/cisagov/ScubaGear/issues/951
closes https://github.com/cisagov/ScubaGear/issues/950
closes #892 

Output in the reports was not accurately depicting tenant configuration settings. 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Check that unit tests pass: 
```
.\RunUnitTests.ps1 -p sharepoint
```

Check that functional tests pass for each policy ID:
- MS.SHAREPOINT.1.3v1
- MS.SHAREPOINT.3.1v1
- MS.SHAREPOINT.3.2v1
- MS.SHAREPOINT.3.3v1

```
$TestContainers = @() 
$TestContainers += New-PesterContainer -Path "Testing/Functional/Products" `
-Data @{ 
    Thumbprint = "<your-thumbprint>"; 
    TenantDomain = "<tenant-domain>"; 
    TenantDisplayName = "<display-name>"; 
    AppId = "<app-id>"; 
    ProductName = "sharepoint"; 
    M365Environment = "gcc";
    Variant = "<spo/pnp>"
} 
$PesterConfig = @{
        Run = @{Container = $TestContainers}
        Filter = @{Tag = @("<Policy ID>")}
        Output = @{Verbosity = 'Detailed'}
    }

$Config = New-PesterConfiguration -Hashtable $PesterConfig 
Invoke-Pester -Configuration $Config
```


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] PR passed smoke test check.
- [ ] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [ ] Resolved all merge conflicts on branch
- [ ] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.