### PR TITLE
Fix build and sign GitHub release

### DIFF
--- a/.github/workflows/build_sign_release.yaml
+++ b/.github/workflows/build_sign_release.yaml
@@ -55,13 +55,19 @@ jobs:
             dotnet --version
             dotnet tool install --global AzureSignTool --version 4.0.1
             $KeyVaultInfo = ${env:KEY_VAULT_INFO} | ConvertFrom-Json
-            . repo/utils/DeployUtils.ps1
+            . repo/utils/workflow/Publish-ScubaGear.ps1
             # Remove non-release files
             Remove-Item -Recurse -Force repo -Include .git*
-            SignScubaGearModule `
+            Write-Output "Creating an array of the files to sign..."
+              $ArrayOfFilePaths = New-ArrayOfFilePaths `
+              -ModuleDestinationPath repo
+              Write-Output "Creating a file with a list of the files to sign..."
+              $FileListFileName = New-FileList `
+              -ArrayOfFilePaths $ArrayOfFilePaths
+            Use-AzureSignTool `
               -AzureKeyVaultUrl $($KeyVaultInfo.KeyVault.URL) `
               -CertificateName $($KeyVaultInfo.KeyVault.CertificateName) `
-              -ModulePath 'repo'
+              -FileList $FileListFileName
             Move-Item  -Path repo -Destination "ScubaGear-${env:RELEASE_VERSION}" -Force
             Compress-Archive -Path "ScubaGear-${env:RELEASE_VERSION}" -DestinationPath "ScubaGear-${env:RELEASE_VERSION}.zip"
           azPSVersion: "latest"

--- a/.github/workflows/build_sign_release.yaml
+++ b/.github/workflows/build_sign_release.yaml
@@ -55,6 +55,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           enable-AzPSSession: true
       - name: Get Key Vault info
+        id: key-vault-info
         env:
           KEY_VAULT_INFO: ${{ secrets.SCUBA_KEY_VAULT_PROD}}
         run: |
@@ -74,9 +75,11 @@ jobs:
             $FileListFileName = New-FileList `
               -ArrayOfFilePaths $ArrayOfFilePaths
             Write-Output "Calling AzureSignTool function to sign scripts, manifest, and modules..."
+            AzureKeyVaultUrl = '${{ steps.key-vault-info.outputs.KeyVaultUrl }}'
+            CertificateName = '${{ steps.key-vault-info.outputs.KeyVaultCertificateName }}'
             Use-AzureSignTool `
-              -AzureKeyVaultUrl $($KeyVaultInfo.KeyVault.URL) `
-              -CertificateName $($KeyVaultInfo.KeyVault.CertificateName) `
+              -AzureKeyVaultUrl $AzureKeyVaultUrl `
+              -CertificateName $CertificateName `
               -FileList $FileListFileName
             Move-Item  -Path repo -Destination "ScubaGear-${env:RELEASE_VERSION}" -Force
             Compress-Archive -Path "ScubaGear-${env:RELEASE_VERSION}" -DestinationPath "ScubaGear-${env:RELEASE_VERSION}.zip"

--- a/.github/workflows/build_sign_release.yaml
+++ b/.github/workflows/build_sign_release.yaml
@@ -32,6 +32,9 @@ jobs:
     permissions:
       id-token: write
       contents: write
+    defaults:
+      run:
+        shell: powershell
     # This condition prevents duplicate runs.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
@@ -39,41 +42,47 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: repo
-      - name: OIDC Login to Azure Public Cloud with AzPowershell (enableAzPSSession true)
+      - name: Install Azure Signing Tool
+        run: |
+          dotnet --version
+          dotnet tool install --global AzureSignTool --version 5.0.0
+      # OIDC Login to Azure Public Cloud with AzPowershell (enableAzPSSession true)
+      - name: Login to Azure
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           enable-AzPSSession: true
-      - name: Sign Module
-        uses: azure/powershell@v1
+      - name: Get Key Vault info
         env:
           KEY_VAULT_INFO: ${{ secrets.SCUBA_KEY_VAULT_PROD}}
