### PR TITLE
Add exceptions for GitLeaks false positives

### DIFF
--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/AADProvider/Export-Caps.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/AADProvider/Export-Caps.Tests.ps1
@@ -60,7 +60,7 @@ Describe "GetIncludedUsers" {
         $Cap.Conditions.Users.IncludeRoles += "baaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
         $Cap.Conditions.Users.IncludeRoles += "caaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
         $Cap.Conditions.Users.IncludeGroups += "daaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
-        $Cap.Conditions.Users.IncludeGroups += "eaaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        $Cap.Conditions.Users.IncludeGroups += "eaaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" #gitleaks:allow
         $Cap.Conditions.Users.IncludeGroups += "faaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
         $UsersIncluded = $($CapHelper.GetIncludedUsers($Cap)) -Join ", "
         $UsersIncluded | Should -Be "1 specific user, 2 specific roles, 3 specific groups"
@@ -148,7 +148,7 @@ Describe "GetExcludedUsers" {
         $Cap.Conditions.Users.ExcludeRoles += "baaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
         $Cap.Conditions.Users.ExcludeRoles += "caaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
         $Cap.Conditions.Users.ExcludeGroups += "daaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
-        $Cap.Conditions.Users.ExcludeGroups += "eaaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        $Cap.Conditions.Users.ExcludeGroups += "eaaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" #gitleaks:allow
         $Cap.Conditions.Users.ExcludeGroups += "faaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
         $UsersExcluded = $($CapHelper.GetExcludedUsers($Cap)) -Join ", "
         $UsersExcluded | Should -Be "1 specific user, 2 specific roles, 3 specific groups"
@@ -211,7 +211,7 @@ Describe "GetApplications" {
         $Cap.Conditions.Applications.IncludeApplications += "baaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
         $Cap.Conditions.Applications.IncludeApplications += "caaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
         $Cap.Conditions.Applications.ExcludeApplications += "daaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
-        $Cap.Conditions.Applications.ExcludeApplications += "eaaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        $Cap.Conditions.Applications.ExcludeApplications += "eaaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" #gitleaks:allow
         $Apps = $($CapHelper.GetApplications($Cap))
         $Apps[0] | Should -Be "Policy applies to: apps"
         $Apps[1] | Should -Be "Apps included: 3 specific apps"


### PR DESCRIPTION
## 🗣 Description ##

GitLeaks (in the pipeline) was reporting that we were leaking 3 secrets to our GitHub repo, but these were all false positives.  I added an exception for each of these, and now GitLeaks is no longer reporting them. 

## 💭 Motivation and context ##

Closes:  #1204 

## 🧪 Testing ##

- Saw the error reports on the `main` branch
- Added the exception code (`#gitleaks:allow`) to the AAD code on a new branch
- Verified that the pipeline ran green

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

- [ ] PR passed smoke test check.
- [ ] Feature branch has been rebased against changes from parent branch, as needed
- [ ] Resolved all merge conflicts on branch
- [ ] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
