### PR TITLE
Boost AAD performance by replacing Cmdlets with slow load times

### DIFF
--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -856,7 +856,7 @@ default PrivilegedRoleExclusions(_, _) := false
 # for users & groups. If there are users with permenant assignment
 # return true if all users + groups are in the config.
 PrivilegedRoleExclusions(PrivilegedRole, PolicyID) := true if {
-    PrivilegedRoleAssignedPrincipals := {x.PrincipalId | some x in PrivilegedRole.Assignments; x.EndDateTime == null}
+    PrivilegedRoleAssignedPrincipals := {x.principalId | some x in PrivilegedRole.Assignments; x.endDateTime == null}
 
     AllowedPrivilegedRoleUsers := {y | some y in input.scuba_config.Aad[PolicyID].RoleExclusions.Users; y != null}
     AllowedPrivilegedRoleGroups := {y | some y in input.scuba_config.Aad[PolicyID].RoleExclusions.Groups; y != null}
@@ -867,7 +867,7 @@ PrivilegedRoleExclusions(PrivilegedRole, PolicyID) := true if {
 
 # if no users with permenant assignment & config empty, return true
 PrivilegedRoleExclusions(PrivilegedRole, PolicyID) := true if {
-    count({x.PrincipalId | some x in PrivilegedRole.Assignments; x.EndDateTime == null}) > 0
+    count({x.principalId | some x in PrivilegedRole.Assignments; x.endDateTime == null}) > 0
     count({y | some y in input.scuba_config.Aad[PolicyID].RoleExclusions.Users; y != null}) == 0
     count({y | some y in input.scuba_config.Aad[PolicyID].RoleExclusions.Groups; y != null}) == 0
 }
@@ -902,7 +902,7 @@ tests contains {
 # Get all privileged roles that do not have a start date
 RolesAssignedOutsidePim contains Role.DisplayName if {
     some Role in input.privileged_roles
-    NoStartAssignments := {is_null(X.StartDateTime) | some X in Role.Assignments}
+    NoStartAssignments := {is_null(X.startDateTime) | some X in Role.Assignments}
 
     count(FilterArray(NoStartAssignments, true)) > 0
 }

--- a/PowerShell/ScubaGear/RequiredVersions.ps1
+++ b/PowerShell/ScubaGear/RequiredVersions.ps1
@@ -51,11 +51,6 @@ $ModuleList = @(
         MaximumVersion = [version] '2.19.99999'
     },
     @{
-        ModuleName = 'Microsoft.Graph.Beta.Identity.Governance'
-        ModuleVersion = [version] '2.0.0'
-        MaximumVersion = [version] '2.19.99999'
-    },
-    @{
         ModuleName = 'Microsoft.Graph.Beta.Identity.SignIns'
         ModuleVersion = [version] '2.0.0'
         MaximumVersion = [version] '2.19.99999'

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/AADProvider/Invoke-GraphDirectly.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/AADProvider/Invoke-GraphDirectly.ps1
@@ -1,0 +1,21 @@
+$ProviderPath = '../../../../../Modules/Providers'
+Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "$($ProviderPath)/ExportAADProvider.psm1") -Function 'Get-PrivilegedRole' -Force
+
+InModuleScope ExportAADProvider {
+    Describe -Tag 'AADProvider' -Name "Invoke-GraphDirectly" {
+        BeforeAll {
+            Mock -ModuleName ExportAADProvider Invoke-MgGraphRequest {return @{Value = @{cowsound = "moo"}}}
+        }
+
+        It "should return the expected value from Invoke-MgGraphRequest" {
+            $expected = @{cowsound = "moo"}
+            $result = Invoke-Graphdirectly("Get-MgBetaUser")
+            $result.Keys | Should -Be $expected.Keys
+            $result.Values | Should -Be $expected.Values
+        }
+    }
+}
+
+AfterAll {
+    Remove-Module ExportAADProvider -Force -ErrorAction SilentlyContinue
+}

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADBaseConfig.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADBaseConfig.rego
@@ -183,9 +183,9 @@ PrivilegedRoles := [
         "DisplayName": "Global Administrator",
         "Assignments": [
             {
-                "StartDateTime": "/Date(1660328610000)/",
-                "EndDateTime": "/Date(1691006065170)/",
-                "PrincipalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
+                "startDateTime": "/Date(1660328610000)/",
+                "endDateTime": "/Date(1691006065170)/",
+                "principalId": "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
             }
         ],
         "Rules": [
@@ -223,8 +223,8 @@ PrivilegedRoles := [
         "DisplayName": "Privileged Role Administrator",
         "Assignments": [
             {
-                "EndDateTime": "/Date(1691006065170)/",
-                "PrincipalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
+                "endDateTime": "/Date(1691006065170)/",
+                "principalId": "e54ac846-1f5a-4afe-aa69-273b42c3b0c1"
             }
         ],
         "Rules": [

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
@@ -163,7 +163,7 @@ test_AdditionalProperties_Correct_V1 if {
 
 test_AdditionalProperties_Correct_V2 if {
     Roles := json.patch(PrivilegedRoles,
-                [{"op": "add", "path": "0/Assignments/0/EndDateTime", "value": null},
+                [{"op": "add", "path": "0/Assignments/0/endDateTime", "value": null},
                 {"op": "remove", "path": "1"}])
 
     Output := aad.tests with input.privileged_roles as Roles
@@ -177,7 +177,7 @@ test_AdditionalProperties_Correct_V2 if {
 
 test_AdditionalProperties_Correct_V3 if {
     Roles := json.patch(PrivilegedRoles,
-                [{"op": "add", "path": "0/Assignments/0/EndDateTime", "value": null},
+                [{"op": "add", "path": "0/Assignments/0/endDateTime", "value": null},
                 {"op": "remove", "path": "1"}])
 
     Output := aad.tests with input.privileged_roles as Roles
@@ -191,7 +191,7 @@ test_AdditionalProperties_Correct_V3 if {
 
 test_AdditionalProperties_LicenseMissing_V1 if {
     Roles := json.patch(PrivilegedRoles,
-                [{"op": "add", "path": "0/Assignments/0/EndDateTime", "value": null},
+                [{"op": "add", "path": "0/Assignments/0/endDateTime", "value": null},
                 {"op": "add", "path": "1/DisplayName", "value": "Application Administrator"}])
 
     Output := aad.tests with input.privileged_roles as Roles
@@ -205,7 +205,7 @@ test_AdditionalProperties_LicenseMissing_V1 if {
 
 test_AdditionalProperties_Incorrect_V1 if {
     Roles := json.patch(PrivilegedRoles,
-                [{"op": "add", "path": "0/Assignments/0/EndDateTime", "value": null},
+                [{"op": "add", "path": "0/Assignments/0/endDateTime", "value": null},
                 {"op": "remove", "path": "1"}])
 
     Output := aad.tests with input.privileged_roles as Roles
@@ -217,7 +217,7 @@ test_AdditionalProperties_Incorrect_V1 if {
 
 test_AdditionalProperties_Incorrect_V2 if {
     Roles := json.patch(PrivilegedRoles,
-                [{"op": "add", "path": "0/Assignments/0/EndDateTime", "value": null},
+                [{"op": "add", "path": "0/Assignments/0/endDateTime", "value": null},
                 {"op": "add", "path": "1/DisplayName", "value": "Application Administrator"}])
 
     Output := aad.tests with input.privileged_roles as Roles
@@ -229,9 +229,9 @@ test_AdditionalProperties_Incorrect_V2 if {
 
 test_AdditionalProperties_Incorrect_V3 if {
     Roles := json.patch(PrivilegedRoles,
-                [{"op": "add", "path": "0/Assignments/0/EndDateTime", "value": null},
+                [{"op": "add", "path": "0/Assignments/0/endDateTime", "value": null},
                 {"op": "add", "path": "1/DisplayName", "value": "Application Administrator"},
-                {"op": "add", "path": "1/Assignments/0/EndDateTime", "value": null}])
+                {"op": "add", "path": "1/Assignments/0/endDateTime", "value": null}])
 
     Output := aad.tests with input.privileged_roles as Roles
                         with input.service_plans as ServicePlans
@@ -246,10 +246,10 @@ test_AdditionalProperties_Incorrect_V3 if {
 
 test_AdditionalProperties_Incorrect_V4 if {
     Roles := json.patch(PrivilegedRoles,
-                [{"op": "add", "path": "0/Assignments/0/EndDateTime", "value": null},
-                {"op": "add", "path": "0/Assignments/1", "value": {"EndDateTime": null, "PrincipalId":"38035edd-63a1-4c08-8bd2-ad78d0624057"}},
+                [{"op": "add", "path": "0/Assignments/0/endDateTime", "value": null},
+                {"op": "add", "path": "0/Assignments/1", "value": {"endDateTime": null, "principalId":"38035edd-63a1-4c08-8bd2-ad78d0624057"}},
                 {"op": "add", "path": "1/DisplayName", "value": "Application Administrator"},
-                {"op": "add", "path": "1/Assignments/0/EndDateTime", "value": null}])
+                {"op": "add", "path": "1/Assignments/0/endDateTime", "value": null}])
 
     Output := aad.tests with input.privileged_roles as Roles
                         with input.service_plans as ServicePlans
@@ -264,7 +264,7 @@ test_AdditionalProperties_Incorrect_V4 if {
 
 test_AdditionalProperties_Incorrect_V5 if {
     Roles := json.patch(PrivilegedRoles,
-                [{"op": "add", "path": "0/Assignments/0/EndDateTime", "value": null},
+                [{"op": "add", "path": "0/Assignments/0/endDateTime", "value": null},
                 {"op": "remove", "path": "1"}])
 
     Output := aad.tests with input.privileged_roles as Roles
@@ -278,7 +278,7 @@ test_AdditionalProperties_Incorrect_V5 if {
 
 test_AdditionalProperties_Incorrect_V6 if {
     Roles := json.patch(PrivilegedRoles,
-                [{"op": "add", "path": "0/Assignments/0/EndDateTime", "value": null},
+                [{"op": "add", "path": "0/Assignments/0/endDateTime", "value": null},
                 {"op": "add", "path": "1/DisplayName", "value": "Application Administrator"}])
 
     Output := aad.tests with input.privileged_roles as Roles
@@ -292,9 +292,9 @@ test_AdditionalProperties_Incorrect_V6 if {
 
 test_AdditionalProperties_Incorrect_V7 if {
     Roles := json.patch(PrivilegedRoles,
-                [{"op": "add", "path": "0/Assignments/0/EndDateTime", "value": null},
+                [{"op": "add", "path": "0/Assignments/0/endDateTime", "value": null},
                 {"op": "add", "path": "1/DisplayName", "value": "Application Administrator"},
-                {"op": "add", "path": "1/Assignments/0/EndDateTime", "value": null}])
+                {"op": "add", "path": "1/Assignments/0/endDateTime", "value": null}])
 
     Output := aad.tests with input.privileged_roles as Roles
                         with input.service_plans as ServicePlans
@@ -311,10 +311,10 @@ test_AdditionalProperties_Incorrect_V7 if {
 
 test_AdditionalProperties_Incorrect_V8 if {
     Roles := json.patch(PrivilegedRoles,
-                [{"op": "add", "path": "0/Assignments/0/EndDateTime", "value": null},
-                {"op": "add", "path": "0/Assignments/1", "value": {"EndDateTime": null, "PrincipalId":"38035edd-63a1-4c08-8bd2-ad78d0624057"}},
+                [{"op": "add", "path": "0/Assignments/0/endDateTime", "value": null},
+                {"op": "add", "path": "0/Assignments/1", "value": {"endDateTime": null, "principalId":"38035edd-63a1-4c08-8bd2-ad78d0624057"}},
                 {"op": "add", "path": "1/DisplayName", "value": "Application Administrator"},
-                {"op": "add", "path": "1/Assignments/0/EndDateTime", "value": null}])
+                {"op": "add", "path": "1/Assignments/0/endDateTime", "value": null}])
 
     Output := aad.tests with input.privileged_roles as Roles
                         with input.service_plans as ServicePlans
@@ -331,7 +331,7 @@ test_AdditionalProperties_Incorrect_V8 if {
 
 test_AdditionalProperties_Incorrect_V9 if {
     Roles := json.patch(PrivilegedRoles,
-                [{"op": "add", "path": "0/Assignments/0/EndDateTime", "value": null},
+                [{"op": "add", "path": "0/Assignments/0/endDateTime", "value": null},
                 {"op": "add", "path": "1/DisplayName", "value": "Application Administrator"}])
 
     Output := aad.tests with input.privileged_roles as Roles
@@ -345,7 +345,7 @@ test_AdditionalProperties_Incorrect_V9 if {
 
 test_AdditionalProperties_Incorrect_V10 if {
     Roles := json.patch(PrivilegedRoles,
-                [{"op": "add", "path": "0/Assignments/0/EndDateTime", "value": null},
+                [{"op": "add", "path": "0/Assignments/0/endDateTime", "value": null},
                 {"op": "remove", "path": "1"}])
 
     Output := aad.tests with input.privileged_roles as Roles
@@ -359,7 +359,7 @@ test_AdditionalProperties_Incorrect_V10 if {
 
 test_AdditionalProperties_Incorrect_V11 if {
     Roles := json.patch(PrivilegedRoles,
-                [{"op": "add", "path": "0/Assignments/0/EndDateTime", "value": null},
+                [{"op": "add", "path": "0/Assignments/0/endDateTime", "value": null},
                 {"op": "add", "path": "1/DisplayName", "value": "Application Administrator"}])
 
     Output := aad.tests with input.privileged_roles as Roles
@@ -373,9 +373,9 @@ test_AdditionalProperties_Incorrect_V11 if {
 
 test_AdditionalProperties_Incorrect_V12 if {
     Roles := json.patch(PrivilegedRoles,
-                [{"op": "add", "path": "0/Assignments/0/EndDateTime", "value": null},
+                [{"op": "add", "path": "0/Assignments/0/endDateTime", "value": null},
                 {"op": "add", "path": "1/DisplayName", "value": "Application Administrator"},
-                {"op": "add", "path": "1/Assignments/0/EndDateTime", "value": null}])
+                {"op": "add", "path": "1/Assignments/0/endDateTime", "value": null}])
 
     Output := aad.tests with input.privileged_roles as Roles
                         with input.service_plans as ServicePlans
@@ -392,10 +392,10 @@ test_AdditionalProperties_Incorrect_V12 if {
 
 test_AdditionalProperties_Incorrect_V13 if {
     Roles := json.patch(PrivilegedRoles,
-                [{"op": "add", "path": "0/Assignments/0/EndDateTime", "value": null},
-                {"op": "add", "path": "0/Assignments/1", "value": {"EndDateTime": null, "PrincipalId":"38035edd-63a1-4c08-8bd2-ad78d0624057"}},
+                [{"op": "add", "path": "0/Assignments/0/endDateTime", "value": null},
+                {"op": "add", "path": "0/Assignments/1", "value": {"endDateTime": null, "principalId":"38035edd-63a1-4c08-8bd2-ad78d0624057"}},
                 {"op": "add", "path": "1/DisplayName", "value": "Application Administrator"},
-                {"op": "add", "path": "1/Assignments/0/EndDateTime", "value": null}])
+                {"op": "add", "path": "1/Assignments/0/endDateTime", "value": null}])
 
     Output := aad.tests with input.privileged_roles as Roles
                         with input.service_plans as ServicePlans
@@ -412,7 +412,7 @@ test_AdditionalProperties_Incorrect_V13 if {
 
 test_AdditionalProperties_Incorrect_V14 if {
     Roles := json.patch(PrivilegedRoles,
-                [{"op": "add", "path": "0/Assignments/0/EndDateTime", "value": null},
+                [{"op": "add", "path": "0/Assignments/0/endDateTime", "value": null},
                 {"op": "add", "path": "1/DisplayName", "value": "Application Administrator"}])
 
     Output := aad.tests with input.privileged_roles as Roles
@@ -440,7 +440,7 @@ test_Assignments_Correct if {
 
 test_Assignments_Incorrect if {
     Roles := json.patch(PrivilegedRoles,
-                [{"op": "add", "path": "0/Assignments/0/StartDateTime", "value": null},
+                [{"op": "add", "path": "0/Assignments/0/startDateTime", "value": null},
                 {"op": "remove", "path": "1"}])
 
     Output := aad.tests with input.privileged_roles as Roles

--- a/Testing/Functional/Products/TestPlans/aad.g5.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/aad.g5.testplan.yaml
@@ -108,7 +108,7 @@ TestPlan:
     TestDriver: RunCached
     Tests:
       - TestDescription: MS.AAD.7.4v1 Non-Compliant case - User with permanent active assignment
-        #### This test case guarantees that at least one privileged role assignment has an EndDateTime of null
+        #### This test case guarantees that at least one privileged role assignment has an endDateTime of null
         Preconditions:
           - Command: UpdateProviderExport
             Splat:
@@ -117,13 +117,13 @@ TestPlan:
                   - DisplayName: Global Administrator
                     RoleTemplateId: "62e90394-69f5-4237-9190-012177145e10"
                     Assignments:
-                      - EndDateTime: "/Date(1672947244397)/"
-                        PrincipalId: "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
+                      - endDateTime: "/Date(1672947244397)/"
+                        principalId: "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                   - DisplayName: User Administrator
                     RoleTemplateId: "fe930be7-5e62-47db-91af-98c3a49a38b1"
                     Assignments:
-                      - EndDateTime: null
-                        PrincipalId: "ce71e61c-f465-4db6-8d26-5f3e52bdd801"
+                      - endDateTime: null
+                        principalId: "ce71e61c-f465-4db6-8d26-5f3e52bdd801"
         Postconditions: []
         ExpectedResult: false
       - TestDescription: MS.AAD.7.4v1 Compliant case - No users with permanent assignment
@@ -135,13 +135,13 @@ TestPlan:
                   - DisplayName: Global Administrator
                     RoleTemplateId: "62e90394-69f5-4237-9190-012177145e10"
                     Assignments:
-                      - EndDateTime: "/Date(1672947244397)/"
-                        PrincipalId: "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
+                      - endDateTime: "/Date(1672947244397)/"
+                        principalId: "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                   - DisplayName: User Administrator
                     RoleTemplateId: "fe930be7-5e62-47db-91af-98c3a49a38b1"
                     Assignments:
-                      - EndDateTime: "/Date(1672947244397)/"
-                        PrincipalId: "ce71e61c-f465-4db6-8d26-5f3e52bdd801"
+                      - endDateTime: "/Date(1672947244397)/"
+                        principalId: "ce71e61c-f465-4db6-8d26-5f3e52bdd801"
         Postconditions: []
         ExpectedResult: true
 
@@ -149,7 +149,7 @@ TestPlan:
     TestDriver: RunCached
     Tests:
       - TestDescription: MS.AAD.7.5v1 Non-Compliant case - User assigned outside of PIM
-        #### This test case guarantees that at least one privileged role assignment has an StartDateTime of null
+        #### This test case guarantees that at least one privileged role assignment has an startDateTime of null
         Preconditions:
           - Command: UpdateProviderExport
             Splat:
@@ -158,14 +158,14 @@ TestPlan:
                   - DisplayName: Global Administrator
                     RoleTemplateId: "62e90394-69f5-4237-9190-012177145e10"
                     Assignments:
-                      - StartDateTime: "/Date(1672947244397)/"
-                        PrincipalId: "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
+                      - startDateTime: "/Date(1672947244397)/"
+                        principalId: "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     Rules: []
                   - DisplayName: User Administrator
                     RoleTemplateId: "fe930be7-5e62-47db-91af-98c3a49a38b1"
                     Assignments:
-                      - StartDateTime: null
-                        PrincipalId: "ce71e61c-f465-4db6-8d26-5f3e52bdd801"
+                      - startDateTime: null
+                        principalId: "ce71e61c-f465-4db6-8d26-5f3e52bdd801"
         Postconditions: []
         ExpectedResult: false
       - TestDescription: MS.AAD.7.5v1 Compliant case - No users assigned outside of PIM
@@ -177,14 +177,14 @@ TestPlan:
                   - DisplayName: Global Administrator
                     RoleTemplateId: "62e90394-69f5-4237-9190-012177145e10"
                     Assignments:
-                      - StartDateTime: "/Date(1672947244397)/"
-                        PrincipalId: "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
+                      - startDateTime: "/Date(1672947244397)/"
+                        principalId: "ae71e61c-f465-4db6-8d26-5f3e52bdd800"
                     Rules: []
                   - DisplayName: User Administrator
                     RoleTemplateId: "fe930be7-5e62-47db-91af-98c3a49a38b1"
                     Assignments:
-                      - StartDateTime: "/Date(1672947244397)/"
-                        PrincipalId: "ce71e61c-f465-4db6-8d26-5f3e52bdd801"
+                      - startDateTime: "/Date(1672947244397)/"
+                        principalId: "ce71e61c-f465-4db6-8d26-5f3e52bdd801"
                     Rules: []
         Postconditions: []
         ExpectedResult: true

--- a/utils/UninstallModules.ps1
+++ b/utils/UninstallModules.ps1
@@ -24,7 +24,6 @@ $ModuleList = @(
     "Microsoft.Graph.Authentication", # starting here, MS Graph modules for AAD
     "Microsoft.Graph.Beta.Groups",
     "Microsoft.Graph.Beta.Identity.DirectoryManagement",
-    "Microsoft.Graph.Beta.Identity.Governance",
     "Microsoft.Graph.Beta.Identity.SignIns",
     "Microsoft.Graph.Beta.Users",
     "powershell-yaml"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##

*This PR replaces #1094 which became too difficult to deal with since there were heavy merge conflicts - reference that PR for additional details.

The gist of this pull request was to modify the AAD provider so that we replace the Cmdlets in the Microsoft.Graph.Beta.Identity.Governance Powershell module with direct calls to MS Graph REST APIs. We found that the offending Powershell module takes a significant amount of time to load into memory when you call ScubaGear the first time in a fresh Powershell window. The good news was that the RESP API returns the same fields as the Cmdlet, except that the field names begin with a lower case letter so that is why you see those respective changes in the Rego and unit/functional tests as well as references in the AAD provider. 

closes #816

## 🧪 Testing ##

The original code changes were tested against the E5, G5, G3 and GCC High tenants. Additional testing should be done by the reviewers to ensure the code performs as expected and doesn't crash.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] PR passed smoke test check.
- [ ] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [ ] Resolved all merge conflicts on branch
- [ ] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
