### PR TITLE
Update Regal to v0.23.1

### DIFF
--- a/.github/workflows/unit_test_opa.yaml
+++ b/.github/workflows/unit_test_opa.yaml
@@ -32,6 +32,6 @@ jobs:
       - name: Setup Regal
         uses: StyraInc/setup-regal@v1.0.0
         with:
-          version: v0.18.0
+          version: v0.23.1
       - name: Run Regal Lint
         run: regal lint --format github ${{ env.MODULE_ROOT }}/Rego ${{ env.MODULE_ROOT }}/Testing

--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -2,14 +2,6 @@
 # All rules documented here:
 # https://docs.styra.com/regal/category/rules
 rules:
-  bugs:
-    # https://docs.styra.com/regal/rules/bugs/constant-condition
-    constant-condition:
-      # Many rule bodies containing only `true`. This is
-      # redundant, as that's the implied rule body when
-      # none is provided. It's harmless, but should be
-      # fixed anyway so real issues aren't missed.
-      level: warning
   custom:
     # https://docs.styra.com/regal/rules/custom/naming-convention
     naming-convention:
@@ -35,10 +27,6 @@ rules:
       # Safe to ignore.
       level: ignore
   imports:
-    implicit-future-keywords:
-      # This rule is on it's way out anyway, as future
-      # versions of OPA will make these keywords standard.
-      level: ignore
     # https://docs.styra.com/regal/rules/imports/prefer-package-imports
     prefer-package-imports:
       # Mostly just a style preference, motivated by how
@@ -62,19 +50,23 @@ rules:
       max-line-length: 150
       non-breakable-word-threshold: 100
       level: warning
+    # https://docs.styra.com/regal/rules/style/messy-rule
+    messy-rule:
+      # This rule suggests grouping incremental rules together, which
+      # might be worth considering for readability, but certainly not
+      # critical.
+      level: ignore
     # https://docs.styra.com/regal/rules/style/no-whitespace-comment
     no-whitespace-comment:
       # This repo is actually good about this, but frequently
       # uses '#--' as a delimiter of sorts. That should be OK,
       # and the next version of Regal will allow for exceptions
       # like this: https://github.com/StyraInc/regal/issues/379
-      level: ignore
+      level: warning
+      except-pattern: '^--|^gitleaks:'
     # https://docs.styra.com/regal/rules/style/opa-fmt
     opa-fmt:
       level: ignore
-    # https://docs.styra.com/regal/rules/style/prefer-some-in-iteration
-    prefer-some-in-iteration:
-      level: warning
     # https://docs.styra.com/regal/rules/style/prefer-snake-case
     prefer-snake-case:
       # This is the default style preference for Rego, but since
@@ -92,12 +84,3 @@ rules:
     # https://docs.styra.com/regal/rules/style/todo-comment
     todo-comment:
       level: ignore
-  testing:
-    # https://docs.styra.com/regal/rules/testing/identically-named-tests
-    identically-named-tests:
-      # Only a few of these — would be easy to fix
-      level: warning
-    # https://docs.styra.com/regal/rules/testing/test-outside-test-package
-    test-outside-test-package:
-      # This is just a style preference
-      level: warning

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -784,7 +784,7 @@ GlobalAdmins contains User.DisplayName if {
     "Global Administrator" in User.roles
 }
 
-#Set conditions under which this policy will pass
+# Set conditions under which this policy will pass
 default IsGlobalAdminCountGood := false
 IsGlobalAdminCountGood := true if {
     count(GlobalAdmins) <= 8

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/Defender/DefenderConfig_04_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/Defender/DefenderConfig_04_test.rego
@@ -290,7 +290,7 @@ test_ContentContainsSensitiveInformation_Incorrect_V6 if {
     TestResult("MS.DEFENDER.4.1v1", Output, ReportDetailString, false) == true
 }
 
-test_NoDLPLicense_Incorrect_V1 if {
+test_NoDLPLicense_Incorrect_4_1_V1 if {
     Output := defender.tests with input as {
         "defender_license": false,
         "defender_dlp_license": false
@@ -871,7 +871,7 @@ test_Locations_Incorrect_V8 if {
     TestResult("MS.DEFENDER.4.2v1", Output, ReportDetailString, false) == true
 }
 
-test_NoDLPLicense_Incorrect_V1 if {
+test_NoDLPLicense_Incorrect_4_2_V1 if {
     Output := defender.tests with input as {
         "defender_license": false,
         "defender_dlp_license": false
@@ -1161,7 +1161,7 @@ test_BlockAccess_Incorrect_V6 if {
     TestResult("MS.DEFENDER.4.3v1", Output, ReportDetailString, false) == true
 }
 
-test_NoDLPLicense_Incorrect_V1 if {
+test_NoDLPLicense_Incorrect_4_3_V1 if {
     Output := defender.tests with input as {
         "defender_license": false,
         "defender_dlp_license": false
@@ -1307,7 +1307,7 @@ test_NotifyUser_Incorrect_V2 if {
     TestResult("MS.DEFENDER.4.4v1", Output, ReportDetailString, false) == true
 }
 
-test_NoDLPLicense_Incorrect_V1 if {
+test_NoDLPLicense_Incorrect_4_4_V1 if {
     Output := defender.tests with input as {
         "defender_license": false,
         "defender_dlp_license": false


### PR DESCRIPTION
Hi there! It's been a while :) 

I figured I'd see how the latest Regal release would work here, and it worked just well. Just some minor changes needed:

- Remove rules from config that aren't needed
- Add configuration for new rules (only 'messy-rule' needed)
- Modify 'no-whitespace-comment' config to allow common exception
- Fix 'identically-named-tests' violation by renaming the tests