### PR TITLE
Extend Microsoft.Graph.* dependency max version from 2.19.x -> 2.x.x

### DIFF
--- a/PowerShell/ScubaGear/RequiredVersions.ps1
+++ b/PowerShell/ScubaGear/RequiredVersions.ps1
@@ -33,27 +33,27 @@ $ModuleList = @(
     @{
         ModuleName = 'Microsoft.Graph.Authentication'
         ModuleVersion = [version] '2.0.0'
-        MaximumVersion = [version] '2.19.99999'
+        MaximumVersion = [version] '2.99.99999'
     },
     @{
         ModuleName = 'Microsoft.Graph.Beta.Users'
         ModuleVersion = [version] '2.0.0'
-        MaximumVersion = [version] '2.19.99999'
+        MaximumVersion = [version] '2.99.99999'
     },
     @{
         ModuleName = 'Microsoft.Graph.Beta.Groups'
         ModuleVersion = [version] '2.0.0'
-        MaximumVersion = [version] '2.19.99999'
+        MaximumVersion = [version] '2.99.99999'
     },
     @{
         ModuleName = 'Microsoft.Graph.Beta.Identity.DirectoryManagement'
         ModuleVersion = [version] '2.0.0'
-        MaximumVersion = [version] '2.19.99999'
+        MaximumVersion = [version] '2.99.99999'
     },
     @{
         ModuleName = 'Microsoft.Graph.Beta.Identity.SignIns'
         ModuleVersion = [version] '2.0.0'
-        MaximumVersion = [version] '2.19.99999'
+        MaximumVersion = [version] '2.99.99999'
     },
     @{
         ModuleName = 'powershell-yaml'


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->
Updates the `RequiredVersions.ps1` set of Microsoft.Graph.* module dependencies `MaximumVersion` from 2.19.9999 to 2.99.9999.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

ScubaGear does not pin modules to specific minor versions unless there is a specific technical issue.  There is no such reason at this time for Microsoft.Graph.*, but the max version prevents minor versions beyond 2.19.  The current version of those modules is 2.19 so future minor versions will not be allowed by ScubaGear unless the max version is updated to allow all 2.x versions.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

1. Clear all ScubaGear dependent modules (and ScubaGear itself) from test system
2. Install ScubaGear (or import)
3. Run Initialize-SCuBA
4. Confirm that Microsoft.Graph.* latest version is installed
5. Run `Invoke-SCuBA` and confirm it works as intended (or confirm auto smoke test works)

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [x] Resolved all merge conflicts on branch
- [x] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