-        with:
-          inlineScript: |
-            dotnet --version
-            dotnet tool install --global AzureSignTool --version 4.0.1
-            $KeyVaultInfo = ${env:KEY_VAULT_INFO} | ConvertFrom-Json
+        run: |
+          $KeyVaultInfo = ${env:KEY_VAULT_INFO} | ConvertFrom-Json
+          echo "KeyVaultUrl=$($KeyVaultInfo.KeyVault.URL)" >> $env:GITHUB_OUTPUT
+          echo "KeyVaultCertificateName=$($KeyVaultInfo.KeyVault.CertificateName)" >> $env:GITHUB_OUTPUT
+      - name: Sign Module
+        run: |
+            # Source the deploy utilities so the functions in it can be called.
             . repo/utils/workflow/Publish-ScubaGear.ps1
             # Remove non-release files
             Remove-Item -Recurse -Force repo -Include .git*
             Write-Output "Creating an array of the files to sign..."
-              $ArrayOfFilePaths = New-ArrayOfFilePaths `
+            $ArrayOfFilePaths = New-ArrayOfFilePaths `
               -ModuleDestinationPath repo
-              Write-Output "Creating a file with a list of the files to sign..."
-              $FileListFileName = New-FileList `
+            Write-Output "Creating a file with a list of the files to sign..."
+            $FileListFileName = New-FileList `
               -ArrayOfFilePaths $ArrayOfFilePaths
+            Write-Output "Calling AzureSignTool function to sign scripts, manifest, and modules..."
             Use-AzureSignTool `
               -AzureKeyVaultUrl $($KeyVaultInfo.KeyVault.URL) `
               -CertificateName $($KeyVaultInfo.KeyVault.CertificateName) `
               -FileList $FileListFileName
             Move-Item  -Path repo -Destination "ScubaGear-${env:RELEASE_VERSION}" -Force
             Compress-Archive -Path "ScubaGear-${env:RELEASE_VERSION}" -DestinationPath "ScubaGear-${env:RELEASE_VERSION}.zip"
-          azPSVersion: "latest"
-      - name: release
+      - name: Create Release
         uses: softprops/action-gh-release@v1
-        id: create_release
+        id: create-release
         with:
           draft: true
           prerelease: false
@@ -82,15 +91,14 @@ jobs:
           files: ScubaGear-${{ inputs.version }}.zip
           generate_release_notes: true
           fail_on_unmatched_files: true
-      - name: Download release
+      - name: Download Release
         uses: dsaltares/fetch-gh-release-asset@1.1.1
         if: ${{ inputs.runQuickCheck }}
         with:
-          version: ${{ steps.create_release.outputs.id}}
+          version: ${{ steps.create-release.outputs.id}}
           file: "ScubaGear-${{ inputs.version }}.zip"
-      - name: Quick check release
+      - name: Quick Check Release
         if: ${{ inputs.runQuickCheck }}
-        shell: powershell
         run: |
           Expand-Archive -Path "ScubaGear-${{ inputs.version }}.zip"
           Get-ChildItem

--- a/.github/workflows/build_sign_release.yaml
+++ b/.github/workflows/build_sign_release.yaml
@@ -75,8 +75,8 @@ jobs:
             $FileListFileName = New-FileList `
               -ArrayOfFilePaths $ArrayOfFilePaths
             Write-Output "Calling AzureSignTool function to sign scripts, manifest, and modules..."
