### PR TITLE
Improve AAD provider performance by directly invoking Graph APIs for Cmdlets with slow load times

### DIFF
--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -550,7 +550,7 @@ function Invoke-ProviderList {
                     $RetVal = ""
                     switch ($Product) {
                         "aad" {
-                            $RetVal = Export-AADProvider | Select-Object -Last 1
+                            $RetVal = Export-AADProvider -M365Environment $M365Environment | Select-Object -Last 1
                         }
                         "exo" {
                             $RetVal = Export-EXOProvider | Select-Object -Last 1

--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -35,18 +35,14 @@ function Invoke-GraphDirectly {
         foreach ($item in $queryParams.GetEnumerator()) {
             $q.Add($item.Key, $item.Value)
         }
+        $endpoint = "https://example.com" + $endpoint
         $uri = [System.UriBuilder]$endpoint
         $uri.Query = $q.ToString()
-        $endpoint = $uri.ToString()
+        $endpoint = $uri.Path + $uri.Query
     }
     Write-Debug "Graph Api direct: $endpoint"
 
-    # try {
-        $resp = Invoke-MgGraphRequest -Uri $endpoint -UserAgent 'ScubaGear'
-    # }
-    # catch {
-    #     write-host "Spoof-Commandlet error occured: $($_.Exception)"
-    # }
+    $resp = Invoke-MgGraphRequest -Uri $endpoint -UserAgent 'ScubaGear'
     return $resp.Value
 }
 

--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -3,7 +3,7 @@ function Export-AADProvider {
     .Description
     Gets the Azure Active Directory (AAD) settings that are relevant
     to the SCuBA AAD baselines using a subset of the modules under the
-    overall Microsoft Graph PowerShell Module
+    overall Microsoft Graph PowerShell Module 
     .Functionality
     Internal
     #>

--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -12,7 +12,7 @@ $GraphEndpoints = @{
     "Get-MgBetaPolicyAuthenticationMethodPolicy" = "https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy"
     "Get-MgBetaDomain" = "https://graph.microsoft.com/beta/domains"
     "Get-MgBetaOrganization" = "https://graph.microsoft.com/beta/organization"
-    "Get-MgBetaUser" = "https://graph.microsoft.com/beta/users" 
+    "Get-MgBetaUser" = "https://graph.microsoft.com/beta/users"
     "Get-MgBetaPolicyRoleManagementPolicyAssignment"  = "https://graph.microsoft.com/beta/policies/roleManagementPolicyAssignments"
 }
 
@@ -42,7 +42,7 @@ function Invoke-GraphDirectly {
 
     if ($queryParams) {
         <#
-          If query params are passed in, we need to augment the endpoint URI to include the params. Paperwork below. 
+          If query params are passed in, we need to augment the endpoint URI to include the params. Paperwork below.
           We can't use string formatting easily because the graph API expects parameters
           that are prefixed with the dollar symbol. Maybe someone smarter than me can figure that out.
         #>
@@ -335,7 +335,7 @@ function Get-PrivilegedUser {
                     # Get the users that are assigned to the PIM group as Eligible members
                     # $PIMGroupMembers = Get-MgBetaIdentityGovernancePrivilegedAccessGroupEligibilityScheduleInstance -All -ErrorAction Stop -Filter "groupId eq '$GroupId'"
                     $graphArgs = @{
-                        "commandlet" = "Get-MgBetaIdentityGovernancePrivilegedAccessGroupEligibilityScheduleInstance" 
+                        "commandlet" = "Get-MgBetaIdentityGovernancePrivilegedAccessGroupEligibilityScheduleInstance"
                         "queryParams" = @{'$filter' = "groupId eq '$GroupId'"}
                         "M365Environment" = $M365Environment }
                     $PIMGroupMembers = Invoke-GraphDirectly @graphArgs
@@ -364,7 +364,7 @@ function Get-PrivilegedUser {
         # Get a list of all the users and groups that have Eligible assignments
         # $AllPIMRoleAssignments = Get-MgBetaRoleManagementDirectoryRoleEligibilityScheduleInstance -All -ErrorAction Stop
         $graphArgs = @{
-            "commandlet" = "Get-MgBetaRoleManagementDirectoryRoleEligibilityScheduleInstance" 
+            "commandlet" = "Get-MgBetaRoleManagementDirectoryRoleEligibilityScheduleInstance"
             "M365Environment" = $M365Environment }
         $AllPIMRoleAssignments = Invoke-GraphDirectly @graphArgs
 
@@ -623,7 +623,7 @@ function Get-PrivilegedRole {
         # Get ALL the roles and users actively assigned to them
         # $AllRoleAssignments = Get-MgBetaRoleManagementDirectoryRoleAssignmentScheduleInstance -All -ErrorAction Stop
         $graphArgs = @{
-            "commandlet" = "Get-MgBetaRoleManagementDirectoryRoleAssignmentScheduleInstance" 
+            "commandlet" = "Get-MgBetaRoleManagementDirectoryRoleAssignmentScheduleInstance"
             "M365Environment" = $M365Environment }
         $AllRoleAssignments = Invoke-GraphDirectly @graphArgs
 

--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -1,19 +1,11 @@
+# Many of the commandlets can be replaced with direct API access, but we are starting the transition with the ones
+# below because they have slow imports that affect performance more than the others. Some commandlets are fast
+# and there is no obvoius performance advantage to using the API beyond maybe batching.
 $GraphEndpoints = @{
-    "Get-MgBetaIdentityConditionalAccessPolicy" = "https://graph.microsoft.com/beta/identity/conditionalAccess/policies"
-    "Get-MgBetaSubscribedSku" = "https://graph.microsoft.com/beta/subscribedSkus"
-    "Get-MgBetaDirectoryRole" = "https://graph.microsoft.com/beta/directoryRoles"
-    "Get-MgBetaDirectoryRoleMembers" = "https://graph.microsoft.com/beta/directoryRoles/{0}/members"
-    "Get-MgBetaRoleManagementDirectoryRoleEligibilityScheduleInstance" = "https://graph.microsoft.com/beta/roleManagement/directory/roleEligibilityScheduleInstances"
-    "Get-MgBetaRoleManagementDirectoryRoleAssignmentScheduleInstance" = "https://graph.microsoft.com/beta/roleManagement/directory/roleAssignmentScheduleInstances"
-    "Get-MgBetaIdentityGovernancePrivilegedAccessGroupEligibilityScheduleInstance" = "https://graph.microsoft.com/beta/identityGovernance/privilegedAccess/group/eligibilityScheduleInstances"
-    "Get-MgBetaPrivilegedAccessResource" = "https://graph.microsoft.com/beta/privilegedAccess/aadGroups/resources"
-    "Get-MgBetaPolicyAuthorizationPolicy" = "https://graph.microsoft.com/beta/policies/authorizationPolicy"
-    "Get-MgBetaDirectorySetting" = "https://graph.microsoft.com/beta/settings"
-    "Get-MgBetaPolicyAuthenticationMethodPolicy" = "https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy"
-    "Get-MgBetaDomain" = "https://graph.microsoft.com/beta/domains"
-    "Get-MgBetaOrganization" = "https://graph.microsoft.com/beta/organization"
-    "Get-MgBetaUser" = "https://graph.microsoft.com/beta/users"
-    "Get-MgBetaPolicyRoleManagementPolicyAssignment"  = "https://graph.microsoft.com/beta/policies/roleManagementPolicyAssignments"
+    "Get-MgBetaRoleManagementDirectoryRoleEligibilityScheduleInstance" = "/beta/roleManagement/directory/roleEligibilityScheduleInstances"
+    "Get-MgBetaRoleManagementDirectoryRoleAssignmentScheduleInstance" = "/beta/roleManagement/directory/roleAssignmentScheduleInstances"
+    "Get-MgBetaIdentityGovernancePrivilegedAccessGroupEligibilityScheduleInstance" = "/beta/identityGovernance/privilegedAccess/group/eligibilityScheduleInstances"
+    "Get-MgBetaPrivilegedAccessResource" = "/beta/privilegedAccess/aadGroups/resources"
 }
 
 function Invoke-GraphDirectly {

--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -302,7 +302,6 @@ function Get-PrivilegedUser {
                 # If the premium license for PIM is there, process the users that are "member" of the PIM group as Eligible
                 if ($TenantHasPremiumLicense) {
                     # Get the users that are assigned to the PIM group as Eligible members
-                    # $PIMGroupMembers = Get-MgBetaIdentityGovernancePrivilegedAccessGroupEligibilityScheduleInstance -All -ErrorAction Stop -Filter "groupId eq '$GroupId'"
                     $graphArgs = @{
                         "commandlet" = "Get-MgBetaIdentityGovernancePrivilegedAccessGroupEligibilityScheduleInstance"
                         "queryParams" = @{'$filter' = "groupId eq '$GroupId'"}
@@ -331,7 +330,6 @@ function Get-PrivilegedUser {
     # Process the Eligible role assignments if the premium license for PIM is there
     if ($TenantHasPremiumLicense) {
         # Get a list of all the users and groups that have Eligible assignments
-        # $AllPIMRoleAssignments = Get-MgBetaRoleManagementDirectoryRoleEligibilityScheduleInstance -All -ErrorAction Stop
         $graphArgs = @{
             "commandlet" = "Get-MgBetaRoleManagementDirectoryRoleEligibilityScheduleInstance"
         }
@@ -388,7 +386,6 @@ function Get-PrivilegedUser {
                     }
 
                     # Get the users that are assigned to the PIM group as Eligible members
-                    # $PIMGroupMembers = Get-MgBetaIdentityGovernancePrivilegedAccessGroupEligibilityScheduleInstance -All -ErrorAction Stop -Filter "groupId eq '$UserObjectId'"
                     $graphArgs = @{
                         "commandlet" = "Get-MgBetaIdentityGovernancePrivilegedAccessGroupEligibilityScheduleInstance"
                         "queryParams" = @{'$filter' = "groupId eq '$UserObjectId'"}
@@ -460,7 +457,6 @@ function GetConfigurationsForPimGroups{
     )
 
     # Get a list of the groups that are enrolled in PIM - we want to ignore the others
-    # $PIMGroups = Get-MgBetaPrivilegedAccessResource -All -ErrorAction Stop -PrivilegedAccessId aadGroups
     $graphArgs = @{
         "commandlet" = "Get-MgBetaPrivilegedAccessResource"
         "queryParams" = @{'$PrivilegedAccessId' = "aadGroups"}
@@ -582,7 +578,6 @@ function Get-PrivilegedRole {
         [GroupTypeCache]::CheckedGroups.Clear()
 
         # Get ALL the roles and users actively assigned to them
-        # $AllRoleAssignments = Get-MgBetaRoleManagementDirectoryRoleAssignmentScheduleInstance -All -ErrorAction Stop
         $graphArgs = @{
             "commandlet" = "Get-MgBetaRoleManagementDirectoryRoleAssignmentScheduleInstance"
         }

--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -55,7 +55,7 @@ function Invoke-GraphDirectly {
         $endpoint = $uri.ToString()
     }
     Write-Debug "Graph Api direct: $endpoint"
- 
+
     # try {
         $resp = Invoke-MgGraphRequest -Uri $endpoint -UserAgent 'ScubaGear'
     # }

--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -35,10 +35,9 @@ function Invoke-GraphDirectly {
         foreach ($item in $queryParams.GetEnumerator()) {
             $q.Add($item.Key, $item.Value)
         }
-        $endpoint = "https://example.com" + $endpoint
-        $uri = [System.UriBuilder]$endpoint
+        $uri = [System.UriBuilder]::new("", "", 443, $endpoint)
         $uri.Query = $q.ToString()
-        $endpoint = $uri.Path + $uri.Query
+        $endpoint = $uri.ToString()
     }
     Write-Debug "Graph Api direct: $endpoint"
 

--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -55,7 +55,7 @@ function Invoke-GraphDirectly {
         $endpoint = $uri.ToString()
     }
     Write-Debug "Graph Api direct: $endpoint"
-    
+ 
     # try {
         $resp = Invoke-MgGraphRequest -Uri $endpoint -UserAgent 'ScubaGear'
     # }

--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -14,22 +14,15 @@ function Invoke-GraphDirectly {
         [string]
         $commandlet,
 
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $M365Environment,
-
         [System.Collections.Hashtable]
         $queryParams
     )
 
     Write-Debug "Replacing Cmdlet: $commandlet"
-    $endpoint = $GraphEndpoints[$commandlet]
-    # GCC high and DoD have slightly different endpoint URLs
-    if (($M365Environment -eq "gcchigh") -or ($M365Environment -eq "dod")) {
-        $endpoint = $endpoint.Replace(".com", ".us")
-    }
-    if ($M365Environment -eq "dod") {
-        $endpoint = $endpoint.Replace("graph", "dod-graph")
+    try {
+        $endpoint = $GraphEndpoints[$commandlet]
+    } catch {
+        Write-Error "The commandlet $commandlet can't be used with the Invoke-GraphDirectly function yet."
     }
 
     if ($queryParams) {

--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -170,7 +170,7 @@ function Export-AADProvider {
 
     # Checking to ensure command runs successfully
     $UserCount = $Tracker.TryCommand("Get-MgBetaUserCount", @{"ConsistencyLevel"='eventual'})
-
+    $UserCount = $UserCount[0]
     if(-Not $UserCount -is [int]) {
         $UserCount = "NaN"
     }

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -860,7 +860,7 @@ default PrivilegedRoleExclusions(_, _) := false
 # for users & groups. If there are users with permenant assignment
 # return true if all users + groups are in the config.
 PrivilegedRoleExclusions(PrivilegedRole, PolicyID) := true if {
-    PrivilegedRoleAssignedPrincipals := {x.PrincipalId | some x in PrivilegedRole.Assignments; x.EndDateTime == null}
+    PrivilegedRoleAssignedPrincipals := {x.principalId | some x in PrivilegedRole.Assignments; x.endDateTime == null}
 
     AllowedPrivilegedRoleUsers := {y | some y in input.scuba_config.Aad[PolicyID].RoleExclusions.Users; y != null}
     AllowedPrivilegedRoleGroups := {y | some y in input.scuba_config.Aad[PolicyID].RoleExclusions.Groups; y != null}
@@ -871,7 +871,7 @@ PrivilegedRoleExclusions(PrivilegedRole, PolicyID) := true if {
 
 # if no users with permenant assignment & config empty, return true
 PrivilegedRoleExclusions(PrivilegedRole, PolicyID) := true if {
-    count({x.PrincipalId | some x in PrivilegedRole.Assignments; x.EndDateTime == null}) > 0
+    count({x.principalId | some x in PrivilegedRole.Assignments; x.endDateTime == null}) > 0
     count({y | some y in input.scuba_config.Aad[PolicyID].RoleExclusions.Users; y != null}) == 0
     count({y | some y in input.scuba_config.Aad[PolicyID].RoleExclusions.Groups; y != null}) == 0
 }
@@ -906,7 +906,7 @@ tests contains {
 # Get all privileged roles that do not have a start date
 RolesAssignedOutsidePim contains Role.DisplayName if {
     some Role in input.privileged_roles
-    NoStartAssignments := {is_null(X.StartDateTime) | some X in Role.Assignments}
+    NoStartAssignments := {is_null(X.startDateTime) | some X in Role.Assignments}
 
     count(FilterArray(NoStartAssignments, true)) > 0
 }

--- a/PowerShell/ScubaGear/RequiredVersions.ps1
+++ b/PowerShell/ScubaGear/RequiredVersions.ps1
@@ -51,11 +51,6 @@ $ModuleList = @(
         MaximumVersion = [version] '2.19.99999'
     },
     @{
-        ModuleName = 'Microsoft.Graph.Beta.Identity.Governance'
-        ModuleVersion = [version] '2.0.0'
-        MaximumVersion = [version] '2.19.99999'
-    },
-    @{
         ModuleName = 'Microsoft.Graph.Beta.Identity.SignIns'
         ModuleVersion = [version] '2.0.0'
         MaximumVersion = [version] '2.19.99999'

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/AADProvider/Invoke-GraphDirectly.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/AADProvider/Invoke-GraphDirectly.ps1
@@ -1,0 +1,22 @@
+$ProviderPath = '../../../../../Modules/Providers'
+Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "$($ProviderPath)/ExportAADProvider.psm1") -Function 'Get-PrivilegedRole' -Force
+
+InModuleScope ExportAADProvider {
+    Describe -Tag 'AADProvider' -Name "Invoke-GraphDirectly" {
+        BeforeAll {
+            #function Invoke-MgGraphRequest {return @{Value = @{cowsound = "moo"}}
+            Mock -ModuleName ExportAADProvider Invoke-MgGraphRequest {return @{Value = @{cowsound = "moo"}}}
+        }
+
+        It "should return the expected value from Invoke-MgGraphRequest" {
+            $expected = @{cowsound = "moo"}
+            $result = Invoke-Graphdirectly("Get-MgBetaUser")
+            $result.Keys | Should -Be $expected.Keys
+            $result.Values | Should -Be $expected.Values
+        }
+    }
+}
+
+AfterAll {
+    Remove-Module ExportAADProvider -Force -ErrorAction SilentlyContinue
+}

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/AADProvider/Invoke-GraphDirectly.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/AADProvider/Invoke-GraphDirectly.ps1
@@ -4,7 +4,6 @@ Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "$($ProviderPath)/Export
 InModuleScope ExportAADProvider {
     Describe -Tag 'AADProvider' -Name "Invoke-GraphDirectly" {
         BeforeAll {
-            #function Invoke-MgGraphRequest {return @{Value = @{cowsound = "moo"}}
             Mock -ModuleName ExportAADProvider Invoke-MgGraphRequest {return @{Value = @{cowsound = "moo"}}}
         }
 

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
@@ -1233,7 +1233,7 @@ test_Assignments_Correct if {
                 "DisplayName": "Global Administrator",
                 "Assignments": [
                     {
-                        "StartDateTime": "/Date(1660328610000)/"
+                        "startDateTime": "/Date(1660328610000)/"
                     }
                 ],
                 "Rules": [
@@ -1270,7 +1270,7 @@ test_Assignments_Incorrect if {
                 "DisplayName": "Global Administrator",
                 "Assignments": [
                     {
-                        "StartDateTime": null
+                        "startDateTime": null
                     }
                 ],
                 "Rules": [

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
@@ -416,7 +416,7 @@ test_AdditionalProperties_Correct_V1 if {
                 "DisplayName": "Global Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": "/Date(1691006065170)/",
+                        "endDateTime": "/Date(1691006065170)/",
                         "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
@@ -445,7 +445,7 @@ test_AdditionalProperties_Correct_V2 if {
                 "DisplayName": "Global Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": null,
+                        "endDateTime": null,
                         "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
@@ -486,7 +486,7 @@ test_AdditionalProperties_Correct_V3 if {
                 "DisplayName": "Global Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": null,
+                        "endDateTime": null,
                         "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
@@ -527,7 +527,7 @@ test_AdditionalProperties_LicenseMissing_V1 if {
                 "DisplayName": "Global Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": null,
+                        "endDateTime": null,
                         "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
@@ -536,7 +536,7 @@ test_AdditionalProperties_LicenseMissing_V1 if {
                 "DisplayName": "Application Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": "/Date(1691006065170)/",
+                        "endDateTime": "/Date(1691006065170)/",
                         "PrincipalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
                     }
                 ]
@@ -568,7 +568,7 @@ test_AdditionalProperties_Incorrect_V1 if {
                 "DisplayName": "Global Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": null,
+                        "endDateTime": null,
                         "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
@@ -597,7 +597,7 @@ test_AdditionalProperties_Incorrect_V2 if {
                 "DisplayName": "Global Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": null,
+                        "endDateTime": null,
                         "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
@@ -606,7 +606,7 @@ test_AdditionalProperties_Incorrect_V2 if {
                 "DisplayName": "Application Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": "/Date(1691006065170)/",
+                        "endDateTime": "/Date(1691006065170)/",
                         "PrincipalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
                     }
                 ]
@@ -635,7 +635,7 @@ test_AdditionalProperties_Incorrect_V3 if {
                 "DisplayName": "Global Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": null,
+                        "endDateTime": null,
                         "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
@@ -644,7 +644,7 @@ test_AdditionalProperties_Incorrect_V3 if {
                 "DisplayName": "Application Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": null,
+                        "endDateTime": null,
                         "PrincipalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
                     }
                 ]
@@ -677,11 +677,11 @@ test_AdditionalProperties_Incorrect_V4 if {
                 "DisplayName": "Global Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": null,
+                        "endDateTime": null,
                         "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     },
                     {
-                        "EndDateTime": null,
+                        "endDateTime": null,
                         "PrincipalId": "38035edd-63a1-4c08-8bd2-ad78d0624057"
                     }
                 ]
@@ -690,7 +690,7 @@ test_AdditionalProperties_Incorrect_V4 if {
                 "DisplayName": "Application Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": null,
+                        "endDateTime": null,
                         "PrincipalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
                     }
                 ]
@@ -723,7 +723,7 @@ test_AdditionalProperties_Incorrect_V5 if {
                 "DisplayName": "Global Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": null,
+                        "endDateTime": null,
                         "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
@@ -764,7 +764,7 @@ test_AdditionalProperties_Incorrect_V6 if {
                 "DisplayName": "Global Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": null,
+                        "endDateTime": null,
                         "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
@@ -773,7 +773,7 @@ test_AdditionalProperties_Incorrect_V6 if {
                 "DisplayName": "Application Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": "/Date(1691006065170)/",
+                        "endDateTime": "/Date(1691006065170)/",
                         "PrincipalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
                     }
                 ]
@@ -814,7 +814,7 @@ test_AdditionalProperties_Incorrect_V7 if {
                 "DisplayName": "Global Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": null,
+                        "endDateTime": null,
                         "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
@@ -823,7 +823,7 @@ test_AdditionalProperties_Incorrect_V7 if {
                 "DisplayName": "Application Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": null,
+                        "endDateTime": null,
                         "PrincipalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
                     }
                 ]
@@ -868,11 +868,11 @@ test_AdditionalProperties_Incorrect_V8 if {
                 "DisplayName": "Global Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": null,
+                        "endDateTime": null,
                         "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     },
                     {
-                        "EndDateTime": null,
+                        "endDateTime": null,
                         "PrincipalId": "38035edd-63a1-4c08-8bd2-ad78d0624057"
                     }
                 ]
@@ -881,7 +881,7 @@ test_AdditionalProperties_Incorrect_V8 if {
                 "DisplayName": "Application Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": null,
+                        "endDateTime": null,
                         "PrincipalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
                     }
                 ]
@@ -926,7 +926,7 @@ test_AdditionalProperties_Incorrect_V9 if {
                 "DisplayName": "Global Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": null,
+                        "endDateTime": null,
                         "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
@@ -935,7 +935,7 @@ test_AdditionalProperties_Incorrect_V9 if {
                 "DisplayName": "Application Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": "/Date(1691006065170)/",
+                        "endDateTime": "/Date(1691006065170)/",
                         "PrincipalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
                     }
                 ]
@@ -976,7 +976,7 @@ test_AdditionalProperties_Incorrect_V10 if {
                 "DisplayName": "Global Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": null,
+                        "endDateTime": null,
                         "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
@@ -1017,7 +1017,7 @@ test_AdditionalProperties_Incorrect_V11 if {
                 "DisplayName": "Global Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": null,
+                        "endDateTime": null,
                         "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
@@ -1026,7 +1026,7 @@ test_AdditionalProperties_Incorrect_V11 if {
                 "DisplayName": "Application Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": "/Date(1691006065170)/",
+                        "endDateTime": "/Date(1691006065170)/",
                         "PrincipalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
                     }
                 ]
@@ -1067,7 +1067,7 @@ test_AdditionalProperties_Incorrect_V12 if {
                 "DisplayName": "Global Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": null,
+                        "endDateTime": null,
                         "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
@@ -1076,7 +1076,7 @@ test_AdditionalProperties_Incorrect_V12 if {
                 "DisplayName": "Application Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": null,
+                        "endDateTime": null,
                         "PrincipalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
                     }
                 ]
@@ -1121,11 +1121,11 @@ test_AdditionalProperties_Incorrect_V13 if {
                 "DisplayName": "Global Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": null,
+                        "endDateTime": null,
                         "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     },
                     {
-                        "EndDateTime": null,
+                        "endDateTime": null,
                         "PrincipalId": "38035edd-63a1-4c08-8bd2-ad78d0624057"
                     }
                 ]
@@ -1134,7 +1134,7 @@ test_AdditionalProperties_Incorrect_V13 if {
                 "DisplayName": "Application Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": null,
+                        "endDateTime": null,
                         "PrincipalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
                     }
                 ]
@@ -1179,7 +1179,7 @@ test_AdditionalProperties_Incorrect_V14 if {
                 "DisplayName": "Global Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": null,
+                        "endDateTime": null,
                         "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
@@ -1188,7 +1188,7 @@ test_AdditionalProperties_Incorrect_V14 if {
                 "DisplayName": "Application Administrator",
                 "Assignments": [
                     {
-                        "EndDateTime": "/Date(1691006065170)/",
+                        "endDateTime": "/Date(1691006065170)/",
                         "PrincipalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
                     }
                 ]

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
@@ -417,7 +417,7 @@ test_AdditionalProperties_Correct_V1 if {
                 "Assignments": [
                     {
                         "endDateTime": "/Date(1691006065170)/",
-                        "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
+                        "principalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
             }
@@ -446,7 +446,7 @@ test_AdditionalProperties_Correct_V2 if {
                 "Assignments": [
                     {
                         "endDateTime": null,
-                        "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
+                        "principalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
             }
@@ -487,7 +487,7 @@ test_AdditionalProperties_Correct_V3 if {
                 "Assignments": [
                     {
                         "endDateTime": null,
-                        "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
+                        "principalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
             }
@@ -528,7 +528,7 @@ test_AdditionalProperties_LicenseMissing_V1 if {
                 "Assignments": [
                     {
                         "endDateTime": null,
-                        "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
+                        "principalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
             },
@@ -537,7 +537,7 @@ test_AdditionalProperties_LicenseMissing_V1 if {
                 "Assignments": [
                     {
                         "endDateTime": "/Date(1691006065170)/",
-                        "PrincipalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
+                        "principalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
                     }
                 ]
             }
@@ -569,7 +569,7 @@ test_AdditionalProperties_Incorrect_V1 if {
                 "Assignments": [
                     {
                         "endDateTime": null,
-                        "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
+                        "principalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
             }
@@ -598,7 +598,7 @@ test_AdditionalProperties_Incorrect_V2 if {
                 "Assignments": [
                     {
                         "endDateTime": null,
-                        "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
+                        "principalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
             },
@@ -607,7 +607,7 @@ test_AdditionalProperties_Incorrect_V2 if {
                 "Assignments": [
                     {
                         "endDateTime": "/Date(1691006065170)/",
-                        "PrincipalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
+                        "principalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
                     }
                 ]
             }
@@ -636,7 +636,7 @@ test_AdditionalProperties_Incorrect_V3 if {
                 "Assignments": [
                     {
                         "endDateTime": null,
-                        "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
+                        "principalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
             },
@@ -645,7 +645,7 @@ test_AdditionalProperties_Incorrect_V3 if {
                 "Assignments": [
                     {
                         "endDateTime": null,
-                        "PrincipalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
+                        "principalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
                     }
                 ]
             }
@@ -678,11 +678,11 @@ test_AdditionalProperties_Incorrect_V4 if {
                 "Assignments": [
                     {
                         "endDateTime": null,
-                        "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
+                        "principalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     },
                     {
                         "endDateTime": null,
-                        "PrincipalId": "38035edd-63a1-4c08-8bd2-ad78d0624057"
+                        "principalId": "38035edd-63a1-4c08-8bd2-ad78d0624057"
                     }
                 ]
             },
@@ -691,7 +691,7 @@ test_AdditionalProperties_Incorrect_V4 if {
                 "Assignments": [
                     {
                         "endDateTime": null,
-                        "PrincipalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
+                        "principalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
                     }
                 ]
             }
@@ -724,7 +724,7 @@ test_AdditionalProperties_Incorrect_V5 if {
                 "Assignments": [
                     {
                         "endDateTime": null,
-                        "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
+                        "principalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
             }
@@ -765,7 +765,7 @@ test_AdditionalProperties_Incorrect_V6 if {
                 "Assignments": [
                     {
                         "endDateTime": null,
-                        "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
+                        "principalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
             },
@@ -774,7 +774,7 @@ test_AdditionalProperties_Incorrect_V6 if {
                 "Assignments": [
                     {
                         "endDateTime": "/Date(1691006065170)/",
-                        "PrincipalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
+                        "principalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
                     }
                 ]
             }
@@ -815,7 +815,7 @@ test_AdditionalProperties_Incorrect_V7 if {
                 "Assignments": [
                     {
                         "endDateTime": null,
-                        "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
+                        "principalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
             },
@@ -824,7 +824,7 @@ test_AdditionalProperties_Incorrect_V7 if {
                 "Assignments": [
                     {
                         "endDateTime": null,
-                        "PrincipalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
+                        "principalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
                     }
                 ]
             }
@@ -869,11 +869,11 @@ test_AdditionalProperties_Incorrect_V8 if {
                 "Assignments": [
                     {
                         "endDateTime": null,
-                        "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
+                        "principalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     },
                     {
                         "endDateTime": null,
-                        "PrincipalId": "38035edd-63a1-4c08-8bd2-ad78d0624057"
+                        "principalId": "38035edd-63a1-4c08-8bd2-ad78d0624057"
                     }
                 ]
             },
@@ -882,7 +882,7 @@ test_AdditionalProperties_Incorrect_V8 if {
                 "Assignments": [
                     {
                         "endDateTime": null,
-                        "PrincipalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
+                        "principalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
                     }
                 ]
             }
@@ -927,7 +927,7 @@ test_AdditionalProperties_Incorrect_V9 if {
                 "Assignments": [
                     {
                         "endDateTime": null,
-                        "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
+                        "principalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
             },
@@ -936,7 +936,7 @@ test_AdditionalProperties_Incorrect_V9 if {
                 "Assignments": [
                     {
                         "endDateTime": "/Date(1691006065170)/",
-                        "PrincipalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
+                        "principalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
                     }
                 ]
             }
@@ -977,7 +977,7 @@ test_AdditionalProperties_Incorrect_V10 if {
                 "Assignments": [
                     {
                         "endDateTime": null,
-                        "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
+                        "principalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
             }
@@ -1018,7 +1018,7 @@ test_AdditionalProperties_Incorrect_V11 if {
                 "Assignments": [
                     {
                         "endDateTime": null,
-                        "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
+                        "principalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
             },
@@ -1027,7 +1027,7 @@ test_AdditionalProperties_Incorrect_V11 if {
                 "Assignments": [
                     {
                         "endDateTime": "/Date(1691006065170)/",
-                        "PrincipalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
+                        "principalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
                     }
                 ]
             }
@@ -1068,7 +1068,7 @@ test_AdditionalProperties_Incorrect_V12 if {
                 "Assignments": [
                     {
                         "endDateTime": null,
-                        "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
+                        "principalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
             },
@@ -1077,7 +1077,7 @@ test_AdditionalProperties_Incorrect_V12 if {
                 "Assignments": [
                     {
                         "endDateTime": null,
-                        "PrincipalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
+                        "principalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
                     }
                 ]
             }
@@ -1122,11 +1122,11 @@ test_AdditionalProperties_Incorrect_V13 if {
                 "Assignments": [
                     {
                         "endDateTime": null,
-                        "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
+                        "principalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     },
                     {
                         "endDateTime": null,
-                        "PrincipalId": "38035edd-63a1-4c08-8bd2-ad78d0624057"
+                        "principalId": "38035edd-63a1-4c08-8bd2-ad78d0624057"
                     }
                 ]
             },
@@ -1135,7 +1135,7 @@ test_AdditionalProperties_Incorrect_V13 if {
                 "Assignments": [
                     {
                         "endDateTime": null,
-                        "PrincipalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
+                        "principalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
                     }
                 ]
             }
@@ -1180,7 +1180,7 @@ test_AdditionalProperties_Incorrect_V14 if {
                 "Assignments": [
                     {
                         "endDateTime": null,
-                        "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
+                        "principalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     }
                 ]
             },
@@ -1189,7 +1189,7 @@ test_AdditionalProperties_Incorrect_V14 if {
                 "Assignments": [
                     {
                         "endDateTime": "/Date(1691006065170)/",
-                        "PrincipalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
+                        "principalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
                     }
                 ]
             }

--- a/Testing/Functional/Products/TestPlans/aad.g5.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/aad.g5.testplan.yaml
@@ -108,7 +108,7 @@ TestPlan:
     TestDriver: RunCached
     Tests:
       - TestDescription: MS.AAD.7.4v1 Non-Compliant case - User with permanent active assignment
-        #### This test case guarantees that at least one privileged role assignment has an EndDateTime of null
+        #### This test case guarantees that at least one privileged role assignment has an endDateTime of null
         Preconditions:
           - Command: UpdateProviderExport
             Splat:
@@ -117,12 +117,12 @@ TestPlan:
                   - DisplayName: Global Administrator
                     RoleTemplateId: "62e90394-69f5-4237-9190-012177145e10"
                     Assignments:
-                      - EndDateTime: "/Date(1672947244397)/"
+                      - endDateTime: "/Date(1672947244397)/"
                         PrincipalId: "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                   - DisplayName: User Administrator
                     RoleTemplateId: "fe930be7-5e62-47db-91af-98c3a49a38b1"
                     Assignments:
-                      - EndDateTime: null
+                      - endDateTime: null
                         PrincipalId: "ce71e61c-f465-4db6-8d26-5f3e52bdd801"
         Postconditions: []
         ExpectedResult: false
@@ -135,12 +135,12 @@ TestPlan:
                   - DisplayName: Global Administrator
                     RoleTemplateId: "62e90394-69f5-4237-9190-012177145e10"
                     Assignments:
-                      - EndDateTime: "/Date(1672947244397)/"
+                      - endDateTime: "/Date(1672947244397)/"
                         PrincipalId: "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                   - DisplayName: User Administrator
                     RoleTemplateId: "fe930be7-5e62-47db-91af-98c3a49a38b1"
                     Assignments:
-                      - EndDateTime: "/Date(1672947244397)/"
+                      - endDateTime: "/Date(1672947244397)/"
                         PrincipalId: "ce71e61c-f465-4db6-8d26-5f3e52bdd801"
         Postconditions: []
         ExpectedResult: true

--- a/Testing/Functional/Products/TestPlans/aad.g5.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/aad.g5.testplan.yaml
@@ -149,7 +149,7 @@ TestPlan:
     TestDriver: RunCached
     Tests:
       - TestDescription: MS.AAD.7.5v1 Non-Compliant case - User assigned outside of PIM
-        #### This test case guarantees that at least one privileged role assignment has an StartDateTime of null
+        #### This test case guarantees that at least one privileged role assignment has an startDateTime of null
         Preconditions:
           - Command: UpdateProviderExport
             Splat:
@@ -158,13 +158,13 @@ TestPlan:
                   - DisplayName: Global Administrator
                     RoleTemplateId: "62e90394-69f5-4237-9190-012177145e10"
                     Assignments:
-                      - StartDateTime: "/Date(1672947244397)/"
+                      - startDateTime: "/Date(1672947244397)/"
                         PrincipalId: "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     Rules: []
                   - DisplayName: User Administrator
                     RoleTemplateId: "fe930be7-5e62-47db-91af-98c3a49a38b1"
                     Assignments:
-                      - StartDateTime: null
+                      - startDateTime: null
                         PrincipalId: "ce71e61c-f465-4db6-8d26-5f3e52bdd801"
         Postconditions: []
         ExpectedResult: false
@@ -177,13 +177,13 @@ TestPlan:
                   - DisplayName: Global Administrator
                     RoleTemplateId: "62e90394-69f5-4237-9190-012177145e10"
                     Assignments:
-                      - StartDateTime: "/Date(1672947244397)/"
+                      - startDateTime: "/Date(1672947244397)/"
                         PrincipalId: "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     Rules: []
                   - DisplayName: User Administrator
                     RoleTemplateId: "fe930be7-5e62-47db-91af-98c3a49a38b1"
                     Assignments:
-                      - StartDateTime: "/Date(1672947244397)/"
+                      - startDateTime: "/Date(1672947244397)/"
                         PrincipalId: "ce71e61c-f465-4db6-8d26-5f3e52bdd801"
                     Rules: []
         Postconditions: []

--- a/utils/UninstallModules.ps1
+++ b/utils/UninstallModules.ps1
@@ -24,7 +24,6 @@ $ModuleList = @(
     "Microsoft.Graph.Authentication", # starting here, MS Graph modules for AAD
     "Microsoft.Graph.Beta.Groups",
     "Microsoft.Graph.Beta.Identity.DirectoryManagement",
-    "Microsoft.Graph.Beta.Identity.Governance",
     "Microsoft.Graph.Beta.Identity.SignIns",
     "Microsoft.Graph.Beta.Users",
     "powershell-yaml"


### PR DESCRIPTION
## 🗣 Description ##

This code enhancement of the AAD provider improves the performance of calls to Powershell cmdlets that are part of the Microsoft.Graph.Beta.Identity.Governance module. The enhancement replaces calls to those cmdlets with direct calls to the respective MS Graph REST APIs. The reason this works to cut down the execution time is that we found that the loading of the Identity.Governance module into memory when ScubaGear first runs in a fresh Powershell instance, is commonly a slow activity, in some cases taking over a minute just to load. By calling MS Graph APIs directly we bypass the penalty associated with loading the module into memory. Based on limited testing running in a virtual machine this enhancement resulted in a 42% reduction in execution time against our E5 tenant and a 35% reduction against our G5 tenant.


closes #816 

## 💭 Motivation and context ##

The AAD provider takes considerably longer to run compared to the other providers and in general runs slowly sometimes taking several minutes to complete. This creates delays for our development team who frequently run the code and have to perform testing and it slows down the automated processes that execute the code as well. Although we haven't received requests from end users to improve the performance, a positive side benefit is that their experience will improve when using the tool as well.

## 🧪 Testing ##

These code changes were tested against the E5, G5, G3 and GCC High tenants.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [x] Resolved all merge conflicts on branch
- [ ] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
