### PR TITLE
Remove workflow unit tests from CI pipeline

### DIFF
--- a/.github/workflows/run_pipeline.yaml
+++ b/.github/workflows/run_pipeline.yaml
@@ -53,9 +53,3 @@ jobs:
       - scan-secret
       - check-security
     uses: ./.github/workflows/unit_test_opa.yaml
-  unit-workflow:
-    name: Unit
-    needs:
-      - scan-secret
-      - check-security
-    uses: ./.github/workflows/unit_test_workflows.yaml


### PR DESCRIPTION
## 🗣 Description ##

Remove the workflow unit tests from the CI pipeline, since they are now in their own pipeline, the workflow pipeline.

## 💭 Motivation and context ##

Closes #1271 

## 🧪 Testing ##

Removed job.  Re-ran workflow.  Tests still pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] These code changes follow the ScubaGear [content style guide]
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

- [x] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed
- [x] Resolved all merge conflicts on branch
- [x] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
