### PR TITLE
Fix AAD 401 authentication errors against GCC high tenants

### DIFF
--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -550,7 +550,7 @@ function Invoke-ProviderList {
                     $RetVal = ""
                     switch ($Product) {
                         "aad" {
-                            $RetVal = Export-AADProvider | Select-Object -Last 1
+                            $RetVal = Export-AADProvider -M365Environment $M365Environment | Select-Object -Last 1
                         }
                         "exo" {
                             $RetVal = Export-EXOProvider | Select-Object -Last 1

--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -328,7 +328,7 @@ function Get-PrivilegedUser {
                 if ($TenantHasPremiumLicense) {
                     # Get the users that are assigned to the PIM group as Eligible members
                     $graphArgs = @{
-                        "commandlet" = "Get-MgBetaIdentityGovernancePrivilegedAccessGroupEligibilityScheduleInstance" 
+                        "commandlet" = "Get-MgBetaIdentityGovernancePrivilegedAccessGroupEligibilityScheduleInstance"
                         "queryParams" = @{'$filter' = "groupId eq '$GroupId'"}
                         "M365Environment" = $M365Environment }
                     $PIMGroupMembers = Invoke-GraphDirectly @graphArgs
@@ -356,7 +356,7 @@ function Get-PrivilegedUser {
     if ($TenantHasPremiumLicense) {
         # Get a list of all the users and groups that have Eligible assignments
         $graphArgs = @{
-            "commandlet" = "Get-MgBetaRoleManagementDirectoryRoleEligibilityScheduleInstance" 
+            "commandlet" = "Get-MgBetaRoleManagementDirectoryRoleEligibilityScheduleInstance"
             "M365Environment" = $M365Environment }
         $AllPIMRoleAssignments = Invoke-GraphDirectly @graphArgs
 
@@ -612,7 +612,7 @@ function Get-PrivilegedRole {
 
         # Get ALL the roles and users actively assigned to them
         $graphArgs = @{
-            "commandlet" = "Get-MgBetaRoleManagementDirectoryRoleAssignmentScheduleInstance" 
+            "commandlet" = "Get-MgBetaRoleManagementDirectoryRoleAssignmentScheduleInstance"
             "M365Environment" = $M365Environment }
         $AllRoleAssignments = Invoke-GraphDirectly @graphArgs
 

--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -14,6 +14,10 @@ function Invoke-GraphDirectly {
         [string]
         $commandlet,
 
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $M365Environment,
+
         [System.Collections.Hashtable]
         $queryParams
     )
@@ -23,6 +27,16 @@ function Invoke-GraphDirectly {
         $endpoint = $GraphEndpoints[$commandlet]
     } catch {
         Write-Error "The commandlet $commandlet can't be used with the Invoke-GraphDirectly function yet."
+    }
+
+    if ($M365Environment -eq "gcchigh") {
+        $endpoint = "https://graph.microsoft.us" + $endpoint
+    }
+    elseif ($M365Environment -eq "dod") {
+        $endpoint = "https://dod-graph.microsoft.us" + $endpoint
+    }
+    else {
+        $endpoint = "https://graph.microsoft.com" + $endpoint
     }
 
     if ($queryParams) {
@@ -41,7 +55,7 @@ function Invoke-GraphDirectly {
     }
     Write-Debug "Graph Api direct: $endpoint"
 
-    $resp = Invoke-MgGraphRequest -Uri $endpoint -UserAgent 'ScubaGear'
+    $resp = Invoke-MgGraphRequest -Uri $endpoint
     return $resp.Value
 }
 
@@ -54,6 +68,13 @@ function Export-AADProvider {
     .Functionality
     Internal
     #>
+
+    [CmdletBinding()]
+    param (
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $M365Environment
+    )
 
     Import-Module $PSScriptRoot/ProviderHelpers/CommandTracker.psm1
     $Tracker = Get-CommandTracker
@@ -103,10 +124,10 @@ function Export-AADProvider {
         # Get-PrivilegedUser provides a list of privileged users and their role assignments. Used for 2.11 and 2.12
         if ($RequiredServicePlan) {
             # If the tenant has the premium license then we want to also include PIM Eligible role assignments - otherwise we don't to avoid an API error
-            $PrivilegedUsers = $Tracker.TryCommand("Get-PrivilegedUser", @{"TenantHasPremiumLicense"=$true})
+            $PrivilegedUsers = $Tracker.TryCommand("Get-PrivilegedUser", @{"TenantHasPremiumLicense"=$true; "M365Environment"=$M365Environment})
         }
         else{
-            $PrivilegedUsers = $Tracker.TryCommand("Get-PrivilegedUser", @{"TenantHasPremiumLicense"=$false})
+            $PrivilegedUsers = $Tracker.TryCommand("Get-PrivilegedUser", @{"TenantHasPremiumLicense"=$false; "M365Environment"=$M365Environment})
         }
         $PrivilegedUsers = $PrivilegedUsers | ConvertTo-Json
         # The above Converto-Json call doesn't need to have the input wrapped in an
@@ -125,10 +146,10 @@ function Export-AADProvider {
         # Get-PrivilegedRole provides data for 2.14 - 2.16, policies that evaluate conditions related to Azure AD PIM
         if ($RequiredServicePlan){
             # If the tenant has the premium license then we want to also include PIM Eligible role assignments - otherwise we don't to avoid an API error
-            $PrivilegedRoles = $Tracker.TryCommand("Get-PrivilegedRole", @{"TenantHasPremiumLicense"=$true})
+            $PrivilegedRoles = $Tracker.TryCommand("Get-PrivilegedRole", @{"TenantHasPremiumLicense"=$true; "M365Environment"=$M365Environment})
         }
         else {
-            $PrivilegedRoles = $Tracker.TryCommand("Get-PrivilegedRole", @{"TenantHasPremiumLicense"=$false})
+            $PrivilegedRoles = $Tracker.TryCommand("Get-PrivilegedRole", @{"TenantHasPremiumLicense"=$false; "M365Environment"=$M365Environment})
         }
         $PrivilegedRoles = ConvertTo-Json -Depth 10 @($PrivilegedRoles) # Depth required to get policy rule object details
     }
@@ -246,7 +267,11 @@ function Get-PrivilegedUser {
     param (
         [ValidateNotNullOrEmpty()]
         [switch]
-        $TenantHasPremiumLicense
+        $TenantHasPremiumLicense,
+
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $M365Environment
     )
 
     # A hashtable of privileged users
@@ -303,9 +328,9 @@ function Get-PrivilegedUser {
                 if ($TenantHasPremiumLicense) {
                     # Get the users that are assigned to the PIM group as Eligible members
                     $graphArgs = @{
-                        "commandlet" = "Get-MgBetaIdentityGovernancePrivilegedAccessGroupEligibilityScheduleInstance"
+                        "commandlet" = "Get-MgBetaIdentityGovernancePrivilegedAccessGroupEligibilityScheduleInstance" 
                         "queryParams" = @{'$filter' = "groupId eq '$GroupId'"}
-                    }
+                        "M365Environment" = $M365Environment }
                     $PIMGroupMembers = Invoke-GraphDirectly @graphArgs
                     foreach ($GroupMember in $PIMGroupMembers) {
                         # If the user is not a member of the PIM group (i.e. they are an owner) then skip them
@@ -331,8 +356,8 @@ function Get-PrivilegedUser {
     if ($TenantHasPremiumLicense) {
         # Get a list of all the users and groups that have Eligible assignments
         $graphArgs = @{
-            "commandlet" = "Get-MgBetaRoleManagementDirectoryRoleEligibilityScheduleInstance"
-        }
+            "commandlet" = "Get-MgBetaRoleManagementDirectoryRoleEligibilityScheduleInstance" 
+            "M365Environment" = $M365Environment }
         $AllPIMRoleAssignments = Invoke-GraphDirectly @graphArgs
 
         # Add to the list of privileged users based on Eligible assignments
@@ -389,7 +414,7 @@ function Get-PrivilegedUser {
                     $graphArgs = @{
                         "commandlet" = "Get-MgBetaIdentityGovernancePrivilegedAccessGroupEligibilityScheduleInstance"
                         "queryParams" = @{'$filter' = "groupId eq '$UserObjectId'"}
-                    }
+                        "M365Environment" = $M365Environment}
                     $PIMGroupMembers = Invoke-GraphDirectly @graphArgs
                     foreach ($GroupMember in $PIMGroupMembers) {
                         # If the user is not a member of the PIM group (i.e. they are an owner) then skip them
@@ -453,14 +478,18 @@ function GetConfigurationsForPimGroups{
 
         [ValidateNotNullOrEmpty()]
         [array]
-        $AllRoleAssignments
+        $AllRoleAssignments,
+
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $M365Environment
     )
 
     # Get a list of the groups that are enrolled in PIM - we want to ignore the others
     $graphArgs = @{
         "commandlet" = "Get-MgBetaPrivilegedAccessResource"
         "queryParams" = @{'$PrivilegedAccessId' = "aadGroups"}
-    }
+        "M365Environment" = $M365Environment }
     $PIMGroups = Invoke-GraphDirectly @graphArgs
 
     foreach ($RoleAssignment in $AllRoleAssignments){
@@ -564,7 +593,11 @@ function Get-PrivilegedRole {
     param (
         [ValidateNotNullOrEmpty()]
         [switch]
-        $TenantHasPremiumLicense
+        $TenantHasPremiumLicense,
+
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $M365Environment
     )
 
     $PrivilegedRoles = [ScubaConfig]::ScubaDefault('DefaultPrivilegedRoles')
@@ -579,15 +612,15 @@ function Get-PrivilegedRole {
 
         # Get ALL the roles and users actively assigned to them
         $graphArgs = @{
-            "commandlet" = "Get-MgBetaRoleManagementDirectoryRoleAssignmentScheduleInstance"
-        }
+            "commandlet" = "Get-MgBetaRoleManagementDirectoryRoleAssignmentScheduleInstance" 
+            "M365Environment" = $M365Environment }
         $AllRoleAssignments = Invoke-GraphDirectly @graphArgs
 
         # Each of the helper functions below add configuration settings (aka rules) to the role hashtable.
         # Get the PIM configurations for the roles
         GetConfigurationsForRoles -PrivilegedRoleHashtable $PrivilegedRoleHashtable -AllRoleAssignments $AllRoleAssignments
         # Get the PIM configurations for the groups
-        GetConfigurationsForPimGroups -PrivilegedRoleHashtable $PrivilegedRoleHashtable -AllRoleAssignments $AllRoleAssignments
+        GetConfigurationsForPimGroups -PrivilegedRoleHashtable $PrivilegedRoleHashtable -AllRoleAssignments $AllRoleAssignments -M365Environment $M365Environment
     }
 
     # Return the hashtable

--- a/PowerShell/ScubaGear/Modules/Support/Support.psm1
+++ b/PowerShell/ScubaGear/Modules/Support/Support.psm1
@@ -117,10 +117,10 @@ function Initialize-SCuBA {
     # Need to determine where module is so we can get required versions info
     $ParentPath = Split-Path -parent $PSScriptRoot
     $ModulePath = Split-Path -parent $ParentPath
-    # Why do we need to import this function in the middle of the function?
-    # Two possibilities:
-    # 1) importing the function restricts the import so only that function is exported
-    # 2) imported functions take precedence over imported modules
+    # Removing the import below causes issues with testing, let it be.  
+    # Import module magic may be helping by:
+    #   * restricting the import so only that only function is exported
+    #   * imported function takes precedence over imported modules w/ function
     Import-Module $ModulePath -Function Initialize-Scuba
     $ModuleParentDir = Split-Path -Path (Get-Module ScubaGear).Path -Parent
     try {

--- a/PowerShell/ScubaGear/Modules/Support/Support.psm1
+++ b/PowerShell/ScubaGear/Modules/Support/Support.psm1
@@ -114,10 +114,13 @@ function Initialize-SCuBA {
     # Start a stopwatch to time module installation elapsed time
     $Stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
+    Write-Information 'Importing module...'
     # Need to determine where module is so we can get required versions info
     $ModulePath = (Get-Item $PSScriptRoot).parent.parent
-    Write-Information 'Importing module...'
-    Import-Module (Join-Path -Path $ModulePath -ChildPath 'PowerShell/ScubaGear' -Resolve) -Function Initialize-Scuba
+    Write-Information "The module path is $ModulePath"
+    # Why do we need to import this function in the middle of the function?
+    # We don't know.  But it's required.
+    Import-Module $ModulePath -Function Initialize-Scuba
     $ModuleParentDir = Split-Path -Path (Get-Module ScubaGear).Path -Parent
     try {
         ($RequiredModulesPath = Join-Path -Path $ModuleParentDir -ChildPath 'RequiredVersions.ps1') *> $null

--- a/PowerShell/ScubaGear/Modules/Support/Support.psm1
+++ b/PowerShell/ScubaGear/Modules/Support/Support.psm1
@@ -115,13 +115,9 @@ function Initialize-SCuBA {
     $Stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
     # Need to determine where module is so we can get required versions info
-    $CurrentLocation = Get-Location
-    Write-Information 'Current location is...'
-    Write-Information $CurrentLocation
-    Write-Information 'The PSSCriptRoot location is...'
-    Write-Information $PSScriptRoot
+    $ModulePath = (Get-Item $PSScriptRoot).parent.parent
     Write-Information 'Importing module...'
-    Import-Module (Join-Path -Path $CurrentLocation -ChildPath 'PowerShell/ScubaGear') -Function Initialize-Scuba
+    Import-Module (Join-Path -Path $ModulePath -ChildPath 'PowerShell/ScubaGear' -Resolve) -Function Initialize-Scuba
     $ModuleParentDir = Split-Path -Path (Get-Module ScubaGear).Path -Parent
     try {
         ($RequiredModulesPath = Join-Path -Path $ModuleParentDir -ChildPath 'RequiredVersions.ps1') *> $null

--- a/PowerShell/ScubaGear/Modules/Support/Support.psm1
+++ b/PowerShell/ScubaGear/Modules/Support/Support.psm1
@@ -114,7 +114,6 @@ function Initialize-SCuBA {
     # Start a stopwatch to time module installation elapsed time
     $Stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
-    Write-Information 'Importing module...'
     # Need to determine where module is so we can get required versions info
     $ParentPath = Split-Path -parent $PSScriptRoot
     $ModulePath = Split-Path -parent $ParentPath

--- a/PowerShell/ScubaGear/Modules/Support/Support.psm1
+++ b/PowerShell/ScubaGear/Modules/Support/Support.psm1
@@ -118,7 +118,6 @@ function Initialize-SCuBA {
     # Need to determine where module is so we can get required versions info
     $ParentPath = Split-Path -parent $PSScriptRoot
     $ModulePath = Split-Path -parent $ParentPath
-    Write-Information "The module path is $ModulePath"
     # Why do we need to import this function in the middle of the function?
     # We don't know.  But it's required.
     Import-Module $ModulePath -Function Initialize-Scuba

--- a/PowerShell/ScubaGear/Modules/Support/Support.psm1
+++ b/PowerShell/ScubaGear/Modules/Support/Support.psm1
@@ -116,7 +116,8 @@ function Initialize-SCuBA {
 
     Write-Information 'Importing module...'
     # Need to determine where module is so we can get required versions info
-    $ModulePath = (Get-Item $PSScriptRoot).parent.parent
+    $ParentPath = Split-Path -parent $PSScriptRoot
+    $ModulePath = Split-Path -parent $ParentPath
     Write-Information "The module path is $ModulePath"
     # Why do we need to import this function in the middle of the function?
     # We don't know.  But it's required.

--- a/PowerShell/ScubaGear/Modules/Support/Support.psm1
+++ b/PowerShell/ScubaGear/Modules/Support/Support.psm1
@@ -119,7 +119,9 @@ function Initialize-SCuBA {
     $ParentPath = Split-Path -parent $PSScriptRoot
     $ModulePath = Split-Path -parent $ParentPath
     # Why do we need to import this function in the middle of the function?
-    # We don't know.  But it's required.
+    # Two possibilities:
+    # 1) importing the function restricts the import so only that function is exported
+    # 2) imported functions take precedence over imported modules
     Import-Module $ModulePath -Function Initialize-Scuba
     $ModuleParentDir = Split-Path -Path (Get-Module ScubaGear).Path -Parent
     try {

--- a/PowerShell/ScubaGear/Modules/Support/Support.psm1
+++ b/PowerShell/ScubaGear/Modules/Support/Support.psm1
@@ -116,6 +116,10 @@ function Initialize-SCuBA {
 
     # Need to determine where module is so we can get required versions info
     $CurrentLocation = Get-Location
+    Write-Information 'Current location is...'
+    Write-Information $CurrentLocation
+    Write-Information 'The PSSCriptRoot location is...'
+    Write-Information $PSScriptRoot
     Write-Information 'Importing module...'
     Import-Module (Join-Path -Path $CurrentLocation -ChildPath 'PowerShell/ScubaGear') -Function Initialize-Scuba
     $ModuleParentDir = Split-Path -Path (Get-Module ScubaGear).Path -Parent

--- a/PowerShell/ScubaGear/Modules/Support/Support.psm1
+++ b/PowerShell/ScubaGear/Modules/Support/Support.psm1
@@ -117,7 +117,7 @@ function Initialize-SCuBA {
     # Need to determine where module is so we can get required versions info
     $ParentPath = Split-Path -parent $PSScriptRoot
     $ModulePath = Split-Path -parent $ParentPath
-    # Removing the import below causes issues with testing, let it be.  
+    # Removing the import below causes issues with testing, let it be.
     # Import module magic may be helping by:
     #   * restricting the import so only that only function is exported
     #   * imported function takes precedence over imported modules w/ function

--- a/PowerShell/ScubaGear/Modules/Support/Support.psm1
+++ b/PowerShell/ScubaGear/Modules/Support/Support.psm1
@@ -115,6 +115,9 @@ function Initialize-SCuBA {
     $Stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
     # Need to determine where module is so we can get required versions info
+    $CurrentLocation = Get-Location
+    Write-Information 'Importing module...'
+    Import-Module (Join-Path -Path $CurrentLocation -ChildPath 'PowerShell/ScubaGear') -Function Initialize-Scuba
     $ModuleParentDir = Split-Path -Path (Get-Module ScubaGear).Path -Parent
     try {
         ($RequiredModulesPath = Join-Path -Path $ModuleParentDir -ChildPath 'RequiredVersions.ps1') *> $null

--- a/Testing/Functional/Products/Products.Tests.ps1
+++ b/Testing/Functional/Products/Products.Tests.ps1
@@ -105,7 +105,6 @@ Import-Module $ConnectionModule
 Import-Module Selenium
 
 BeforeDiscovery{
-    Import-Module -Name .\PowerShell\ScubaGear
     if ($Variant) {
         $TestPlanFileName = "TestPlans/$ProductName.$Variant.testplan.yaml"
     }

--- a/Testing/Functional/Products/Products.Tests.ps1
+++ b/Testing/Functional/Products/Products.Tests.ps1
@@ -105,7 +105,7 @@ Import-Module $ConnectionModule
 Import-Module Selenium
 
 BeforeDiscovery{
-
+    Import-Module -Name .\PowerShell\ScubaGear
     if ($Variant) {
         $TestPlanFileName = "TestPlans/$ProductName.$Variant.testplan.yaml"
     }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##

This PR fixes the problem when running AAD against GCC high tenants with newer versions of the Graph dependency modules. We started getting 401 Unauthorized errors against GCC high because there was some problem with the token that we traced to Invoke-MgGraphRequest. The fix was to pass the MS graph FQDN prefix when calling that cmdlet and that seems to rectify the  issue.

Closes #1265 

## 🧪 Testing ##

- Test against all tenants, including GCC high.
- Run AAD with other products and by itself.
- Run ScubaGear with a config file as well.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [ ] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] PR passed smoke test check.
- [ ] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [ ] Resolved all merge conflicts on branch
- [ ] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
