### PR TITLE
Add a backup path to look for the OPA executable in the current directory

### DIFF
--- a/PowerShell/ScubaGear/Modules/RunRego/RunRego.psm1
+++ b/PowerShell/ScubaGear/Modules/RunRego/RunRego.psm1
@@ -41,7 +41,7 @@ function Invoke-Rego {
 
         # See if the OPA executable is in the current executing directory
         if (-not (Test-Path $Cmd)) {
-            throw "Open Policy Agent executable was not found. Please see the README for instructions on how to retry downloading the executable and the directory it should be placed."
+            throw "Open Policy Agent executable was not found. Please see the README for instructions on how to retry downloading the executable and which directory it should be placed."
         }
 
         # Load Utils

--- a/PowerShell/ScubaGear/Modules/RunRego/RunRego.psm1
+++ b/PowerShell/ScubaGear/Modules/RunRego/RunRego.psm1
@@ -35,7 +35,7 @@ function Invoke-Rego {
         $Cmd = Join-Path -Path $OPAPath -ChildPath $OPAFileName  -ErrorAction 'Stop'
 
         # Set backup execution path to be current directory if ScubaTools path fails
-        if (-not (Test-Path $Cmd)) {
+        if (-not (Test-Path $Cmd -PathType Leaf)) {
             $Cmd = Join-Path -Path (Get-Location | Select-Object -ExpandProperty Path) -ChildPath $OPAFileName -ErrorAction 'Stop'
         }
 

--- a/PowerShell/ScubaGear/Modules/RunRego/RunRego.psm1
+++ b/PowerShell/ScubaGear/Modules/RunRego/RunRego.psm1
@@ -30,13 +30,18 @@ function Invoke-Rego {
         $OPAPath = $PSScriptRoot
     )
     try {
-        # PowerShell 5.1 compatible Windows OS check
-        if ("Windows_NT" -eq $Env:OS) {
-            $Cmd = Join-Path -Path $OPAPath -ChildPath "opa_windows_amd64.exe" -ErrorAction 'Stop'
+        # For MacOS/Linux give OPA exeucte permissions: chmod 755 ./opa
+        $OPAFileName = if ("Windows_NT" -eq $Env:OS) {"opa_windows_amd64.exe"} else {"opa"}
+        $Cmd = Join-Path -Path $OPAPath -ChildPath $OPAFileName  -ErrorAction 'Stop'
+
+        # Set backup execution path to be current directory if ScubaTools path fails
+        if (-not (Test-Path $Cmd)) {
+            $Cmd = Join-Path -Path (Get-Location | Select-Object -ExpandProperty Path) -ChildPath $OPAFileName -ErrorAction 'Stop'
         }
-        else {
-            # Permissions: chmod 755 ./opa
-            $Cmd = Join-Path -Path $OPAPath -ChildPath "opa" -ErrorAction 'Stop'
+
+        # See if the OPA executable is in the current executing directory
+        if (-not (Test-Path $Cmd)) {
+            throw "Open Policy Agent executable not found. Please see the README for instructions on how to retry downloading the exectuable."
         }
 
         # Load Utils

--- a/PowerShell/ScubaGear/Modules/RunRego/RunRego.psm1
+++ b/PowerShell/ScubaGear/Modules/RunRego/RunRego.psm1
@@ -41,7 +41,7 @@ function Invoke-Rego {
 
         # See if the OPA executable is in the current executing directory
         if (-not (Test-Path $Cmd)) {
-            throw "Open Policy Agent executable not found. Please see the README for instructions on how to retry downloading the exectuable."
+            throw "Open Policy Agent executable was not found. Please see the README for instructions on how to retry downloading the executable and the directory it should be placed."
         }
 
         # Load Utils

--- a/PowerShell/ScubaGear/Modules/RunRego/RunRego.psm1
+++ b/PowerShell/ScubaGear/Modules/RunRego/RunRego.psm1
@@ -30,7 +30,7 @@ function Invoke-Rego {
         $OPAPath = $PSScriptRoot
     )
     try {
-        # For MacOS/Linux give OPA exeucte permissions: chmod 755 ./opa
+        # For MacOS/Linux give OPA execute permissions: chmod 755 ./opa
         $OPAFileName = if ("Windows_NT" -eq $Env:OS) {"opa_windows_amd64.exe"} else {"opa"}
         $Cmd = Join-Path -Path $OPAPath -ChildPath $OPAFileName  -ErrorAction 'Stop'
 

--- a/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfig.psm1
+++ b/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfig.psm1
@@ -1,24 +1,27 @@
+# Used to test for the correct OPA executable Path
+$OPAToolsPath = (Join-Path -Path $env:USERPROFILE -ChildPath ".scubagear/Tools")
+$OPAExePath = (Join-Path -Path $OPAToolsPath -ChildPath "opa*")
 class ScubaConfig {
     <#
     .SYNOPSIS
-      This class stores Scuba config data loaded from a file.
+    This class stores Scuba config data loaded from a file.
     .DESCRIPTION
-      This class is designed to function as a singleton. The singleton instance
-      is cached on the ScubaConfig type itself. In the context of tests, it may be
-      important to call `.ResetInstance` before and after tests as needed to
-      ensure any preexisting configs are not inadvertantly used for the test,
-      or left in place after the test is finished. The singleton will persist
-      for the life of the powershell session unless the ScubaConfig module is
-      removed. Note that `.LoadConfig` internally calls `.ResetInstance` to avoid
-      issues.
+    This class is designed to function as a singleton. The singleton instance
+    is cached on the ScubaConfig type itself. In the context of tests, it may be
+    important to call `.ResetInstance` before and after tests as needed to
+    ensure any preexisting configs are not inadvertantly used for the test,
+    or left in place after the test is finished. The singleton will persist
+    for the life of the powershell session unless the ScubaConfig module is
+    removed. Note that `.LoadConfig` internally calls `.ResetInstance` to avoid
+    issues.
     .EXAMPLE
-      $Config = [ScubaConfig]::GetInstance()
-      [ScubaConfig]::LoadConfig($SomePath)
+    $Config = [ScubaConfig]::GetInstance()
+    [ScubaConfig]::LoadConfig($SomePath)
     #>
     hidden static [ScubaConfig]$_Instance = [ScubaConfig]::new()
     hidden static [Boolean]$_IsLoaded = $false
     hidden static [hashtable]$ScubaDefaults = @{
-        DefaultOPAPath = (Join-Path -Path $env:USERPROFILE -ChildPath ".scubagear\Tools")
+        DefaultOPAPath =   if (Test-Path $OPAExePath) {$OPAToolsPath} else {$PWD | Select-Object -ExpandProperty Path};
         DefaultProductNames = @("aad", "defender", "exo", "sharepoint", "teams")
         AllProductNames = @("aad", "defender", "exo", "powerplatform", "sharepoint", "teams")
         DefaultM365Environment = "commercial"
@@ -162,4 +165,5 @@ class ScubaConfig {
     static [ScubaConfig]GetInstance(){
         return [ScubaConfig]::_Instance
     }
+
 }

--- a/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfig.psm1
+++ b/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfig.psm1
@@ -1,19 +1,19 @@
 class ScubaConfig {
     <#
     .SYNOPSIS
-      This class stores Scuba config data loaded from a file.
+    This class stores Scuba config data loaded from a file.
     .DESCRIPTION
-      This class is designed to function as a singleton. The singleton instance
-      is cached on the ScubaConfig type itself. In the context of tests, it may be
-      important to call `.ResetInstance` before and after tests as needed to
-      ensure any preexisting configs are not inadvertantly used for the test,
-      or left in place after the test is finished. The singleton will persist
-      for the life of the powershell session unless the ScubaConfig module is
-      removed. Note that `.LoadConfig` internally calls `.ResetInstance` to avoid
-      issues.
+    This class is designed to function as a singleton. The singleton instance
+    is cached on the ScubaConfig type itself. In the context of tests, it may be
+    important to call `.ResetInstance` before and after tests as needed to
+    ensure any preexisting configs are not inadvertantly used for the test,
+    or left in place after the test is finished. The singleton will persist
+    for the life of the powershell session unless the ScubaConfig module is
+    removed. Note that `.LoadConfig` internally calls `.ResetInstance` to avoid
+    issues.
     .EXAMPLE
-      $Config = [ScubaConfig]::GetInstance()
-      [ScubaConfig]::LoadConfig($SomePath)
+    $Config = [ScubaConfig]::GetInstance()
+    [ScubaConfig]::LoadConfig($SomePath)
     #>
     hidden static [ScubaConfig]$_Instance = [ScubaConfig]::new()
     hidden static [Boolean]$_IsLoaded = $false

--- a/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfig.psm1
+++ b/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfig.psm1
@@ -1,27 +1,24 @@
-# Used to test for the correct OPA executable Path
-$OPAToolsPath = (Join-Path -Path $env:USERPROFILE -ChildPath ".scubagear/Tools")
-$OPAExePath = (Join-Path -Path $OPAToolsPath -ChildPath "opa*")
 class ScubaConfig {
     <#
     .SYNOPSIS
-    This class stores Scuba config data loaded from a file.
+      This class stores Scuba config data loaded from a file.
     .DESCRIPTION
-    This class is designed to function as a singleton. The singleton instance
-    is cached on the ScubaConfig type itself. In the context of tests, it may be
-    important to call `.ResetInstance` before and after tests as needed to
-    ensure any preexisting configs are not inadvertantly used for the test,
-    or left in place after the test is finished. The singleton will persist
-    for the life of the powershell session unless the ScubaConfig module is
-    removed. Note that `.LoadConfig` internally calls `.ResetInstance` to avoid
-    issues.
+      This class is designed to function as a singleton. The singleton instance
+      is cached on the ScubaConfig type itself. In the context of tests, it may be
+      important to call `.ResetInstance` before and after tests as needed to
+      ensure any preexisting configs are not inadvertantly used for the test,
+      or left in place after the test is finished. The singleton will persist
+      for the life of the powershell session unless the ScubaConfig module is
+      removed. Note that `.LoadConfig` internally calls `.ResetInstance` to avoid
+      issues.
     .EXAMPLE
-    $Config = [ScubaConfig]::GetInstance()
-    [ScubaConfig]::LoadConfig($SomePath)
+      $Config = [ScubaConfig]::GetInstance()
+      [ScubaConfig]::LoadConfig($SomePath)
     #>
     hidden static [ScubaConfig]$_Instance = [ScubaConfig]::new()
     hidden static [Boolean]$_IsLoaded = $false
     hidden static [hashtable]$ScubaDefaults = @{
-        DefaultOPAPath = if (Test-Path $OPAExePath) {$OPAToolsPath} else {$PWD | Select-Object -ExpandProperty Path};
+        DefaultOPAPath = (Join-Path -Path $env:USERPROFILE -ChildPath ".scubagear\Tools")
         DefaultProductNames = @("aad", "defender", "exo", "sharepoint", "teams")
         AllProductNames = @("aad", "defender", "exo", "powerplatform", "sharepoint", "teams")
         DefaultM365Environment = "commercial"

--- a/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfig.psm1
+++ b/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfig.psm1
@@ -21,7 +21,7 @@ class ScubaConfig {
     hidden static [ScubaConfig]$_Instance = [ScubaConfig]::new()
     hidden static [Boolean]$_IsLoaded = $false
     hidden static [hashtable]$ScubaDefaults = @{
-        DefaultOPAPath =   if (Test-Path $OPAExePath) {$OPAToolsPath} else {$PWD | Select-Object -ExpandProperty Path};
+        DefaultOPAPath = if (Test-Path $OPAExePath) {$OPAToolsPath} else {$PWD | Select-Object -ExpandProperty Path};
         DefaultProductNames = @("aad", "defender", "exo", "sharepoint", "teams")
         AllProductNames = @("aad", "defender", "exo", "powerplatform", "sharepoint", "teams")
         DefaultM365Environment = "commercial"
@@ -165,5 +165,4 @@ class ScubaConfig {
     static [ScubaConfig]GetInstance(){
         return [ScubaConfig]::_Instance
     }
-
 }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/RunRego/Run-Rego.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/RunRego/Run-Rego.Tests.ps1
@@ -1,7 +1,7 @@
 Import-Module (Join-Path -Path $PSScriptRoot -ChildPath '../../../../Modules/RunRego')
 
 InModuleScope 'RunRego' {
-    Describe -Tag 'RunRego' -Name 'Invoke-Rego' -ForEach @(
+    Describe -Tag 'RunRego' -Name 'Invoke-Rego Success' -ForEach @(
         @{Product = 'aad'; Arg = 'AAD'},
         @{Product = 'defender'; Arg = 'Defender'},
         @{Product = 'exo'; Arg = 'EXO'},
@@ -14,17 +14,35 @@ InModuleScope 'RunRego' {
             [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'RegoParams')]
             $RegoParams = @{
                 'InputFile' = Join-Path -Path $PSScriptRoot -ChildPath "./RunRegoStubs/ProviderSettingsExport.json";
-                'OPAPath'   = Join-Path -Path $env:USERPROFILE -ChildPath ".scubagear/Tools";
             }
         }
         It 'Runs the <Arg> Rego on a Provider JSON and returns a TestResults object' {
             $RegoParams += @{
                 'RegoFile'    = Join-Path -Path $PSScriptRoot -ChildPath "../../../../Rego/$($Arg)Config.rego";
                 'PackageName' = $Product;
+                'OPAPath'   = Join-Path -Path $env:USERPROFILE -ChildPath ".scubagear/Tools";
             }
             Invoke-Rego @RegoParams | Should -Not -Be $null
         }
+        It 'Runs the <Arg> Rego on a Provider JSON and fails due to missing OPA executable' {
+            $RegoParams += @{
+                'RegoFile'    = Join-Path -Path $PSScriptRoot -ChildPath "../../../../Rego/$($Arg)Config.rego";
+                'PackageName' = $Product;
+                'OPAPath'   = './'
+            }
+            Invoke-Rego @RegoParams | Should -Throw
+        }
     }
+    # Describe -Tag 'RunRego' -Name 'Invoke-Rego Fail' -ForEach @(
+    #     @{Product = 'aad'; Arg = 'AAD'},
+    #     @{Product = 'defender'; Arg = 'Defender'},
+    #     @{Product = 'exo'; Arg = 'EXO'},
+    #     @{Product = 'powerplatform'; Arg = 'PowerPlatform'},
+    #     @{Product = 'sharepoint'; Arg = 'SharePoint'},
+    #     @{Product = 'teams'; Arg = 'Teams'}
+    # ){
+
+    # }
 }
 
 AfterAll {

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/RunRego/Run-Rego.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/RunRego/Run-Rego.Tests.ps1
@@ -11,7 +11,6 @@ InModuleScope 'RunRego' {
     ){
         BeforeAll {
             Mock -ModuleName RunRego Invoke-ExternalCmd {return 0}
-            Mock -CommandName Test-Path {$true}
             [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'RegoParams')]
             $RegoParams = @{
                 'InputFile' = Join-Path -Path $PSScriptRoot -ChildPath "./RunRegoStubs/ProviderSettingsExport.json";
@@ -23,27 +22,18 @@ InModuleScope 'RunRego' {
                 'PackageName' = $Product;
                 'OPAPath'   = Join-Path -Path $env:USERPROFILE -ChildPath ".scubagear/Tools";
             }
+            Mock -CommandName Test-Path {$true}
             Invoke-Rego @RegoParams | Should -Not -Be $null
         }
         It 'Runs the <Arg> Rego on a Provider JSON and fails due to missing OPA executable' {
             $RegoParams += @{
                 'RegoFile'    = Join-Path -Path $PSScriptRoot -ChildPath "../../../../Rego/$($Arg)Config.rego";
                 'PackageName' = $Product;
-                'OPAPath'   = './'
+                'OPAPath'   = 'DoesNotExist'
             }
-            Invoke-Rego @RegoParams | Should -Throw
+            {Invoke-Rego @RegoParams} | Should -Throw
         }
     }
-    # Describe -Tag 'RunRego' -Name 'Invoke-Rego Fail' -ForEach @(
-    #     @{Product = 'aad'; Arg = 'AAD'},
-    #     @{Product = 'defender'; Arg = 'Defender'},
-    #     @{Product = 'exo'; Arg = 'EXO'},
-    #     @{Product = 'powerplatform'; Arg = 'PowerPlatform'},
-    #     @{Product = 'sharepoint'; Arg = 'SharePoint'},
-    #     @{Product = 'teams'; Arg = 'Teams'}
-    # ){
-
-    # }
 }
 
 AfterAll {

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/RunRego/Run-Rego.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/RunRego/Run-Rego.Tests.ps1
@@ -11,6 +11,7 @@ InModuleScope 'RunRego' {
     ){
         BeforeAll {
             Mock -ModuleName RunRego Invoke-ExternalCmd {return 0}
+            Mock -CommandName Test-Path {$true}
             [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'RegoParams')]
             $RegoParams = @{
                 'InputFile' = Join-Path -Path $PSScriptRoot -ChildPath "./RunRegoStubs/ProviderSettingsExport.json";

--- a/docs/prerequisites/dependencies.md
+++ b/docs/prerequisites/dependencies.md
@@ -50,6 +50,6 @@ To verify that OPA is working, use the following command to check the version:
 .\opa_windows_amd64.exe version
 ```
 
-> **Note**: If ScubaGear is having trouble finding the OPA executable, you are able to place the executable in the directory you are executing `Invoke-SCuBA` in. ScubaGear will also look in the current executing directory for the OPA executable.
+> **Note**: If ScubaGear is having trouble finding the OPA executable, place the OPA executable in the directory from which you are executing `Invoke-SCuBA`. ScubaGear will also look in the current working directory for the OPA executable.
 
 Once the dependencies have been installed, you are ready to set the [permissions](permissions.md).

--- a/docs/prerequisites/dependencies.md
+++ b/docs/prerequisites/dependencies.md
@@ -50,6 +50,6 @@ To verify that OPA is working, use the following command to check the version:
 .\opa_windows_amd64.exe version
 ```
 
-> **Note**: If ScubaGear is having trouble finding the OPA executable, place the OPA executable in the directory from which you are executing `Invoke-SCuBA`. ScubaGear will also look in the current working directory for the OPA executable.
+> **Note**: If ScubaGear is having trouble finding the OPA executable in the `Tools` folder, place the OPA executable in the directory from which you are executing `Invoke-SCuBA`. ScubaGear will also attempt to look in the current executing directory for the OPA executable.
 
 Once the dependencies have been installed, you are ready to set the [permissions](permissions.md).

--- a/docs/prerequisites/dependencies.md
+++ b/docs/prerequisites/dependencies.md
@@ -4,7 +4,7 @@ Before [executing](../execution/execution.md) ScubaGear, its dependencies must b
 
 ```powershell
 # Install the minimum required dependencies
-Initialize-SCuBA 
+Initialize-SCuBA
 ```
 
 > **Note**: ScubaGear utilizes several libraries from Microsoft to read data about their product configurations.  At least one of these libraries is tied to PowerShell 5.  Until Microsoft updates their library, ScubaGear will continue to use PowerShell 5.  As this version is only available on Windows, ScubaGear will only run on Windows.
@@ -32,7 +32,7 @@ If that fails, you can manually download the OPA executable.
 
 ![version](../images/opa_version.png)
 
-> **Note**: To find the default supported version, go to the [ScubaConfig](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfig.psm1) file, look for the variable `$ScubaDefaults`, and find its parameter `DefaultOPAVersion`.  
+> **Note**: To find the default supported version, go to the [ScubaConfig](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfig.psm1) file, look for the variable `$ScubaDefaults`, and find its parameter `DefaultOPAVersion`.
 
 > **Note**: To find older supported versions, go to the [Support](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Modules/Support/Support.psm1) file, and find the constant named `$ACCEPTABLEVERSIONS`.
 
@@ -49,5 +49,7 @@ To verify that OPA is working, use the following command to check the version:
 # Check the OPA version
 .\opa_windows_amd64.exe version
 ```
+
+> **Note**: If ScubaGear is having trouble finding the OPA executable, you are able to place the executable in the directory you are executing `Invoke-SCuBA` in. ScubaGear will also look in the current executing directory for the OPA executable.
 
 Once the dependencies have been installed, you are ready to set the [permissions](permissions.md).


### PR DESCRIPTION
## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->
- Add a backup path to `RunRego.psm1` that checks the user's current executing directory if ScubaGear fails to detect the OPA executable in the `.scubagear/tools` folder.
- This is to assist with troubleshooting when the OPA executable fails to download properly.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->
Closes #835 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
- Remove the opa executable from the tools folder
- Add a copy to your current executing directory. 
- If a copy is not found in both ScubaGear will throw a more detailed error message.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [x] Resolved all merge conflicts on branch
- [ ] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
