### PR TITLE
Add assessment check for MS.DEFENDER.6.2v1

### DIFF
--- a/PowerShell/ScubaGear/Modules/Connection/ConnectHelpers.psm1
+++ b/PowerShell/ScubaGear/Modules/Connection/ConnectHelpers.psm1
@@ -1,3 +1,52 @@
+function Connect-GraphHelper {
+    <#
+    .Description
+    This function is used for assisting in connecting to different M365 Environments via the Graph API.
+    .Functionality
+    Internal
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("commercial", "gcc", "gcchigh", "dod", IgnoreCase = $false)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $M365Environment,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]
+        $Scopes = $null,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [hashtable]
+        $ServicePrincipalParams
+    )
+    $GraphParams = @{
+        'ErrorAction' = 'Stop';
+    }
+
+    if ($ServicePrincipalParams.CertThumbprintParams) {
+        $GraphParams += @{
+            CertificateThumbprint = $ServicePrincipalParams.CertThumbprintParams.CertificateThumbprint;
+            ClientID              = $ServicePrincipalParams.CertThumbprintParams.AppID;
+            TenantId              = $ServicePrincipalParams.CertThumbprintParams.Organization; # Organization also works here
+        }
+    }
+    else {
+        $GraphParams += @{Scopes = $Scopes; }
+    }
+    switch ($M365Environment) {
+        "gcchigh" {
+            $GraphParams += @{'Environment' = "USGov"; }
+        }
+        "dod" {
+            $GraphParams += @{'Environment' = "USGovDoD"; }
+        }
+    }
+    Connect-MgGraph @GraphParams | Out-Null
+}
+
 function Connect-EXOHelper {
     <#
     .Description
@@ -78,6 +127,7 @@ function Connect-DefenderHelper {
 }
 
 Export-ModuleMember -Function @(
+    'Connect-GraphHelper',
     'Connect-EXOHelper',
     'Connect-DefenderHelper'
 )

--- a/PowerShell/ScubaGear/Modules/Providers/ExportDefenderProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportDefenderProvider.psm1
@@ -152,7 +152,7 @@ function Export-DefenderProvider {
 
     $Tracker.TryCommand("Get-MgBetaUser", $UserParameters) | Out-Null
 
-    if(-Not $UsersWithoutAdvancedAuditCount -is [int]) {
+    if(-Not $UsersWithoutAdvancedAuditCount -Or (-Not $UsersWithoutAdvancedAuditCount -is [int])) {
         $UsersWithoutAdvancedAuditCount = "-1"
     }
 

--- a/PowerShell/ScubaGear/Modules/Providers/ExportDefenderProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportDefenderProvider.psm1
@@ -2,7 +2,7 @@ function Export-DefenderProvider {
     <#
     .Description
     Gets the Microsoft 365 Defender settings that are relevant
-    to the SCuBA Microsft 365 Defender baselines using the EXO PowerShell Module
+    to the SCuBA Microsoft 365 Defender baselines using the Graph and EXO PowerShell Modules
     .Functionality
     Internal
     #>
@@ -143,6 +143,19 @@ function Export-DefenderProvider {
         $DLPLicense = ConvertTo-Json $false
     }
 
+    # Run commands to get count of users with Advanced auditing enabled
+    $UserParameters = @{ConsistencyLevel = 'eventual'
+                        Count = 'UsersWithoutAdvancedAuditCount'
+                        All = $true
+                        Filter = "not assignedPlans/any(a:a/servicePlanId eq 2f442157-a11c-46b9-ae5b-6e39ff4e5849 and a/capabilityStatus eq 'Enabled')"
+                       }
+
+    $Tracker.TryCommand("Get-MgBetaUser", $UserParameters) | Out-Null
+
+    if(-Not $UsersWithoutAdvancedAuditCount -is [int]) {
+        $UsersWithoutAdvancedAuditCount = "-1"
+    }
+
     $SuccessfulCommands = ConvertTo-Json @($Tracker.GetSuccessfulCommands())
     $UnSuccessfulCommands = ConvertTo-Json @($Tracker.GetUnSuccessfulCommands())
 
@@ -156,6 +169,7 @@ function Export-DefenderProvider {
     "protection_alerts": $ProtectionAlert,
     "admin_audit_log_config": $AdminAuditLogConfig,
     "atp_policy_for_o365": $ATPPolicy,
+    "total_users_without_advanced_audit": $UsersWithoutAdvancedAuditCount,
     "defender_license": $DefenderLicense,
     "defender_dlp_license": $DLPLicense,
     "defender_successful_commands": $SuccessfulCommands,

--- a/PowerShell/ScubaGear/Modules/Providers/ExportDefenderProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportDefenderProvider.psm1
@@ -144,6 +144,9 @@ function Export-DefenderProvider {
     }
 
     # Run commands to get count of users with Advanced auditing enabled
+    # GUID below is service plan ID for M365_ADVANCED_AUDITING as defined
+    # on Microsoft Licensing Reference shown here:
+    # https://learn.microsoft.com/en-us/entra/identity/users/licensing-service-plan-reference
     $UserParameters = @{ConsistencyLevel = 'eventual'
                         Count = 'UsersWithoutAdvancedAuditCount'
                         All = $true

--- a/PowerShell/ScubaGear/Rego/DefenderConfig.rego
+++ b/PowerShell/ScubaGear/Rego/DefenderConfig.rego
@@ -883,10 +883,7 @@ tests contains {
 # Requires Graph connection to get the user counts
 # default to negative value to indicate no data or error
 default UnlicensedUserCount := -1
-
-UnlicensedUserCount := Count if {
-    Count := input.total_users_without_advanced_audit
-}
+UnlicensedUserCount := input.total_users_without_advanced_audit
 
 LicensedUserMessage := ErrorMessage if {
     UnlicensedUserCount == -1

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Connection/Connect-GraphHelper.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Connection/Connect-GraphHelper.Tests.ps1
@@ -1,0 +1,50 @@
+BeforeDiscovery {
+    $ModuleRootPath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\..\..\Modules\Connection' -Resolve
+    Import-Module (Join-Path -Path $ModuleRootPath -ChildPath 'ConnectHelpers.psm1') -Function 'Connect-GraphHelper' -Force
+}
+
+InModuleScope ConnectHelpers {
+    Describe -Tag 'Connection' -Name 'Connect-GraphHelper' {
+        BeforeAll {
+            function Connect-MgGraph {throw 'this will be mocked'}
+            Mock -ModuleName ConnectHelpers Connect-MgGraph {Write-Debug "M365Environment: $M365Environment"}
+        }
+        context 'Without Service Principal'{
+            It 'Invalid M365Environment parameter' {
+                {Connect-GraphHelper -M365Environment 'invalid_parameter'} | Should -Throw
+            }
+            It 'Invokes for commercial environment' {
+                Connect-GraphHelper -M365Environment 'commercial'
+                Should -Invoke -ModuleName ConnectHelpers -CommandName Connect-MgGraph -Times 1
+            }
+            It 'Invokes for gcc environment' {
+                Connect-GraphHelper -M365Environment 'gcc'
+                Should -Invoke -ModuleName ConnectHelpers -CommandName Connect-MgGraph -Times 1
+            }
+            It 'Invokes for gcchigh environment' {
+                Connect-GraphHelper -M365Environment 'gcchigh'
+                Should -Invoke -ModuleName ConnectHelpers -CommandName Connect-MgGraph -Times 1
+            }
+            It 'Invokes for dod environment' {
+                Connect-GraphHelper -M365Environment 'dod'
+                Should -Invoke -ModuleName ConnectHelpers -CommandName Connect-MgGraph -Times 1
+            }
+        }
+        context 'With Service Principal'{
+            It 'Invoke with Service Principal parameters'{
+                $sp = @{
+                    CertThumbprintParams = @{
+                        CertificateThumbprint = 'A thumbprint';
+                        AppID = 'My Id';
+                        Organization = 'My Organization';
+                    }
+                }
+                Connect-GraphHelper -M365Environment 'commercial' -ServicePrincipalParams $sp
+                Should -Invoke -ModuleName ConnectHelpers -CommandName Connect-MgGraph -Times 1
+            }
+        }
+    }
+}
+AfterAll {
+    Remove-Module ConnectHelpers -ErrorAction SilentlyContinue
+}

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Connection/Connect-Tenant.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Connection/Connect-Tenant.Tests.ps1
@@ -9,8 +9,8 @@ InModuleScope Connection {
         @{Endpoint = 'dod'}
     ){
         BeforeAll {
-            function Connect-MgGraph {throw 'this will be mocked'}
-            Mock Connect-MgGraph -MockWith {}
+            function Connect-GraphHelper {throw 'this will be mocked'}
+            Mock Connect-GraphHelper -MockWith {}
             function Connect-PnPOnline {throw 'this will be mocked'}
             function Connect-PnPOnline {throw 'this will be mocked'}
             Mock Connect-PnPOnline -MockWith {}
@@ -44,16 +44,16 @@ InModuleScope Connection {
             }
         }
         Context 'With Endpoint:  <Endpoint>; ProductNames: <ProductNames>' -ForEach @(
-            @{ProductNames = "aad"; Services = @('Connect-MgGraph')}
-            @{ProductNames = "defender"; Services = @('Connect-EXOHelper')}
+            @{ProductNames = "aad"; Services = @('Connect-GraphHelper')}
+            @{ProductNames = "defender"; Services = @('Connect-EXOHelper', 'Connect-GraphHelper')}
             @{ProductNames = "exo"; Services = @('Connect-EXOHelper')}
             @{ProductNames = "powerplatform"; Services = @('Add-PowerAppsAccount')}
-            @{ProductNames = "sharepoint"; Services = @('Connect-MgGraph', 'Connect-PnPOnline')}
+            @{ProductNames = "sharepoint"; Services = @('Connect-GraphHelper', 'Connect-PnPOnline')}
             @{ProductNames = "teams"; Services = @('Connect-MicrosoftTeams')}
             @{
                 ProductNames = "aad", "defender", "exo", "powerplatform", "sharepoint", "teams"
                 Services = @(
-                    'Connect-MgGraph',
+                    'Connect-GraphHelper',
                     'Connect-EXOHelper',
                     'Add-PowerAppsAccount',
                     'Connect-PnPOnline',

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/DefenderProvider/Export-DefenderProvider.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/DefenderProvider/Export-DefenderProvider.Tests.ps1
@@ -82,6 +82,10 @@ InModuleScope -ModuleName ExportDefenderProvider {
                                 $this.SuccessfulCommands += $Command
                                 return [pscustomobject]@{}
                             }
+                            "Get-MgBetaUser" {
+                                $this.SuccessfulCommands += $Command
+                                return [pscustomobject]@{}
+                            }
                             default {
                                 throw "ERROR you forgot to create a mock method for this cmdlet: $($Command)"
                             }
@@ -135,6 +139,9 @@ InModuleScope -ModuleName ExportDefenderProvider {
             Mock -ModuleName ExportDefenderProvider Get-SafeAttachmentPolicy {}
             function Get-AtpPolicyForO365 {throw 'this will be mocked'}
             Mock -ModuleName ExportDefenderProvider Get-AtpPolicyForO365 {}
+            function Get-MgBetaUser {}
+            Mock -ModuleName ExportDefenderProvider Get-MgBetaUser {}
+
             function Test-SCuBAValidProviderJson {
                 param (
                     [string]

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/Defender/DefenderConfig_06_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/Defender/DefenderConfig_06_test.rego
@@ -5,7 +5,7 @@ import data.utils.report.NotCheckedDetails
 import data.utils.key.TestResult
 import data.utils.key.FAIL
 import data.utils.key.PASS
-
+import data.utils.report.PolicyLink
 
 #
 # Policy MS.DEFENDER.6.1v1
@@ -40,13 +40,54 @@ test_AdminAuditLogEnabled_Incorrect if {
 #
 # Policy MS.DEFENDER.6.2v1
 #--
-test_NotImplemented_Correct_V1 if {
-    PolicyId := "MS.DEFENDER.6.2v1"
+test_AdvAudit_Correct if {
+    Output := defender.tests with input as {
+        "total_users_without_advanced_audit": 0
+    }
 
-    Output := defender.tests with input as { }
+    TestResult("MS.DEFENDER.6.2v1", Output, PASS, true) == true
+}
 
-    ReportDetailString := NotCheckedDetails(PolicyId)
-    TestResult(PolicyId, Output, ReportDetailString, false) == true
+test_AdvAudit_Incorrect_V1 if {
+    Output := defender.tests with input as {
+        "total_users_without_advanced_audit": 10
+    }
+    ErrorDetails := concat(" ", [ "Requirement not met.", "10",
+    "tenant users without M365 Advanced Auditing feature assigned.",
+    "To review and assign users the Microsoft 365 Advanced Auditing feature, see %v.",
+    "To get a list of all users without the license feature run the following:",
+    concat("", ["Get-MgBetaUser -Filter \"not assignedPlans/any(a:a/servicePlanId eq ",
+                "2f442157-a11c-46b9-ae5b-6e39ff4e5849 and a/capabilityStatus eq 'Enabled')\""]
+          ),
+    "-ConsistencyLevel eventual -Count UserCount -All | Select-Object DisplayName,UserPrincipalName"
+    ])
+
+    ErrorMessage := sprintf(ErrorDetails, [PolicyLink("MS.DEFENDER.6.2v1")])
+    TestResult("MS.DEFENDER.6.2v1", Output, ErrorMessage, false) == true
+}
+
+test_AdvAudit_Incorrect_V2 if {
+    Output := defender.tests with input as {
+    }
+
+    ReportDetailString := concat(" ", [
+        "Requirement not met. Error retrieving license information from tenant. ",
+        "**NOTE: M365 Advanced Auditing feature requires E5/G5 or add-on licensing.**"
+    ])
+    TestResult("MS.DEFENDER.6.2v1", Output,  ReportDetailString, false) == true
+}
+
+test_AdvAudit_Incorrect_V3 if {
+    Output := defender.tests with input as {
+        "total_users_without_advanced_audit": -1
+    }
+
+    ReportDetailString := concat(" ", [
+        "Requirement not met. Error retrieving license information from tenant. ",
+        "**NOTE: M365 Advanced Auditing feature requires E5/G5 or add-on licensing.**"
+    ])
+
+    TestResult("MS.DEFENDER.6.2v1", Output,  ReportDetailString, false) == true
 }
 #--
 

--- a/Testing/Functional/Products/TestPlans/defender.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/defender.testplan.yaml
@@ -1418,12 +1418,39 @@ TestPlan:
         ExpectedResult: false
 
   - PolicyId: MS.DEFENDER.6.2v1
-    TestDriver: RunScuba
+    TestDriver: RunCached
     Tests:
-      - TestDescription: MS.DEFENDER.6.2v1 Not Checked
-        Preconditions: []
+      - TestDescription: MS.DEFENDER.6.2v1 Compliant Case
+        Preconditions:
+          - Command: UpdateProviderExport
+            Splat:
+              updates:
+                total_users_without_advanced_audit: 0
         Postconditions: []
-        IsNotChecked: true
+        ExpectedResult: true
+
+  - PolicyId: MS.DEFENDER.6.2v1
+    TestDriver: RunCached
+    Tests:
+      - TestDescription: MS.DEFENDER.6.2v1 Non-Compliant Case
+        Preconditions:
+          - Command: UpdateProviderExport
+            Splat:
+              updates:
+                total_users_without_advanced_audit: 10
+        Postconditions: []
+        ExpectedResult: false
+
+  - PolicyId: MS.DEFENDER.6.2v1
+    TestDriver: RunCached
+    Tests:
+      - TestDescription: MS.DEFENDER.6.2v1 Non-Compliant Case
+        Preconditions:
+          - Command: UpdateProviderExport
+            Splat:
+              updates:
+                total_users_without_advanced_audit: -1
+        Postconditions: []
         ExpectedResult: false
 
   - PolicyId: MS.DEFENDER.6.3v1

--- a/Testing/Functional/Products/TestPlans/defender.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/defender.testplan.yaml
@@ -1418,7 +1418,7 @@ TestPlan:
         ExpectedResult: false
 
   - PolicyId: MS.DEFENDER.6.2v1
-    TestDriver: RunCached
+    TestDriver: ScubaCached
     Tests:
       - TestDescription: MS.DEFENDER.6.2v1 Compliant Case
         Preconditions:
@@ -1430,7 +1430,7 @@ TestPlan:
         ExpectedResult: true
 
   - PolicyId: MS.DEFENDER.6.2v1
-    TestDriver: RunCached
+    TestDriver: ScubaCached
     Tests:
       - TestDescription: MS.DEFENDER.6.2v1 Non-Compliant Case
         Preconditions:
@@ -1442,7 +1442,7 @@ TestPlan:
         ExpectedResult: false
 
   - PolicyId: MS.DEFENDER.6.2v1
-    TestDriver: RunCached
+    TestDriver: ScubaCached
     Tests:
       - TestDescription: MS.DEFENDER.6.2v1 Non-Compliant Case
         Preconditions:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->
Provides enhancement to Defender assessment checks for MS.DEFENDER.6.2v1 to ensure ALL users are assigned an advanced auditing license feature to support the SCB policy item.  The actual update includes:

* A new MSGraph connection helper `Connect-GraphHelper` to modularize connecting to Graph API
* Updates to the Connection module to use the new `Connect-GraphHelper` function
* Connection module updates to connect to Graph when assessing Defender
* Defender provider updates to populate `total_users_without_advanced_audit` count
* New rego assessment checks for MS.DEFENDER.6.2v1 to validate the new count and provide count of users without the requisite license if not zero.
* Additional unit and functional tests to exercise the new assessment check and connection helper

No documentation updates are required as AAD and Defender already used the same permissions (Global Reader) and only an existing scope is required for Defender provider MSGraph calls (User.Read.All).

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->
MS.DEFENDER.6.2v1 was previously set to not be checked due to a lack of a direct mechanism to do so under Defender.  The new approach uses MSGraph to get license information which now provides ScubaGear users with assessment results for the policy item rather than requiring a full manual check as before.  This makes assessing MS.DEFENDER.6.2v1 easier for users.

Closes #88 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Testing the compliant case may be difficult if a test tenant with enough licenses to cover all users is not available.  Invoke-ScubaRunCached with modified results is recommended for that case while setting the `total_users_without_advanced_audit` value to zero or -1.  The functional tests do this as well, so running the Defender functional tests will also exercise the code.

To test the failed case, test on a tenant after making sure at least one user is not assigned the proper license.
`Invoke-Scuba -p defender`

Since changes were also make to Connection, test should include checking:
1) Running with user and service principal authentication
2) Testing when run with all products, just defender, just defender and powerplatform
    Note: This last one exercises the different connection cases and paths where MSGraph is enabled.


## 📷 Screenshots (if appropriate) ##
Example of MS.DEFENDER.6.2v1 results when not all users are assigned the advanced audit license:
![Screenshot 2024-07-29 at 4 32 24 PM](https://github.com/user-attachments/assets/aa6402d3-6114-46be-8129-10dd65d327a0)


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [x] Resolved all merge conflicts on branch
- [x] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
