### PR TITLE
Rectify AAD functional test failures and improved naming of some AAD Rego rulesets

### DIFF
--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -15,7 +15,7 @@ import data.utils.aad.ReportDetailsArrayLicenseWarning
 import data.utils.aad.UserExclusionsFullyExempt
 import data.utils.aad.GroupExclusionsFullyExempt
 import data.utils.aad.Aad2P2Licenses
-import data.utils.aad.HasAcceptableMFA
+import data.utils.aad.IsPhishingResistantMFA
 import data.utils.aad.PolicyConditionsMatch
 import data.utils.aad.CAPLINK
 import data.utils.aad.DomainReportDetails
@@ -188,7 +188,7 @@ PhishingResistantMFAPolicies contains CAPolicy.DisplayName if {
     GroupExclusionsFullyExempt(CAPolicy, "MS.AAD.3.1v1") == true
     UserExclusionsFullyExempt(CAPolicy, "MS.AAD.3.1v1") == true
 
-    HasAcceptableMFA(CAPolicy) == true
+    IsPhishingResistantMFA(CAPolicy) == true
 }
 
 # Pass if at least 1 policy meets all conditions
@@ -210,11 +210,11 @@ tests contains {
 #--
 
 # Save all policy names if PhishingResistantMFAPolicies exist
-AllMFA := AlternativeMFA | PhishingResistantMFAPolicies
+AllMFA := NonSpecificMFAPolicies | PhishingResistantMFAPolicies
 
 # If policy matches basic conditions, special conditions,
 # & all exclusions are intentional, save the policy name
-AlternativeMFA contains CAPolicy.DisplayName if {
+NonSpecificMFAPolicies contains CAPolicy.DisplayName if {
     some CAPolicy in input.conditional_access_policies
 
     # Match all simple conditions
@@ -398,7 +398,7 @@ tests contains {
 # privliged roles are included in policy & not excluded.
 # If policy matches basic conditions, special conditions,
 # & all exclusions are intentional, save the policy name
-PhishingResistantMFA contains CAPolicy.DisplayName if {
+PhishingResistantMFAPrivilegedRoles contains CAPolicy.DisplayName if {
     some CAPolicy in input.conditional_access_policies
 
     CAPolicy.State == "enabled"
@@ -418,7 +418,7 @@ PhishingResistantMFA contains CAPolicy.DisplayName if {
     UserExclusionsFullyExempt(CAPolicy, "MS.AAD.3.6v1") == true
 
     # Policy has only acceptable MFA
-    HasAcceptableMFA(CAPolicy) == true
+    IsPhishingResistantMFA(CAPolicy) == true
 }
 
 # Pass if at least 1 policy meets all conditions
@@ -426,12 +426,12 @@ tests contains {
     "PolicyId": "MS.AAD.3.6v1",
     "Criticality": "Shall",
     "Commandlet": ["Get-MgBetaIdentityConditionalAccessPolicy"],
-    "ActualValue": PhishingResistantMFA,
-    "ReportDetails": concat(". ", [ReportFullDetailsArray(PhishingResistantMFA, DescriptionString), CAPLINK]),
+    "ActualValue": PhishingResistantMFAPrivilegedRoles,
+    "ReportDetails": concat(". ", [ReportFullDetailsArray(PhishingResistantMFAPrivilegedRoles, DescriptionString), CAPLINK]),
     "RequirementMet": Status
 } if {
     DescriptionString := "conditional access policy(s) found that meet(s) all requirements"
-    Status := count(PhishingResistantMFA) > 0
+    Status := count(PhishingResistantMFAPrivilegedRoles) > 0
 }
 #--
 

--- a/PowerShell/ScubaGear/Rego/Utils/AAD.rego
+++ b/PowerShell/ScubaGear/Rego/Utils/AAD.rego
@@ -159,7 +159,7 @@ PolicyConditionsMatch(Policy) := true if {
 # Save the Allowed MFA items as a set, check if there are any MFA
 # items allowed besides the acceptable ones & if there is at least
 # 1 MFA item allowed. Return true
-HasAcceptableMFA(Policy) := true if {
+IsPhishingResistantMFA(Policy) := true if {
     # Strength must be at least one of acceptable with no unacceptable strengths
     Strengths := ConvertToSet(Policy.GrantControls.AuthenticationStrength.AllowedCombinations)
     AcceptableMFA := {"windowsHelloForBusiness", "fido2", "x509CertificateMultiFactor"}

--- a/Testing/Functional/Products/TestPlans/aad.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/aad.testplan.yaml
@@ -161,7 +161,7 @@ TestPlan:
         Preconditions:
           - Command: UpdateCachedConditionalAccessPolicyByName
             Splat:
-              displayName: MS.AAD.3.2v1 If phishing-resistant MFA has not been enforced, an alternative MFA method SHALL be enforced for all users
+              displayName: Automated Test 1 - DO NOT MODIFY
               updates:
                 State: enabled
         Postconditions: []

--- a/Testing/Functional/Products/TestPlans/aad.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/aad.testplan.yaml
@@ -469,7 +469,7 @@ TestPlan:
   - PolicyId: MS.AAD.3.7v1
     TestDriver: ScubaCached
     Tests:
-      - TestDescription: MS.AAD.3.7v1 Non-Compliant case - require both compliant and domain joined device only for specific user
+      - TestDescription: MS.AAD.3.7v1 Non-Compliant case - require compliant or domain joined device only for specific user
         Preconditions:
           - Command: UpdateCachedConditionalAccessPolicyByName
             Splat:
@@ -479,7 +479,7 @@ TestPlan:
                 GrantControls.BuiltInControls:
                   - "compliantDevice"
                   - "domainJoinedDevice"
-                GrantControls.Operator: AND
+                GrantControls.Operator: OR
                 Conditions:
                   Users:
                     IncludeUsers: ["e897fa07-cfcc-4aeb-9b61-afbf173fb9df"]
@@ -493,77 +493,7 @@ TestPlan:
                     ExcludeApplications: []
         Postconditions: []
         ExpectedResult: false
-      - TestDescription: MS.AAD.3.7v1 Compliant case - require both compliant and domain joined device for everyone
-        Preconditions:
-          - Command: UpdateCachedConditionalAccessPolicyByName
-            Splat:
-              displayName: Automated Test 1 - DO NOT MODIFY
-              updates:
-                State: enabled
-                GrantControls.BuiltInControls:
-                  - "compliantDevice"
-                  - "domainJoinedDevice"
-                GrantControls.Operator: AND
-                Conditions:
-                  Users:
-                    IncludeUsers: ["All"]
-                    ExcludeUsers: []
-                    IncludeRoles: []
-                    IncludeGroups: []
-                    ExcludeGroups: []
-                    ExcludeRoles: []
-                  Applications:
-                    IncludeApplications: ["All"]
-                    ExcludeApplications: []
-        Postconditions: []
-        ExpectedResult: true
-      - TestDescription: MS.AAD.3.7v1 Compliant case - only compliant Device required
-        Preconditions:
-          - Command: UpdateCachedConditionalAccessPolicyByName
-            Splat:
-              displayName: Automated Test 1 - DO NOT MODIFY
-              updates:
-                State: enabled
-                GrantControls.BuiltInControls:
-                  - "compliantDevice"
-                GrantControls.Operator: OR
-                Conditions:
-                  Users:
-                    IncludeUsers: ["All"]
-                    ExcludeUsers: []
-                    IncludeRoles: []
-                    IncludeGroups: []
-                    ExcludeGroups: []
-                    ExcludeRoles: []
-                  Applications:
-                    IncludeApplications: ["All"]
-                    ExcludeApplications: []
-        Postconditions: []
-        ExpectedResult: true
-      - TestDescription: MS.AAD.3.7v1 Compliant case - only domain Joined Device required
-        Preconditions:
-          - Command: UpdateCachedConditionalAccessPolicyByName
-            Splat:
-              displayName: Automated Test 1 - DO NOT MODIFY
-              updates:
-                State: enabled
-                GrantControls.BuiltInControls:
-                  - "domainJoinedDevice"
-                GrantControls.Operator: OR
-                Conditions:
-                  Users:
-                    IncludeUsers: ["All"]
-                    ExcludeUsers: []
-                    IncludeRoles: []
-                    IncludeGroups: []
-                    ExcludeGroups: []
-                    ExcludeRoles: []
-                  Applications:
-                    IncludeApplications: ["All"]
-                    ExcludeApplications: []
-        Postconditions: []
-        ExpectedResult: true
-      - TestDescription: MS.AAD.3.7v1 Compliant case - compliant or domain joined device required
+      - TestDescription: MS.AAD.3.7v1 Compliant case - require compliant or domain joined device for everyone
         Preconditions:
           - Command: UpdateCachedConditionalAccessPolicyByName
             Splat:


### PR DESCRIPTION
## 🗣 Description ##

*Note: to make these changes I had to change the name of the TestDriver in the functional tests to "ScubaCached" since that fix was not applied to main yet.

- Fixed 3.2 functional test so that it does not rely on the tenant having a compliant non-specific MFA conditional access policy that matches the conditions for baseline policy 3.2. Instead the test case now uses the special conditional access policy named Automated Test to setup the condition instead, since that is a more reliable method.

- Fixed incorrect functional test cases for MS.AAD.3.7v1. Bug found by Julian on 7/30/2024 when performing testing on a different pull request. The test cases should be using the GrantControls.Operator OR operator but they were using AND. Also because of this change I removed the functional test cases for 3.7 that are no longer applicable.

- Renamed PhishingResistantMFA to PhishingResistantMFAPrivilegedRoles to accurately reflect the purpose of the ruleset. The name PhishingResistantMFA is generic and could be confused with other policies that examine whether phishing resistant MFA is enabled.

- Renamed HasAcceptableMFA to IsPhishingResistantMFA to more precisely reflect what the ruleset is used for.

- Renamed AlternativeMFA to NonSpecificMFAPolicies to more precisely reflect what the ruleset is used for.

closes #1168 
closes #1182 

## 🧪 Testing ##

I tested by running the functional tests of the affected policies (3.1, 3.2, 3.3, 3.6, 3.7) against E5, G3, G5, GCC High tenants. Also made sure unit tests were successful.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [ ] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] PR passed smoke test check.
- [ ] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [ ] Resolved all merge conflicts on branch
- [ ] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