-            AzureKeyVaultUrl = '${{ steps.key-vault-info.outputs.KeyVaultUrl }}'
-            CertificateName = '${{ steps.key-vault-info.outputs.KeyVaultCertificateName }}'
+            $AzureKeyVaultUrl = '${{ steps.key-vault-info.outputs.KeyVaultUrl }}'
+            $CertificateName = '${{ steps.key-vault-info.outputs.KeyVaultCertificateName }}'
             Use-AzureSignTool `
               -AzureKeyVaultUrl $AzureKeyVaultUrl `
               -CertificateName $CertificateName `

--- a/.github/workflows/build_sign_release.yaml
+++ b/.github/workflows/build_sign_release.yaml
@@ -64,25 +64,25 @@ jobs:
           echo "KeyVaultCertificateName=$($KeyVaultInfo.KeyVault.CertificateName)" >> $env:GITHUB_OUTPUT
       - name: Sign Module
         run: |
-            # Source the deploy utilities so the functions in it can be called.
-            . repo/utils/workflow/Publish-ScubaGear.ps1
-            # Remove non-release files
-            Remove-Item -Recurse -Force repo -Include .git*
-            Write-Output "Creating an array of the files to sign..."
-            $ArrayOfFilePaths = New-ArrayOfFilePaths `
-              -ModuleDestinationPath repo
-            Write-Output "Creating a file with a list of the files to sign..."
-            $FileListFileName = New-FileList `
-              -ArrayOfFilePaths $ArrayOfFilePaths
-            Write-Output "Calling AzureSignTool function to sign scripts, manifest, and modules..."
-            $AzureKeyVaultUrl = '${{ steps.key-vault-info.outputs.KeyVaultUrl }}'
-            $CertificateName = '${{ steps.key-vault-info.outputs.KeyVaultCertificateName }}'
-            Use-AzureSignTool `
-              -AzureKeyVaultUrl $AzureKeyVaultUrl `
-              -CertificateName $CertificateName `
-              -FileList $FileListFileName
-            Move-Item  -Path repo -Destination "ScubaGear-${env:RELEASE_VERSION}" -Force
-            Compress-Archive -Path "ScubaGear-${env:RELEASE_VERSION}" -DestinationPath "ScubaGear-${env:RELEASE_VERSION}.zip"
+          # Source the deploy utilities so the functions in it can be called.
+          . repo/utils/workflow/Publish-ScubaGear.ps1
+          # Remove non-release files
+          Remove-Item -Recurse -Force repo -Include .git*
+          Write-Output "Creating an array of the files to sign..."
+          $ArrayOfFilePaths = New-ArrayOfFilePaths `
+            -ModuleDestinationPath repo
+          Write-Output "Creating a file with a list of the files to sign..."
+          $FileListFileName = New-FileList `
+            -ArrayOfFilePaths $ArrayOfFilePaths
+          Write-Output "Calling AzureSignTool function to sign scripts, manifest, and modules..."
+          $AzureKeyVaultUrl = '${{ steps.key-vault-info.outputs.KeyVaultUrl }}'
+          $CertificateName = '${{ steps.key-vault-info.outputs.KeyVaultCertificateName }}'
+          Use-AzureSignTool `
+            -AzureKeyVaultUrl $AzureKeyVaultUrl `
+            -CertificateName $CertificateName `
+            -FileList $FileListFileName
+          Move-Item  -Path repo -Destination "ScubaGear-${env:RELEASE_VERSION}" -Force
+          Compress-Archive -Path "ScubaGear-${env:RELEASE_VERSION}" -DestinationPath "ScubaGear-${env:RELEASE_VERSION}.zip"
       - name: Create Release
         uses: softprops/action-gh-release@v1
         id: create-release


### PR DESCRIPTION
## 🗣 Description ##

The build and sign GitHub release workflow uses some of the same publish code that the publish to PSGallery workflows use (see utils/workflow/Publish-ScubaGear.ps1).  The publish code was recently refactored, but the GitHub workflow was not updated to use the changes.  This PR corrects that oversight.

## 💭 Motivation and context ##

Closes: #1255 
Future improvements: #1257 

## 🧪 Testing ##

Checked the workflow pipeline.
Published an RC to GitHub.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] These code changes follow the ScubaGear [content style guide]
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

- [x] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed
- [x] Resolved all merge conflicts on branch
- [x] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
