### PR TITLE
Allow policies to be omitted from ScubaGear

### DIFF
--- a/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
+++ b/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
@@ -88,7 +88,7 @@ function New-Report {
         "Warnings" = 0;
         "Failures" = 0;
         "Passes" = 0;
-        "Skips" = 0;
+        "Omits" = 0;
         "Manual" = 0;
         "Errors" = 0;
         "Date" = $SettingsExport.date;
@@ -102,30 +102,30 @@ function New-Report {
             $Test = $TestResults | Where-Object -Property PolicyId -eq $Control.Id
 
             if ($null -ne $Test){
-                $Skip = $false
+                $Omit = $false
                 if (Test-Contains $SettingsExport.scuba_config $BaselineName) {
-                    if (Test-Contains $SettingsExport.scuba_config.$BaselineName "IgnorePolicy") {
-                        if (Test-Contains $SettingsExport.scuba_config.$BaselineName.IgnorePolicy $Control.Id) {
-                            $Skip = $true
+                    if (Test-Contains $SettingsExport.scuba_config.$BaselineName "OmitPolicy") {
+                        if (Test-Contains $SettingsExport.scuba_config.$BaselineName.OmitPolicy $Control.Id) {
+                            $Omit = $true
                         }
                     }
                 }
-                if ($Skip) {
-                    $ReportSummary.Skips += 1
-                    $SkipRationale = $SettingsExport.scuba_config.$BaselineName.IgnorePolicy.$($Control.Id)
-                    if ([string]::IsNullOrEmpty($SkipRationale)) {
-                        Write-Warning "Config file indicates skipping $($Control.Id), but no rationale provided."
-                        $SkipRationale = "Rationale not provided."
+                if ($Omit) {
+                    $ReportSummary.Omits += 1
+                    $OmitRationale = $SettingsExport.scuba_config.$BaselineName.OmitPolicy.$($Control.Id)
+                    if ([string]::IsNullOrEmpty($OmitRationale)) {
+                        Write-Warning "Config file indicates omitting $($Control.Id), but no rationale provided."
+                        $OmitRationale = "Rationale not provided."
                     }
                     else {
-                        $SkipRationale = "`"$($SkipRationale)`""
+                        $OmitRationale = "`"$($OmitRationale)`""
                     }
                     $Fragment += [pscustomobject]@{
                         "Control ID"=$Control.Id
                         "Requirement"=$Control.Value
-                        "Result"= "Skipped"
+                        "Result"= "Omitted"
                         "Criticality"= $Test.Criticality
-                        "Details"= "Test skipped by user. $($SkipRationale)"
+                        "Details"= "Test skipped by user. $($OmitRationale)"
                     }
                     continue
                 }

--- a/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
+++ b/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
@@ -120,7 +120,7 @@ function New-Report {
                         "Requirement"=$Control.Value
                         "Result"= "Omitted"
                         "Criticality"= $Test.Criticality
-                        "Details"= "Test disabled by user. $($OmitRationale)"
+                        "Details"= "Test omitted by user. $($OmitRationale)"
                     }
                     continue
                 }

--- a/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
+++ b/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
@@ -301,28 +301,6 @@ function New-Report {
     $ReportSummary
 }
 
-function Test-Contains {
-    <#
-    .Description
-    Tests if a custom PowerShell object contains a given key.
-    .Functionality
-    Internal
-    #>
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory=$true)]
-        [ValidateNotNullOrEmpty()]
-        [PSCustomObject]
-        $Object,
-
-        [Parameter(Mandatory = $false)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $Key
-    )
-    $Object.psobject.properties.name -Contains $Key
-}
-
 function Get-OmissionState {
     <#
     .Description
@@ -343,10 +321,10 @@ function Get-OmissionState {
         $ControlId
     )
     $Omit = $false
-    if (Test-Contains $Config "OmitPolicy") {
-        if (Test-Contains $Config.OmitPolicy $ControlId) {
+    if ($Config.psobject.properties.name -Contains "OmitPolicy") {
+        if ($Config.OmitPolicy.psobject.properties.name -Contains $ControlId) {
             # The config indicates the control should be omitted
-            if (Test-Contains $Config.OmitPolicy.$($ControlId) "Expiration") {
+            if ($Config.OmitPolicy.$($ControlId).psobject.properties.name -Contains "Expiration") {
                 # An expiration date for the omission expiration was provided. Evaluate the date
                 # to see if the control should still be omitted.
                 if ($Config.OmitPolicy.$($ControlId).Expiration -eq "") {

--- a/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
+++ b/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
@@ -88,6 +88,7 @@ function New-Report {
         "Warnings" = 0;
         "Failures" = 0;
         "Passes" = 0;
+        "Skips" = 0;
         "Manual" = 0;
         "Errors" = 0;
         "Date" = $SettingsExport.date;
@@ -110,7 +111,7 @@ function New-Report {
                     }
                 }
                 if ($Skip) {
-                    $ReportSummary.Passes += 1
+                    $ReportSummary.Skips += 1
                     $SkipRationale = $SettingsExport.scuba_config.$BaselineName.IgnorePolicy.$($Control.Id)
                     $Fragment += [pscustomobject]@{
                         "Control ID"=$Control.Id

--- a/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
+++ b/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
@@ -107,7 +107,7 @@ function New-Report {
                 $Omit = Get-OmissionState $Config $Control.Id
                 if ($Omit) {
                     $ReportSummary.Omits += 1
-                    $OmitRationale = $Config.$BaselineName.OmitPolicy.$($Control.Id).Rationale
+                    $OmitRationale = $Config.OmitPolicy.$($Control.Id).Rationale
                     if ([string]::IsNullOrEmpty($OmitRationale)) {
                         Write-Warning "Config file indicates omitting $($Control.Id), but no rationale provided."
                         $OmitRationale = "Rationale not provided."
@@ -343,48 +343,46 @@ function Get-OmissionState {
         $ControlId
     )
     $Omit = $false
-    if (Test-Contains $Config $BaselineName) {
-        if (Test-Contains $Config.$BaselineName "OmitPolicy") {
-            if (Test-Contains $Config.$BaselineName.OmitPolicy $ControlId) {
-                # The config indicates the control should be omitted
-                if (Test-Contains $Config.$BaselineName.OmitPolicy.$($ControlId) "Expiration") {
-                    # An expiration date for the omission expiration was provided. Evaluate the date
-                    # to see if the control should still be omitted.
-                    if ($Config.$BaselineName.OmitPolicy.$($ControlId).Expiration -eq "") {
-                        # If the Expiration date is an empty string, omit the policy
-                        $Omit = $true
-                    }
-                    else {
-                        # An expiration date was provided and it's not an empty string
-                        $Now = Get-Date
-                        $ExpirationString = $Config.$BaselineName.OmitPolicy.$($ControlId).Expiration
-                        try {
-                            $ExpirationDate = Get-Date -Date $ExpirationString
-                            if ($ExpirationDate -lt $Now) {
-                                # The expiration date is passed, don't omit the policy
-                                $Warning = "Config file indicates omitting $($ControlId), but the provided "
-                                $Warning += "expiration date, $ExpirationString, has passed. Control will "
-                                $Warning += "not be omitted."
-                                Write-Warning $Warning
-                            }
-                            else {
-                                # The expiration date is in the future, omit the policy
-                                $Omit = $true
-                            }
-                        }
-                        catch {
-                            # Malformed date, don't omit the policy
-                            $Warning = "Config file indicates omitting $($ControlId), but the provided "
-                            $Warning += "expiration date, $ExpirationString, is malformed. The expected "
-                            $Warning += "format is yyyy-mm-dd. Control will not be omitted."
-                            Write-Warning $Warning
-                        }
-                    }
-                }
-                else {
-                    # The expiration date was not provided, omit the policy
+    if (Test-Contains $Config "OmitPolicy") {
+        if (Test-Contains $Config.OmitPolicy $ControlId) {
+            # The config indicates the control should be omitted
+            if (Test-Contains $Config.OmitPolicy.$($ControlId) "Expiration") {
+                # An expiration date for the omission expiration was provided. Evaluate the date
+                # to see if the control should still be omitted.
+                if ($Config.OmitPolicy.$($ControlId).Expiration -eq "") {
+                    # If the Expiration date is an empty string, omit the policy
                     $Omit = $true
                 }
+                else {
+                    # An expiration date was provided and it's not an empty string
+                    $Now = Get-Date
+                    $ExpirationString = $Config.OmitPolicy.$($ControlId).Expiration
+                    try {
+                        $ExpirationDate = Get-Date -Date $ExpirationString
+                        if ($ExpirationDate -lt $Now) {
+                            # The expiration date is passed, don't omit the policy
+                            $Warning = "Config file indicates omitting $($ControlId), but the provided "
+                            $Warning += "expiration date, $ExpirationString, has passed. Control will "
+                            $Warning += "not be omitted."
+                            Write-Warning $Warning
+                        }
+                        else {
+                            # The expiration date is in the future, omit the policy
+                            $Omit = $true
+                        }
+                    }
+                    catch {
+                        # Malformed date, don't omit the policy
+                        $Warning = "Config file indicates omitting $($ControlId), but the provided "
+                        $Warning += "expiration date, $ExpirationString, is malformed. The expected "
+                        $Warning += "format is yyyy-mm-dd. Control will not be omitted."
+                        Write-Warning $Warning
+                    }
+                }
+            }
+            else {
+                # The expiration date was not provided, omit the policy
+                $Omit = $true
             }
         }
     }

--- a/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
+++ b/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
@@ -113,12 +113,19 @@ function New-Report {
                 if ($Skip) {
                     $ReportSummary.Skips += 1
                     $SkipRationale = $SettingsExport.scuba_config.$BaselineName.IgnorePolicy.$($Control.Id)
+                    if ([string]::IsNullOrEmpty($SkipRationale)) {
+                        Write-Warning "Config file indicates skipping $($Control.Id), but no rationale provided."
+                        $SkipRationale = "Rationale not provided."
+                    }
+                    else {
+                        $SkipRationale = "`"$($SkipRationale)`""
+                    }
                     $Fragment += [pscustomobject]@{
                         "Control ID"=$Control.Id
                         "Requirement"=$Control.Value
                         "Result"= "Skipped"
                         "Criticality"= $Test.Criticality
-                        "Details"= "Test skipped by user. Rationale: `"$($SkipRationale)`""
+                        "Details"= "Test skipped by user. $($SkipRationale)"
                     }
                     continue
                 }
@@ -312,7 +319,7 @@ function Test-Contains {
         [ValidateNotNullOrEmpty()]
         [PSCustomObject]
         $Object,
-        
+
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [string]

--- a/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
+++ b/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
@@ -125,7 +125,7 @@ function New-Report {
                         "Requirement"=$Control.Value
                         "Result"= "Omitted"
                         "Criticality"= $Test.Criticality
-                        "Details"= "Test skipped by user. $($OmitRationale)"
+                        "Details"= "Test disabled by user. $($OmitRationale)"
                     }
                     continue
                 }

--- a/PowerShell/ScubaGear/Modules/CreateReport/scripts/main.js
+++ b/PowerShell/ScubaGear/Modules/CreateReport/scripts/main.js
@@ -25,6 +25,9 @@ const colorRows = () => {
             else if (rows[i].children[statusCol].innerHTML === "Pass") {
                 rows[i].style.background = "var(--test-pass)";
             }
+            else if (rows[i].children[statusCol].innerHTML === "Skipped") {
+                rows[i].style.background = "var(--test-pass)";
+            }
             else if (rows[i].children[criticalityCol].innerHTML.includes("Not-Implemented")) {
                 rows[i].style.background = "var(--test-other)";
             }

--- a/PowerShell/ScubaGear/Modules/CreateReport/scripts/main.js
+++ b/PowerShell/ScubaGear/Modules/CreateReport/scripts/main.js
@@ -25,8 +25,8 @@ const colorRows = () => {
             else if (rows[i].children[statusCol].innerHTML === "Pass") {
                 rows[i].style.background = "var(--test-pass)";
             }
-            else if (rows[i].children[statusCol].innerHTML === "Skipped") {
-                rows[i].style.background = "var(--test-pass)";
+            else if (rows[i].children[statusCol].innerHTML === "Omitted") {
+                rows[i].style.background = "var(--test-other)";
             }
             else if (rows[i].children[criticalityCol].innerHTML.includes("Not-Implemented")) {
                 rows[i].style.background = "var(--test-other)";

--- a/PowerShell/ScubaGear/Modules/CreateReport/styles/ParentReportStyle.css
+++ b/PowerShell/ScubaGear/Modules/CreateReport/styles/ParentReportStyle.css
@@ -15,7 +15,7 @@ footer {
     display: inline-block;
     padding: 0.313em;
     border-radius: 0.313em;
-    min-width: 140px;
+    min-width: 100px;
     text-align: center;
 }
 

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -1005,8 +1005,12 @@ function Invoke-ReportCreation {
                 $LinkPath = "$($IndividualReportFolderName)/$($BaselineName)Report.html"
                 $LinkClassName = '"individual_reports"' # uses no escape characters
                 $Link = "<a class=$($LinkClassName) href='$($LinkPath)'>$($FullName)</a>"
-
-                $PassesSummary = "<div class='summary pass'>$($Report.Passes) tests passed</div>"
+                if ($Report.Skips -gt 0) {
+                    $PassesSummary = "<div class='summary pass'>$($Report.Passes) passed / $($Report.Passes) skipped</div>"
+                }
+                else {
+                    $PassesSummary = "<div class='summary pass'>$($Report.Passes) tests passed</div>"
+                }
                 $WarningsSummary = "<div class='summary'></div>"
                 $FailuresSummary = "<div class='summary'></div>"
                 $BaselineURL = "<a href= `"https://github.com/cisagov/ScubaGear/blob/v$($ModuleVersion)/baselines`" target=`"_blank`"><h3 style=`"width: 100px;`">Baseline Documents</h3></a>"

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -1005,17 +1005,18 @@ function Invoke-ReportCreation {
                 $LinkPath = "$($IndividualReportFolderName)/$($BaselineName)Report.html"
                 $LinkClassName = '"individual_reports"' # uses no escape characters
                 $Link = "<a class=$($LinkClassName) href='$($LinkPath)'>$($FullName)</a>"
-                if ($Report.Skips -gt 0) {
-                    $PassesSummary = "<div class='summary pass'>$($Report.Passes) passed / $($Report.Skips) skipped</div>"
-                }
-                else {
-                    $PassesSummary = "<div class='summary pass'>$($Report.Passes) tests passed</div>"
-                }
+                $PassesSummary = "<div class='summary'></div>"
                 $WarningsSummary = "<div class='summary'></div>"
                 $FailuresSummary = "<div class='summary'></div>"
                 $BaselineURL = "<a href= `"https://github.com/cisagov/ScubaGear/blob/v$($ModuleVersion)/baselines`" target=`"_blank`"><h3 style=`"width: 100px;`">Baseline Documents</h3></a>"
                 $ManualSummary = "<div class='summary'></div>"
-                $ErrorSummary = "<div class='summary'></div>"
+                $OmitSummary = "<div class='summary'></div>"
+                $ErrorSummary = ""
+
+                if ($Report.Passes -gt 0) {
+                    $Noun = Pluralize -SingularNoun "pass" -PluralNoun "passes" -Count $Report.Passes
+                    $PassesSummary = "<div class='summary pass'>$($Report.Passes) $($Noun)</div>"
+                }
 
                 if ($Report.Warnings -gt 0) {
                     $Noun = Pluralize -SingularNoun "warning" -PluralNoun "warnings" -Count $Report.Warnings
@@ -1023,13 +1024,17 @@ function Invoke-ReportCreation {
                 }
 
                 if ($Report.Failures -gt 0) {
-                    $Noun = Pluralize -SingularNoun "test" -PluralNoun "tests" -Count $Report.Failures
-                    $FailuresSummary = "<div class='summary failure'>$($Report.Failures) $($Noun) failed</div>"
+                    $Noun = Pluralize -SingularNoun "failure" -PluralNoun "failures" -Count $Report.Failures
+                    $FailuresSummary = "<div class='summary failure'>$($Report.Failures) $($Noun)</div>"
                 }
 
                 if ($Report.Manual -gt 0) {
                     $Noun = Pluralize -SingularNoun "check" -PluralNoun "checks" -Count $Report.Manual
-                    $ManualSummary = "<div class='summary manual'>$($Report.Manual) manual $($Noun) needed</div>"
+                    $ManualSummary = "<div class='summary manual'>$($Report.Manual) manual $($Noun)</div>"
+                }
+
+                if ($Report.Omits -gt 0) {
+                    $OmitSummary = "<div class='summary manual'>$($Report.Omits) omitted</div>"
                 }
 
                 if ($Report.Errors -gt 0) {
@@ -1039,7 +1044,7 @@ function Invoke-ReportCreation {
 
                 $Fragment += [pscustomobject]@{
                 "Baseline Conformance Reports" = $Link;
-                "Details" = "$($PassesSummary) $($WarningsSummary) $($FailuresSummary) $($ManualSummary) $($ErrorSummary)"
+                "Details" = "$($PassesSummary) $($WarningsSummary) $($FailuresSummary) $($ManualSummary) $($OmitSummary) $($ErrorSummary)"
                 }
             }
             $TenantMetaData += [pscustomobject]@{

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -1006,7 +1006,7 @@ function Invoke-ReportCreation {
                 $LinkClassName = '"individual_reports"' # uses no escape characters
                 $Link = "<a class=$($LinkClassName) href='$($LinkPath)'>$($FullName)</a>"
                 if ($Report.Skips -gt 0) {
-                    $PassesSummary = "<div class='summary pass'>$($Report.Passes) passed / $($Report.Passes) skipped</div>"
+                    $PassesSummary = "<div class='summary pass'>$($Report.Passes) passed / $($Report.Skips) skipped</div>"
                 }
                 else {
                     $PassesSummary = "<div class='summary pass'>$($Report.Passes) tests passed</div>"

--- a/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfig.psm1
+++ b/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfig.psm1
@@ -56,6 +56,29 @@ class ScubaConfig {
         $this.SetParameterDefaults()
         [ScubaConfig]::_IsLoaded = $true
 
+        # If OmitPolicy was included in the config file, validate the policy IDs included there.
+        if ($this.Configuration.ContainsKey("OmitPolicy")) {
+            foreach ($Policy in $this.Configuration.OmitPolicy.Keys) {
+                if (-not ($Policy -match "^ms\.[a-z]+\.[0-9]+\.[0-9]+v[0-9]+$")) {
+                    # Note that -match is a case insensitive match
+                    # Note that the regex does not validate the product name, this will be done later
+                    $Warning = "Config file indicates omitting $Policy, but $Policy is not a valid control ID. "
+                    $Warning += "Expected format is 'MS.[PRODUCT].[GROUP].[NUMBER]v[VERSION]', "
+                    $Warning += "e.g., 'MS.DEFENDER.1.1v1'. Control will not be omitted."
+                    Write-Warning $Warning
+                    Continue
+                }
+                $Product = ($Policy -Split "\.")[1]
+                # Here's where the product name is validated
+                if (-not ($this.Configuration.ProductNames -Contains $Product)) {
+                    $Warning = "Config file indicates omitting $Policy, but $Product is not one of the products "
+                    $Warning += "specified in the ProductNames parameter. Control will not be omitted."
+                    Write-Warning $Warning
+                    Continue
+                }
+            }
+        }
+
         return [ScubaConfig]::_IsLoaded
     }
 

--- a/PowerShell/ScubaGear/Modules/Support/Support.psm1
+++ b/PowerShell/ScubaGear/Modules/Support/Support.psm1
@@ -728,6 +728,9 @@ function New-Config {
     parameters. Additional parameters and variables not available on the
     command line can also be included in the file that will be provided to the
     tool for use in specific tests.
+    .Parameter OmitPolicy
+    A comma-separated list of policies to exclude from the ScubaGear report, e.g., MS.DEFENDER.1.1v1.
+    Note that the rationales will need to be manually added to the resulting config file.
     .Functionality
     Public
     #>
@@ -812,7 +815,12 @@ function New-Config {
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [string]
-        $ConfigLocation = "./"
+        $ConfigLocation = "./",
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        $OmitPolicy = @()
     )
 
     $Config = New-Object ([System.Collections.specialized.OrderedDictionary])
@@ -823,6 +831,12 @@ function New-Config {
             #$config[$_] = $val
             $Config.add($_, $Val)
         }
+    }
+
+    if ($config.Contains("OmitPolicy")) {
+        # We don't want this parameter to be saved as a top-level key in the config, as this
+        # isn't the place ScubaGear will look for it.
+        $config.Remove("OmitPolicy")
     }
 
     $CapExclusionNamespace = @(
@@ -849,6 +863,49 @@ function New-Config {
 
     $PartnerDomainImpersonationProtectionNamespace = "MS.DEFENDER.2.3v1"
 
+    $OmissionNamespace = "OmitPolicy"
+
+    # List to track which policies the user specified in $OmitPolicies are properly formatted
+    $OmitPolicyValidated = @()
+
+    # Hashmap to structure the ignored policies template
+    $OmitTemplate = @{}
+
+    foreach ($Policy in $OmitPolicy) {
+        if (-not ($Policy -match "^ms\.[a-z]+\.[0-9]+\.[0-9]+v[0-9]+$")) {
+            # Note that -match is a case insensitive match
+            # Note that the regex does not validate the product name, this will be done
+            # later
+            $Warning = "The policy, $Policy, in the OmitPolicy parameter, is not a valid "
+            $Warning += "policy ID. Expected format 'MS.[PRODUCT].[GROUP].[NUMBER]v[VERSION]', "
+            $Warning += "e.g., 'MS.DEFENDER.1.1v1'. Skipping."
+            Write-Warning $Warning
+            Continue
+        }
+        $Product = ($Policy -Split "\.")[1]
+        # Here's where the product name is validated
+        if (-not ($ProductNames -Contains $Product)) {
+            $Warning = "The policy, $Policy, in the OmitPolicy parameter, is not encompassed by "
+            $Warning += "the products specified in the ProductName parameter. Skipping."
+            Write-Warning $Warning
+            Continue
+        }
+        if (-not $OmitTemplate.ContainsKey($Product)) {
+            $OmitTemplate[$Product] = @{ $OmissionNamespace = @{} }
+        }
+        # Ensure the policy ID is properly capitalized (i.e., all caps except for the "v1" portion)
+        $PolicyCapitalized = $Policy.Substring(0, $Policy.Length-2).ToUpper() + $Policy.SubString($Policy.Length-2)
+        $OmitPolicyValidated += $PolicyCapitalized
+        $OmitTemplate[$Product][$OmissionNamespace][$PolicyCapitalized] = @{
+            "Rationale" = "";
+            "Expiration" = "";
+        }
+    }
+
+    $Warning = "The following policies have been configured for omission: $($OmitPolicyValidated -Join ', '). "
+    $Warning += "Note that as the New-Config function does not support providing the rationale for omission via "
+    $Warning += "the commandline, you will need to open the resulting config file and manually enter the rationales."
+    Write-Warning $Warning
 
     $AadTemplate = New-Object ([System.Collections.specialized.OrderedDictionary])
     $AadCapExclusions = New-Object ([System.Collections.specialized.OrderedDictionary])
@@ -901,6 +958,17 @@ function New-Config {
             "defender" {
                 $config.add("Defender", $DefenderTemplate)
                 }
+        }
+    }
+    foreach ($Product in $Products) {
+        if ($OmitTemplate.ContainsKey($Product)) {
+            $ProductTitleCase = $Product.Substring(0, 1).ToUpper()+$Product.ToLower().Substring(1).ToLower()
+            if ($config.Contains($ProductTitleCase)) {
+                $config[$ProductTitleCase][$OmissionNamespace] = $OmitTemplate[$Product][$OmissionNamespace]
+            }
+            else {
+                $config.add($ProductTitleCase, $OmitTemplate[$Product])
+            }
         }
     }
     convertto-yaml $Config | set-content "$($ConfigLocation)/SampleConfig.yaml"

--- a/PowerShell/ScubaGear/Sample-Config-Files/ignore_policies.yaml
+++ b/PowerShell/ScubaGear/Sample-Config-Files/ignore_policies.yaml
@@ -7,6 +7,8 @@ Description: |
   program process and practices.
 ProductNames:
   - exo
+  - teams
+  - defender
 M365Environment: commercial
 OPAPath: .
 LogIn: true
@@ -17,18 +19,37 @@ OutProviderFileName: ProviderSettingsExport
 OutRegoFileName: TestResults
 OutReportName: BaselineReports
 Exo:
-  MS.EXO.4.3v1:
-    Ignore: true
-    IgnoreRationale:
-      "This policy is not applicable to our company as it only applies
-      to federal, executive branch, departments and agencies."
-Defender:
-  MS.DEFENDER.2.1v1:
-    Ignore: true
-    IgnoreRationale: "Phishing protections provided by a third-party service."
-  MS.DEFENDER.2.2v1:
-    Ignore: true
-    IgnoreRationale: "Phishing protections provided by a third-party service."
-  MS.DEFENDER.2.3v1:
-    Ignore: true
-    IgnoreRationale: "Phishing protections provided by a third-party service."
+  IgnorePolicy:
+    MS.EXO.4.3v1: "This policy is not applicable to our company as it only applies
+        to federal, executive branch, departments and agencies." # Assuming this config file corresponds to a private
+        # company, not a gov entity
+    MS.EXO.8.1v1: &DefenderRationale "Service provided via Microsoft M365 Defender."
+    MS.EXO.8.2v1: *DefenderRationale
+    MS.EXO.9.1v1: *DefenderRationale
+    MS.EXO.9.2v1: *DefenderRationale
+    MS.EXO.9.3v1: *DefenderRationale
+    MS.EXO.10.1v1: *DefenderRationale
+    MS.EXO.10.2v1: *DefenderRationale
+    MS.EXO.10.3v1: *DefenderRationale
+    MS.EXO.11.1v1: *DefenderRationale
+    MS.EXO.11.2v1: *DefenderRationale
+    MS.EXO.11.3v1: *DefenderRationale
+    MS.EXO.14.1v1: *DefenderRationale
+    MS.EXO.14.2v1: *DefenderRationale
+    MS.EXO.14.3v1: *DefenderRationale
+    MS.EXO.15.1v1: *DefenderRationale
+    MS.EXO.15.2v1: *DefenderRationale
+    MS.EXO.15.3v1: *DefenderRationale
+    MS.EXO.16.1v1: *DefenderRationale
+    MS.EXO.16.2v1: *DefenderRationale
+    MS.EXO.17.1v1: *DefenderRationale
+    MS.EXO.17.2v1: *DefenderRationale
+    MS.EXO.17.3v1: *DefenderRationale
+Teams:
+  IgnorePolicy:
+    MS.TEAMS.6.1v1: *DefenderRationale
+    MS.TEAMS.6.2v1: *DefenderRationale
+    MS.TEAMS.7.1v1: *DefenderRationale
+    MS.TEAMS.7.2v1: *DefenderRationale
+    MS.TEAMS.8.1v1: *DefenderRationale
+    MS.TEAMS.8.2v1: *DefenderRationale

--- a/PowerShell/ScubaGear/Sample-Config-Files/ignore_policies.yaml
+++ b/PowerShell/ScubaGear/Sample-Config-Files/ignore_policies.yaml
@@ -1,0 +1,34 @@
+Description: |
+  SCuBAGear YAML Configuration file with custom variables
+  This configuration shows a standard SCuBAGear set of parameters to run
+  but also includes examples of configuring specific policies to be ignored
+  by ScubaGear baseline. Any ignored policies should be carefully considered
+  and documented as part of an organization's cybersecurity risk management
+  program process and practices.
+ProductNames:
+  - exo
+M365Environment: commercial
+OPAPath: .
+LogIn: true
+DisconnectOnExit: false
+OutPath: .
+OutFolderName: M365BaselineConformance
+OutProviderFileName: ProviderSettingsExport
+OutRegoFileName: TestResults
+OutReportName: BaselineReports
+Exo:
+  MS.EXO.4.3v1:
+    Ignore: true
+    IgnoreRationale:
+      "This policy is not applicable to our company as it only applies
+      to federal, executive branch, departments and agencies."
+Defender:
+  MS.DEFENDER.2.1v1:
+    Ignore: true
+    IgnoreRationale: "Phishing protections provided by a third-party service."
+  MS.DEFENDER.2.2v1:
+    Ignore: true
+    IgnoreRationale: "Phishing protections provided by a third-party service."
+  MS.DEFENDER.2.3v1:
+    Ignore: true
+    IgnoreRationale: "Phishing protections provided by a third-party service."

--- a/PowerShell/ScubaGear/Sample-Config-Files/omit_policies.yaml
+++ b/PowerShell/ScubaGear/Sample-Config-Files/omit_policies.yaml
@@ -18,71 +18,20 @@ OutFolderName: M365BaselineConformance
 OutProviderFileName: ProviderSettingsExport
 OutRegoFileName: TestResults
 OutReportName: BaselineReports
-Exo:
-  OmitPolicy:
-    MS.EXO.2.2v1:
-      Rationale: "Known false positive; our SPF policy currently cannot to be retrieved via ScubaGear due to a split
-        horizon setup but is available publicly."
-      Expiration: "2023-1231"
-    MS.EXO.4.3v1:
-      Rationale: "This policy is not applicable to our company as it only applies
-        to federal, executive branch, departments and agencies."
-        # Assuming this config file corresponds to a private company, not a gov entity
-    MS.EXO.8.1v1:
-      Rationale: &DefenderRationale "Service provided via Microsoft M365 Defender."
-    MS.EXO.8.2v1:
-      Rationale: *DefenderRationale
-    MS.EXO.9.1v1:
-      Rationale: *DefenderRationale
-    MS.EXO.9.2v1:
-      Rationale: *DefenderRationale
-    MS.EXO.9.3v1:
-      Rationale: *DefenderRationale
-    MS.EXO.10.1v1:
-      Rationale: *DefenderRationale
-    MS.EXO.10.2v1:
-      Rationale: *DefenderRationale
-    MS.EXO.10.3v1:
-      Rationale: *DefenderRationale
-    MS.EXO.11.1v1:
-      Rationale: *DefenderRationale
-    MS.EXO.11.2v1:
-      Rationale: *DefenderRationale
-    MS.EXO.11.3v1:
-      Rationale: *DefenderRationale
-    MS.EXO.14.1v1:
-      Rationale: *DefenderRationale
-    MS.EXO.14.2v1:
-      Rationale: *DefenderRationale
-    MS.EXO.14.3v1:
-      Rationale: *DefenderRationale
-    MS.EXO.15.1v1:
-      Rationale: *DefenderRationale
-    MS.EXO.15.2v1:
-      Rationale: *DefenderRationale
-    MS.EXO.15.3v1:
-      Rationale: *DefenderRationale
-    MS.EXO.16.1v1:
-      Rationale: *DefenderRationale
-    MS.EXO.16.2v1:
-      Rationale: *DefenderRationale
-    MS.EXO.17.1v1:
-      Rationale: *DefenderRationale
-    MS.EXO.17.2v1:
-      Rationale: *DefenderRationale
-    MS.EXO.17.3v1:
-      Rationale: *DefenderRationale
-Teams:
-  OmitPolicy:
-    MS.TEAMS.6.1v1:
-      Rationale: *DefenderRationale
-    MS.TEAMS.6.2v1:
-      Rationale: *DefenderRationale
-    MS.TEAMS.7.1v1:
-      Rationale: *DefenderRationale
-    MS.TEAMS.7.2v1:
-      Rationale: *DefenderRationale
-    MS.TEAMS.8.1v1:
-      Rationale: *DefenderRationale
-    MS.TEAMS.8.2v1:
-      Rationale: *DefenderRationale
+OmitPolicy:
+  MS.EXO.2.2v1:
+    Rationale: "Known false positive; our SPF policy currently cannot to be retrieved via ScubaGear due to a split
+      horizon setup but is available publicly."
+    Expiration: "2023-12-31"
+  MS.TEAMS.6.1v1:
+    Rationale: &DefenderRationale "Service provided via Microsoft M365 Defender."
+  MS.TEAMS.6.2v1:
+    Rationale: *DefenderRationale
+  MS.TEAMS.7.1v1:
+    Rationale: *DefenderRationale
+  MS.TEAMS.7.2v1:
+    Rationale: *DefenderRationale
+  MS.TEAMS.8.1v1:
+    Rationale: *DefenderRationale
+  MS.TEAMS.8.2v1:
+    Rationale: *DefenderRationale

--- a/PowerShell/ScubaGear/Sample-Config-Files/omit_policies.yaml
+++ b/PowerShell/ScubaGear/Sample-Config-Files/omit_policies.yaml
@@ -18,7 +18,6 @@ OutFolderName: M365BaselineConformance
 OutProviderFileName: ProviderSettingsExport
 OutRegoFileName: TestResults
 OutReportName: BaselineReports
-Organization: "cisaent.onmicrosoft.com"
 Exo:
   OmitPolicy:
     MS.EXO.2.2v1:

--- a/PowerShell/ScubaGear/Sample-Config-Files/omit_policies.yaml
+++ b/PowerShell/ScubaGear/Sample-Config-Files/omit_policies.yaml
@@ -1,8 +1,8 @@
 Description: |
   SCuBAGear YAML Configuration file with custom variables
   This configuration shows a standard SCuBAGear set of parameters to run
-  but also includes examples of configuring specific policies to be ignored
-  by ScubaGear baseline. Any ignored policies should be carefully considered
+  but also includes examples of configuring specific policies to be omitted
+  from the ScubaGear output. Any omitted policies should be carefully considered
   and documented as part of an organization's cybersecurity risk management
   program process and practices.
 ProductNames:
@@ -18,38 +18,72 @@ OutFolderName: M365BaselineConformance
 OutProviderFileName: ProviderSettingsExport
 OutRegoFileName: TestResults
 OutReportName: BaselineReports
+Organization: "cisaent.onmicrosoft.com"
 Exo:
   OmitPolicy:
-    MS.EXO.4.3v1: "This policy is not applicable to our company as it only applies
-        to federal, executive branch, departments and agencies." # Assuming this config file corresponds to a private
-        # company, not a gov entity
-    MS.EXO.8.1v1: &DefenderRationale "Service provided via Microsoft M365 Defender."
-    MS.EXO.8.2v1: *DefenderRationale
-    MS.EXO.9.1v1: *DefenderRationale
-    MS.EXO.9.2v1: *DefenderRationale
-    MS.EXO.9.3v1: *DefenderRationale
-    MS.EXO.10.1v1: *DefenderRationale
-    MS.EXO.10.2v1: *DefenderRationale
-    MS.EXO.10.3v1: *DefenderRationale
-    MS.EXO.11.1v1: *DefenderRationale
-    MS.EXO.11.2v1: *DefenderRationale
-    MS.EXO.11.3v1: *DefenderRationale
-    MS.EXO.14.1v1: *DefenderRationale
-    MS.EXO.14.2v1: *DefenderRationale
-    MS.EXO.14.3v1: *DefenderRationale
-    MS.EXO.15.1v1: *DefenderRationale
-    MS.EXO.15.2v1: *DefenderRationale
-    MS.EXO.15.3v1: *DefenderRationale
-    MS.EXO.16.1v1: *DefenderRationale
-    MS.EXO.16.2v1: *DefenderRationale
-    MS.EXO.17.1v1: *DefenderRationale
-    MS.EXO.17.2v1: *DefenderRationale
-    MS.EXO.17.3v1: *DefenderRationale
+    MS.EXO.2.2v1:
+      Rationale: "Known false positive; our SPF policy currently cannot to be retrieved via ScubaGear due to a split
+        horizon setup but is available publicly."
+      Expiration: "2023-1231"
+    MS.EXO.4.3v1:
+      Rationale: "This policy is not applicable to our company as it only applies
+        to federal, executive branch, departments and agencies."
+        # Assuming this config file corresponds to a private company, not a gov entity
+    MS.EXO.8.1v1:
+      Rationale: &DefenderRationale "Service provided via Microsoft M365 Defender."
+    MS.EXO.8.2v1:
+      Rationale: *DefenderRationale
+    MS.EXO.9.1v1:
+      Rationale: *DefenderRationale
+    MS.EXO.9.2v1:
+      Rationale: *DefenderRationale
+    MS.EXO.9.3v1:
+      Rationale: *DefenderRationale
+    MS.EXO.10.1v1:
+      Rationale: *DefenderRationale
+    MS.EXO.10.2v1:
+      Rationale: *DefenderRationale
+    MS.EXO.10.3v1:
+      Rationale: *DefenderRationale
+    MS.EXO.11.1v1:
+      Rationale: *DefenderRationale
+    MS.EXO.11.2v1:
+      Rationale: *DefenderRationale
+    MS.EXO.11.3v1:
+      Rationale: *DefenderRationale
+    MS.EXO.14.1v1:
+      Rationale: *DefenderRationale
+    MS.EXO.14.2v1:
+      Rationale: *DefenderRationale
+    MS.EXO.14.3v1:
+      Rationale: *DefenderRationale
+    MS.EXO.15.1v1:
+      Rationale: *DefenderRationale
+    MS.EXO.15.2v1:
+      Rationale: *DefenderRationale
+    MS.EXO.15.3v1:
+      Rationale: *DefenderRationale
+    MS.EXO.16.1v1:
+      Rationale: *DefenderRationale
+    MS.EXO.16.2v1:
+      Rationale: *DefenderRationale
+    MS.EXO.17.1v1:
+      Rationale: *DefenderRationale
+    MS.EXO.17.2v1:
+      Rationale: *DefenderRationale
+    MS.EXO.17.3v1:
+      Rationale: *DefenderRationale
 Teams:
   OmitPolicy:
-    MS.TEAMS.6.1v1: *DefenderRationale
-    MS.TEAMS.6.2v1: *DefenderRationale
-    MS.TEAMS.7.1v1: *DefenderRationale
-    MS.TEAMS.7.2v1: *DefenderRationale
-    MS.TEAMS.8.1v1: *DefenderRationale
-    MS.TEAMS.8.2v1: *DefenderRationale
+    MS.TEAMS.6.1v1:
+      Rationale: *DefenderRationale
+    MS.TEAMS.6.2v1:
+      Rationale: *DefenderRationale
+    MS.TEAMS.7.1v1:
+      Rationale: *DefenderRationale
+    MS.TEAMS.7.2v1:
+      Rationale: *DefenderRationale
+    MS.TEAMS.8.1v1:
+      Rationale: *DefenderRationale
+    MS.TEAMS.8.2v1:
+      Rationale: *DefenderRationale

--- a/PowerShell/ScubaGear/Sample-Config-Files/omit_policies.yaml
+++ b/PowerShell/ScubaGear/Sample-Config-Files/omit_policies.yaml
@@ -17,9 +17,6 @@ OutFolderName: M365BaselineConformance
 OutProviderFileName: ProviderSettingsExport
 OutRegoFileName: TestResults
 OutReportName: BaselineReports
-CertificateThumbPrint: "51E15BC936056EF821CE6728364F057651260074"
-AppID: "76e2fe6c-af3f-49f7-a6aa-65d53c58c91b"
-Organization: "cisaent.onmicrosoft.com"
 OmitPolicy:
   MS.EXO.2.2v1:
     Rationale: "Known false positive; our SPF policy currently cannot to be retrieved via ScubaGear due to a split

--- a/PowerShell/ScubaGear/Sample-Config-Files/omit_policies.yaml
+++ b/PowerShell/ScubaGear/Sample-Config-Files/omit_policies.yaml
@@ -8,7 +8,6 @@ Description: |
 ProductNames:
   - exo
   - teams
-  - defender
 M365Environment: commercial
 OPAPath: .
 LogIn: true
@@ -18,20 +17,16 @@ OutFolderName: M365BaselineConformance
 OutProviderFileName: ProviderSettingsExport
 OutRegoFileName: TestResults
 OutReportName: BaselineReports
+CertificateThumbPrint: "51E15BC936056EF821CE6728364F057651260074"
+AppID: "76e2fe6c-af3f-49f7-a6aa-65d53c58c91b"
+Organization: "cisaent.onmicrosoft.com"
 OmitPolicy:
   MS.EXO.2.2v1:
     Rationale: "Known false positive; our SPF policy currently cannot to be retrieved via ScubaGear due to a split
       horizon setup but is available publicly."
     Expiration: "2023-12-31"
   MS.TEAMS.6.1v1:
-    Rationale: &DefenderRationale "Service provided via Microsoft M365 Defender."
+    Rationale: &DLPRationale "The DLP capability required for Teams is implemented by third party product, [x],
+      which ScubaGear does not have the ability to check."
   MS.TEAMS.6.2v1:
-    Rationale: *DefenderRationale
-  MS.TEAMS.7.1v1:
-    Rationale: *DefenderRationale
-  MS.TEAMS.7.2v1:
-    Rationale: *DefenderRationale
-  MS.TEAMS.8.1v1:
-    Rationale: *DefenderRationale
-  MS.TEAMS.8.2v1:
-    Rationale: *DefenderRationale
+    Rationale: *DLPRationale

--- a/PowerShell/ScubaGear/Sample-Config-Files/omit_policies.yaml
+++ b/PowerShell/ScubaGear/Sample-Config-Files/omit_policies.yaml
@@ -19,7 +19,7 @@ OutProviderFileName: ProviderSettingsExport
 OutRegoFileName: TestResults
 OutReportName: BaselineReports
 Exo:
-  IgnorePolicy:
+  OmitPolicy:
     MS.EXO.4.3v1: "This policy is not applicable to our company as it only applies
         to federal, executive branch, departments and agencies." # Assuming this config file corresponds to a private
         # company, not a gov entity
@@ -46,7 +46,7 @@ Exo:
     MS.EXO.17.2v1: *DefenderRationale
     MS.EXO.17.3v1: *DefenderRationale
 Teams:
-  IgnorePolicy:
+  OmitPolicy:
     MS.TEAMS.6.1v1: *DefenderRationale
     MS.TEAMS.6.2v1: *DefenderRationale
     MS.TEAMS.7.1v1: *DefenderRationale

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/CreateReport/Get-OmissionState.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/CreateReport/Get-OmissionState.Tests.ps1
@@ -1,0 +1,102 @@
+Import-Module (Join-Path -Path $PSScriptRoot -ChildPath '../../../../Modules/CreateReport')
+
+InModuleScope CreateReport {
+    Describe -Tag CreateReport -Name 'Get-OmissionState' {
+        BeforeAll {
+            Mock -CommandName Write-Warning {}
+        }
+
+        Context "When no expiration date is provided" {
+            It 'Returns false if the policy ID is not in the config' {
+                # If the policy is not in the config, the expriation date is N/A and the function
+                # should mark the policy as not omitted.
+                $Config = [PSCustomObject]@{
+                    "OmitPolicy" = [PSCustomObject]@{
+                        "MS.EXO.1.1v1" = [PSCustomObject]@{ "Rationale" = "Example rationale" }
+                    }
+                }
+                $Result = Get-OmissionState $Config "MS.DEFENDER.1.1v1"
+                $Result | Should -Be $false
+                Should -Invoke -CommandName Write-Warning -Exactly -Times 0
+            }
+
+            It 'Returns true if the policy ID is in the config' {
+                # If the policy is in the config and the expriation date is not provided, as the
+                # expiration date is optional, the function should mark the policy as omitted.
+                $Config = [PSCustomObject]@{
+                    "OmitPolicy" = [PSCustomObject]@{
+                        "MS.DEFENDER.1.1v1" = [PSCustomObject]@{ "Rationale" = "Example rationale" }
+                    }
+                }
+                $Result = Get-OmissionState $Config "MS.DEFENDER.1.1v1"
+                $Result | Should -Be $true
+                Should -Invoke -CommandName Write-Warning -Exactly -Times 0
+            }
+        }
+
+        Context "When an expiration date is provided" {
+            BeforeAll {
+                Mock -CommandName Get-Date {
+                    # Modify the Get-Date function so that it returns a fixed date when
+                    # no date is provided, instead of the current time.
+                    if ($null -eq $Date) {
+                        Get-Date -Date "2024-01-02"
+                    }
+                    else {
+                        # If a specific date is requested, operate as normal
+                        $Date
+                    }
+                }
+            }
+
+            It 'Returns true if the expiration is in the future' {
+                # If the date is in the future, the function should still mark the
+                # policy as not omitted.
+                $Config = [PSCustomObject]@{
+                    "OmitPolicy" = [PSCustomObject]@{
+                        "MS.DEFENDER.1.1v1" = [PSCustomObject]@{
+                            "Rationale" = "Example rationale";
+                            "Expiration" = "2024-01-03" }
+                    }
+                }
+                $Result = Get-OmissionState $Config "MS.DEFENDER.1.1v1"
+                $Result | Should -Be $true
+                Should -Invoke -CommandName Write-Warning -Exactly -Times 0
+            }
+
+            It 'Returns false and warns if the expiration is in the past' {
+                # If the date is in the past, the functions should warn the user
+                # and mark the policy as not omitted.
+                $Config = [PSCustomObject]@{
+                    "OmitPolicy" = [PSCustomObject]@{
+                        "MS.DEFENDER.1.1v1" = [PSCustomObject]@{
+                            "Rationale" = "Example rationale";
+                            "Expiration" = "2024-01-01" }
+                    }
+                }
+                $Result = Get-OmissionState $Config "MS.DEFENDER.1.1v1"
+                $Result | Should -Be $false
+                Should -Invoke -CommandName Write-Warning -Exactly -Times 1
+            }
+
+            It 'Returns false and warns if the expiration is malformed' {
+                # The functions should recognize that the date is malformed, warn the user,
+                # and mark the policy as not omitted.
+                $Config = [PSCustomObject]@{
+                    "OmitPolicy" = [PSCustomObject]@{
+                        "MS.DEFENDER.1.1v1" = [PSCustomObject]@{
+                            "Rationale" = "Example rationale";
+                            "Expiration" = "bad date" }
+                    }
+                }
+                $Result = Get-OmissionState $Config "MS.DEFENDER.1.1v1"
+                $Result | Should -Be $false
+                Should -Invoke -CommandName Write-Warning -Exactly -Times 1
+            }
+        }
+    }
+
+    AfterAll {
+        Remove-Module CreateReport -ErrorAction SilentlyContinue
+    }
+}

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/CreateReport/Get-OmissionState.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/CreateReport/Get-OmissionState.Tests.ps1
@@ -93,6 +93,20 @@ InModuleScope CreateReport {
                 $Result | Should -Be $false
                 Should -Invoke -CommandName Write-Warning -Exactly -Times 1
             }
+
+            It 'Returns false if the ID is malformed' {
+                # The functions should recognize that the ID is malformed
+                # and mark the policy as not omitted.
+                $Config = [PSCustomObject]@{
+                    "OmitPolicy" = [PSCustomObject]@{
+                        "MSDEFENDER.1.1v1" = [PSCustomObject]@{
+                            "Rationale" = "Example rationale";
+                        }
+                    }
+                }
+                $Result = Get-OmissionState $Config "MS.DEFENDER.1.1v1"
+                $Result | Should -Be $false
+            }
         }
     }
 

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfigLoadConfig.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfigLoadConfig.Tests.ps1
@@ -2,11 +2,12 @@ using module '..\..\..\..\Modules\ScubaConfig\ScubaConfig.psm1'
 
 InModuleScope ScubaConfig {
     Describe -tag "Utils" -name 'ScubaConfigLoadConfig' {
+        BeforeAll {
+            Mock -CommandName Write-Warning {}
+            function Get-ScubaDefault {throw 'this will be mocked'}
+            Mock -ModuleName ScubaConfig Get-ScubaDefault {"."}
+        }
         context 'Handling repeated LoadConfig invocations' {
-            BeforeAll {
-                function Get-ScubaDefault {throw 'this will be mocked'}
-                Mock -ModuleName ScubaConfig Get-ScubaDefault {"."}
-            }
             It 'Load valid config file followed by another'{
                 $cfg = [ScubaConfig]::GetInstance()
                 # Load the first file and check the ProductNames value.
@@ -25,9 +26,44 @@ InModuleScope ScubaConfig {
                 }
                 [ScubaConfig]::GetInstance().LoadConfig($PSCommandPath) | Should -BeTrue
                 $cfg.Configuration.ProductNames | Should -Be 'exo'
+                Should -Invoke -CommandName Write-Warning -Exactly -Times 0
             }
             AfterAll {
                 [ScubaConfig]::ResetInstance()
+            }
+        }
+        context "Handling policy omissions" {
+            It 'Does not warn for proper control IDs' {
+                function global:ConvertFrom-Yaml {
+                    @{
+                        ProductNames=@('exo');
+                        OmitPolicy=@{"MS.EXO.1.1v1"=@{"Rationale"="Example rationale"}}
+                    }
+                }
+                [ScubaConfig]::GetInstance().LoadConfig($PSCommandPath) | Should -BeTrue
+                Should -Invoke -CommandName Write-Warning -Exactly -Times 0
+            }
+
+            It 'Warns for malformed control IDs' {
+                function global:ConvertFrom-Yaml {
+                    @{
+                        ProductNames=@('exo');
+                        OmitPolicy=@{"MSEXO.1.1v1"=@{"Rationale"="Example rationale"}}
+                    }
+                }
+                [ScubaConfig]::GetInstance().LoadConfig($PSCommandPath) | Should -BeTrue
+                Should -Invoke -CommandName Write-Warning -Exactly -Times 1
+            }
+
+            It 'Warns for control IDs not encompassed by ProductNames' {
+                function global:ConvertFrom-Yaml {
+                    @{
+                        ProductNames=@('exo');
+                        OmitPolicy=@{"MS.Gmail.1.1v1"=@{"Rationale"="Example rationale"}}
+                    }
+                }
+                [ScubaConfig]::GetInstance().LoadConfig($PSCommandPath) | Should -BeTrue
+                Should -Invoke -CommandName Write-Warning -Exactly -Times 1
             }
         }
     }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/New-Config.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/New-Config.Tests.ps1
@@ -47,6 +47,37 @@ InModuleScope Support {
 
             Test-Path -Path "$($TestPath)/SampleConfig.yaml" -PathType leaf | Should -Be $true
         }
+
+        Context "When policy IDs are provided in the OmitPolicy parameter" {
+            It 'It reminds users to manually add the rationales' {
+                # Should warn once to for the reminder to manually add the rationales
+                $OmitArgs = $CMDArgs
+                $OmitArgs['OmitPolicy'] = @("MS.DEFENDER.1.1v1", "MS.DEFENDER.1.2v1")
+                { New-Config @OmitArgs } | Should -Not -Throw
+                Should -Invoke -CommandName Write-Warning -Exactly -Times 1
+                Test-Path -Path "$($TestPath)/SampleConfig.yaml" -PathType leaf | Should -Be $true
+            }
+
+            It 'Warns for malformed policy IDs' {
+                # The function should recognize that the policy ID does not match the expected
+                # format and give an additional warning for this
+                $OmitArgs = $CMDArgs
+                $OmitArgs['OmitPolicy'] = @("MS.DEFENDER1.1v1")
+                { New-Config @OmitArgs } | Should -Not -Throw
+                Should -Invoke -CommandName Write-Warning -Exactly -Times 2
+                Test-Path -Path "$($TestPath)/SampleConfig.yaml" -PathType leaf | Should -Be $true
+            }
+
+            It 'Warns for unexpected product in the policy ID' {
+                # The function should recognize that EXAMPLE is not a valid product
+                # and give an additional warning for this
+                $OmitArgs = $CMDArgs
+                $OmitArgs['OmitPolicy'] = @("MS.EXAMPLE.1.1v1", "MS.DEFENDER.1.2v1")
+                { New-Config @OmitArgs } | Should -Not -Throw
+                Should -Invoke -CommandName Write-Warning -Exactly -Times 2
+                Test-Path -Path "$($TestPath)/SampleConfig.yaml" -PathType leaf | Should -Be $true
+            }
+        }
     }
 
     AfterAll {

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -96,13 +96,11 @@ In some cases, it may be appropriate to omit specific policies from ScubaGear ev
 - When a policy is implemented by a third-party service that ScubaGear does not audit
 - When a policy is not applicable to your organization (e.g., policy MS.EXO.4.3v1 is only applicable to federal, executive branch, departments and agencies)
 
-The `OmitPolicy` top-level key in the [ScubaGear configuration file](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Sample-Config-Files/omit_policies.yaml) allows the user to specify the policies that should be omitted from the ScubaGear report. Omitted policies will show up as "Omitted" in the HTML report and will be colored gray. Omitting policies must only be done if the omissions are approved within an organization's security risk management process. **Exercise care when omitting policies because this can inadvertently introduce blind spots when assessing your system.**
+The `OmitPolicy` top-level key, shown in this [example ScubaGear configuration file](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Sample-Config-Files/omit_policies.yaml), allows the user to specify the policies that should be omitted from the ScubaGear report. Omitted policies will show up as "Omitted" in the HTML report and will be colored gray. Omitting policies must only be done if the omissions are approved within an organization's security risk management process. **Exercise care when omitting policies because this can inadvertently introduce blind spots when assessing your system.**
 
 For each omitted policy, the config file allows you to indicate the following:
 - `Rationale`: The reason the policy should be omitted from the report. This value will be displayed in the "Details" column of the report. ScubaGear will output a warning if no rationale is provided.
 - `Expiration`: Optional. A date after which the policy should no longer be omitted from the report. The expected format is yyyy-mm-dd.
-
-Policy omissions can be provided to the `New-Config` function as a comma-separated list of policy IDs under the `OmitPolicy` parameter. However, the `New-Config` function does not allow you to specify the rationales or expiration dates via the commandline; these must be manually entered into the resulting config file.
 
 ## Product-specific Configuration
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -8,7 +8,7 @@ Most of the `Invoke-SCuBA` cmdlet [parameters](parameters.md) can be placed into
 
 ## Sample Configuration Files
 
-[Sample config files](https://github.com/cisagov/ScubaGear/tree/main/PowerShell/ScubaGear/Sample-Config-Files) are available in the repo. Five of these sample config files are explained in more detail in the sections below.
+[Sample config files](https://github.com/cisagov/ScubaGear/tree/main/PowerShell/ScubaGear/Sample-Config-Files) are available in the repo. Four of these sample config files are explained in more detail in the sections below.
 
 ### Basic Use
 
@@ -96,7 +96,7 @@ In some cases, it may be appropriate to exclude policies from ScubaGear evaluati
 - False positives due to a policy being implemented via a third-party service
 - Policies not applicable to your organization (e.g., MS.EXO.4.3v1, which is only applicable to federal, executive branch, departments and agencies)
 
-**However, exclusions can introduce blind spots to your system and must be managed carefully.**
+Exclusions must only be used if they are approved within an organization's security risk acceptance process. **Exclusions can introduce blind spots to your system and must be managed carefully.**
 
 The `OmitPolicy` top-level key in the [configuration](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Sample-Config-Files/omit_policies.yaml) allows the user to specify the IDs of policies that should be excluded from the ScubaGear report. Excluded policies will show up as "Omitted" in the HTML report and will be colored gray.
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -96,9 +96,7 @@ In some cases, it may be appropriate to exclude policies from ScubaGear evaluati
 - False positives due to a policy being implemented via a third-party service
 - Policies not applicable to your organization (e.g., MS.EXO.4.3v1, which is only applicable to federal, executive branch, departments and agencies)
 
-Exclusions must only be used if they are approved within an organization's security risk acceptance process. **Exclusions can introduce blind spots to your system and must be managed carefully.**
-
-The `OmitPolicy` top-level key in the [configuration](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Sample-Config-Files/omit_policies.yaml) allows the user to specify the IDs of policies that should be excluded from the ScubaGear report. Excluded policies will show up as "Omitted" in the HTML report and will be colored gray.
+The `OmitPolicy` top-level key in the [configuration](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Sample-Config-Files/omit_policies.yaml) allows the user to specify the IDs of policies that should be excluded from the ScubaGear report. Excluded policies will show up as "Omitted" in the HTML report and will be colored gray. Exclusions must only be used if they are approved within an organization's security risk acceptance process. **Exclusions can introduce blind spots to your system and must be managed carefully.**
 
 For each exclusion, the config allows you to indicate the following:
 - `Rationale`: The reason the policy should be excluded from the report. This value will be displayed in the "Details" column of the report. ScubaGear will output a warning if no rationale is provided.

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -8,7 +8,7 @@ Most of the `Invoke-SCuBA` cmdlet [parameters](parameters.md) can be placed into
 
 ## Sample Configuration Files
 
-[Sample config files](https://github.com/cisagov/ScubaGear/tree/main/PowerShell/ScubaGear/Sample-Config-Files) are available in the repo. Four of these sample config files are explained in more detail in the sections below.
+[Sample config files](https://github.com/cisagov/ScubaGear/tree/main/PowerShell/ScubaGear/Sample-Config-Files) are available in the repo. Five of these sample config files are explained in more detail in the sections below.
 
 ### Basic Use
 
@@ -89,6 +89,22 @@ ScubaGear's support module can generate an empty sample config file. Running the
 # Create an empty config file
 New-Config
 ```
+
+## Omit Policies
+
+In some cases, it may be appropriate to exclude policies from ScubaGear evaluation. For example:
+- False positives due to a policy being implemented via a third-party service
+- Policies not applicable to your organization (e.g., MS.EXO.4.3v1, which is only applicable to federal, executive branch, departments and agencies)
+
+**However, exclusions can introduce blind spots to your system and must be managed carefully.**
+
+The `OmitPolicy` top-level key in the [configuration](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Sample-Config-Files/omit_policies.yaml) allows the user to specify the IDs of policies that should be excluded from the ScubaGear report. Excluded policies will show up as "Omitted" in the HTML report and will be colored gray.
+
+For each exclusion, the config allows you to indicate the following:
+- `Rationale`: The reason the policy should be excluded from the report. This value will be displayed in the "Details" column of the report. ScubaGear will output a warning if no rationale is provided.
+- `Expiration`: Optional. A date after which the policy should no longer be omitted from the report. The expected format is yyyy-mm-dd.
+
+Policy omissions can be provided to the `New-Config` function as a comma-separated list of policy IDs under the `OmitPolicy` parameter. However, the `New-Config` function does not allow you to specify the rationales or expiration dates via the commandline; these must be manually entered into the resulting config file.
 
 ## Product-specific Configuration
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -92,14 +92,14 @@ New-Config
 
 ## Omit Policies
 
-In some cases, it may be appropriate to exclude policies from ScubaGear evaluation. For example:
-- False positives due to a policy being implemented via a third-party service
-- Policies not applicable to your organization (e.g., MS.EXO.4.3v1, which is only applicable to federal, executive branch, departments and agencies)
+In some cases, it may be appropriate to omit specific policies from ScubaGear evaluation. For example:
+- When a policy is implemented by a third-party service that ScubaGear does not audit
+- When a policy is not applicable to your organization (e.g., policy MS.EXO.4.3v1 is only applicable to federal, executive branch, departments and agencies)
 
-The `OmitPolicy` top-level key in the [configuration](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Sample-Config-Files/omit_policies.yaml) allows the user to specify the IDs of policies that should be excluded from the ScubaGear report. Excluded policies will show up as "Omitted" in the HTML report and will be colored gray. Exclusions must only be used if they are approved within an organization's security risk acceptance process. **Exclusions can introduce blind spots to your system and must be managed carefully.**
+The `OmitPolicy` top-level key in the [ScubaGear configuration file](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Sample-Config-Files/omit_policies.yaml) allows the user to specify the policies that should be omitted from the ScubaGear report. Omitted policies will show up as "Omitted" in the HTML report and will be colored gray. Omitting policies must only be done if the omissions are approved within an organization's security risk management process. **Exercise care when omitting policies because this can inadvertently introduce blind spots when assessing your system.**
 
-For each exclusion, the config allows you to indicate the following:
-- `Rationale`: The reason the policy should be excluded from the report. This value will be displayed in the "Details" column of the report. ScubaGear will output a warning if no rationale is provided.
+For each omitted policy, the config file allows you to indicate the following:
+- `Rationale`: The reason the policy should be omitted from the report. This value will be displayed in the "Details" column of the report. ScubaGear will output a warning if no rationale is provided.
 - `Expiration`: Optional. A date after which the policy should no longer be omitted from the report. The expected format is yyyy-mm-dd.
 
 Policy omissions can be provided to the `New-Config` function as a comma-separated list of policy IDs under the `OmitPolicy` parameter. However, the `New-Config` function does not allow you to specify the rationales or expiration dates via the commandline; these must be manually entered into the resulting config file.


### PR DESCRIPTION
## 🗣 Description ##
Make it so that policies can be omitted from the ScubaGear reports.

## 💭 Motivation and context ##
Closes https://github.com/cisagov/ScubaGear/issues/740.
Closes https://github.com/cisagov/ScubaGear/issues/739.
Closes https://github.com/cisagov/ScubaGear/issues/738.

## 🧪 Testing ##
I'd recommend that the reviewers start by reading the documentation I added for this feature, to get a good overview of the approach taken: https://github.com/cisagov/ScubaGear/blob/739-allow-any-given-policy-to-be-ignored/docs/configuration/configuration.md#omit-policies.

Testing I've done:
- Added 8 new Pester cases to cover these changes
- Manually tested without a config file to ensure normal executions is unchanged
- Manually tested excluding several policies without expiration dates
- Manually tested excluding policies without specifying the rationale
- Manually tested excluding policies with expirations date, both in the past and future
- Manually tested excluding policies with a malformed expiration date
- Manually tested generating a config file with policy omissions via New-Config, including some edge cases, such as malformed policy ids, variations in capitalization, and unexpected product names in the policy IDs.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] PR passed smoke test check.
- [ ] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [ ] Resolved all merge conflicts on branch
- [ ] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
