### PR TITLE
Fix encoding issue by removing BOM from provider output files

### DIFF
--- a/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
+++ b/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
@@ -1,3 +1,5 @@
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath "..\Utility")
+
 function New-Report {
      <#
     .Description
@@ -60,11 +62,11 @@ function New-Report {
 
     $ProductSecureBaseline = $SecureBaselines.$BaselineName
 
-    $FileName = Join-Path -Path $OutPath -ChildPath "$($OutProviderFileName).json"
-    $SettingsExport =  Get-Content $FileName | ConvertFrom-Json
+    $FileName = Join-Path -Path $OutPath -ChildPath "$($OutProviderFileName).json" -Resolve
+    $SettingsExport =  Get-Utf8NoBom -FilePath $FileName | ConvertFrom-Json
 
-    $FileName = Join-Path -Path $OutPath -ChildPath "$($OutRegoFileName).json"
-    $TestResults =  Get-Content $FileName | ConvertFrom-Json
+    $FileName = Join-Path -Path $OutPath -ChildPath "$($OutRegoFileName).json" -Resolve
+    $TestResults =  Get-Utf8NoBom -FilePath $FileName | ConvertFrom-Json
 
     $Fragments = @()
 

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -628,7 +628,7 @@ function Invoke-ProviderList {
         }
 "@
 
-            # PowerShell 5 includes the "byte-order mark" (BOM) when it writes UTF-8 files. However, OPA appears to not
+            # PowerShell 5 includes the "byte-order mark" (BOM) when it writes UTF-8 files. However, OPA (as of 0.68) appears to not
             # be able to handle the "\/" character sequence if the input json is UTF-8 encoded with the BOM, resulting
             # in the "unable to parse input: yaml" error message. As such, we need to save the provider output without
             # the BOM

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -519,7 +519,46 @@ function Out-Utf8NoBom {
         $FinalPath = Join-Path -Path $ResolvedPath -ChildPath $FileName -ErrorAction 'Stop'
         # The $false in the next line indicates that the BOM should not be used.
         $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-        [System.IO.File]::WriteAllLines($FinalPath, $Content, $Utf8NoBomEncoding)
+        Invoke-WriteAllLines($FinalPath, $Content, $Utf8NoBomEncoding)
+        return $FinalPath  # Used to test path construction more easily
+    }
+}
+
+function Invoke-WriteAllLines {
+    <#
+    .Description
+    Using the .NET framework, save the provided content to the file
+    path provided using the given encoding.
+    .Functionality
+    Internal
+    .Parameter Content
+    The content to save to the file.
+    .Parameter Path
+    The full file path to the file being written.
+    .Parameter Encoding
+    An object of type System.Text.Encoding that determines how the
+    content is encoded for output to file.
+    Default: UTF-8 without BOM encoding used
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Content,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [System.Text.Encoding]
+        $Encoding = (New-Object System.Text.UTF8Encoding $False)
+    )
+    process {
+        [System.IO.File]::WriteAllLines($Path, $Content, $Encoding)
     }
 }
 

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -629,7 +629,7 @@ function Invoke-ProviderList {
 "@
 
             $FinalPath = Join-Path -Path $OutFolderPath -ChildPath "$($OutProviderFileName).json" -ErrorAction 'Stop'
-
+            Write-Warning $FinalPath
             # PowerShell 5 includes the "byte-order mark" (BOM) when it writes UTF-8 files. However, OPA appears to not
             # be able to handle the "\/" character sequence if the input json is UTF-8 encoded with the BOM, resulting
             # in the "unable to parse input: yaml" error message. We can save a UTF-8 file without the BOM by utilizing

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -1465,8 +1465,6 @@ function Remove-Resources {
         Remove-Module $Provider -ErrorAction "SilentlyContinue"
     }
 
-    Remove-Module "Utility" -ErrorAction "SilentlyContinue"
-    Remove-Module "Support" -ErrorAction "SilentlyContinue"
     Remove-Module "ScubaConfig" -ErrorAction "SilentlyContinue"
     Remove-Module "RunRego" -ErrorAction "SilentlyContinue"
     Remove-Module "CreateReport" -ErrorAction "SilentlyContinue"

--- a/PowerShell/ScubaGear/Modules/Utility/Utility.psm1
+++ b/PowerShell/ScubaGear/Modules/Utility/Utility.psm1
@@ -1,0 +1,137 @@
+
+function Set-Utf8NoBom {
+    <#
+    .Description
+    Using the .NET framework, save the provided input as a UTF-8 file without the byte-order marking (BOM).
+    .Functionality
+    Internal
+    .Parameter Content
+    The content to save to the file.
+    .Parameter Location
+    The location to save the file to. Note that it MUST already exist and that the name of the file you want to save
+    should not be included in this string.
+    .Parameter FileName
+    The name of the file you want to save. Note this should not include the full path, i.e., use "Example.json" instead
+    of "./examplefolder/Example.json"
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Content,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Location,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $FileName
+    )
+    process {
+        # Need to insure the location is an absolute path, otherwise you can get some inconsistent behavior.
+        $ResolvedPath = $(Resolve-Path $Location).ProviderPath
+        $FinalPath = Join-Path -Path $ResolvedPath -ChildPath $FileName -ErrorAction 'Stop'
+        # The $false in the next line indicates that the BOM should not be used.
+        $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+        Invoke-WriteAllLines -Content $Content -Path $FinalPath -Encoding $Utf8NoBomEncoding
+        $FinalPath  # Used to test path construction more easily
+    }
+}
+
+function Get-Utf8NoBom {
+    <#
+    .Description
+    Using the .NET framework, read the provided path as a UTF-8 file without the byte-order marking (BOM).
+    .Functionality
+    Internal
+    .Parameter FilePath
+    The full path of the file you want to read.  The file must exist.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $FilePath
+    )
+    process {
+        # The $false in the next line indicates that the BOM should not be used.
+        $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+        $Content = Invoke-ReadAllLines -Path $FilePath -Encoding $Utf8NoBomEncoding
+        return $Content
+    }
+}
+
+function Invoke-WriteAllLines {
+    <#
+    .Description
+    Using the .NET framework, save the provided content to the file
+    path provided using the given encoding.
+    .Functionality
+    Internal
+    .Parameter Content
+    The content to save to the file.
+    .Parameter Path
+    The full file path to the file being written.
+    .Parameter Encoding
+    An object of type System.Text.Encoding that determines how the
+    content is encoded for output to file.
+    Default: UTF-8 without BOM encoding used
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Content,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [System.Text.Encoding]
+        $Encoding = (New-Object System.Text.UTF8Encoding $False)
+    )
+    process {
+        [System.IO.File]::WriteAllLines($Path, $Content, $Encoding)
+    }
+}
+
+function Invoke-ReadAllLines {
+    <#
+    .Description
+    Using the .NET framework, read content from the file
+    path provided using the given encoding.
+    .Functionality
+    Internal
+    .Parameter Path
+    The full file path to the file being written.
+    .Parameter Encoding
+    An object of type System.Text.Encoding that determines how the
+    content is encoded for output to file.
+    Default: UTF-8 without BOM encoding used
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Path,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [System.Text.Encoding]
+        $Encoding = (New-Object System.Text.UTF8Encoding $False)
+    )
+    process {
+        $Content = [System.IO.File]::ReadAllLines($Path, $Encoding)
+        return $Content
+    }
+}

--- a/PowerShell/ScubaGear/Modules/Utility/Utility.psm1
+++ b/PowerShell/ScubaGear/Modules/Utility/Utility.psm1
@@ -61,7 +61,9 @@ function Get-Utf8NoBom {
     process {
         # The $false in the next line indicates that the BOM should not be used.
         $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-        $Content = Invoke-ReadAllLines -Path $FilePath -Encoding $Utf8NoBomEncoding
+
+        $ResolvedPath = $(Resolve-Path $FilePath).ProviderPath
+        $Content = Invoke-ReadAllLines -Path $ResolvedPath -Encoding $Utf8NoBomEncoding
         return $Content
     }
 }

--- a/PowerShell/ScubaGear/Modules/Utility/Utility.psm1
+++ b/PowerShell/ScubaGear/Modules/Utility/Utility.psm1
@@ -37,7 +37,7 @@ function Set-Utf8NoBom {
         $FinalPath = Join-Path -Path $ResolvedPath -ChildPath $FileName -ErrorAction 'Stop'
         # The $false in the next line indicates that the BOM should not be used.
         $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-        Invoke-WriteAllLines -Content $Content -Path $FinalPath -Encoding $Utf8NoBomEncoding
+        Invoke-WriteAllText -Content $Content -Path $FinalPath -Encoding $Utf8NoBomEncoding
         $FinalPath  # Used to test path construction more easily
     }
 }
@@ -63,12 +63,12 @@ function Get-Utf8NoBom {
         $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
 
         $ResolvedPath = $(Resolve-Path $FilePath).ProviderPath
-        $Content = Invoke-ReadAllLines -Path $ResolvedPath -Encoding $Utf8NoBomEncoding
+        $Content = Invoke-ReadAllText -Path $ResolvedPath -Encoding $Utf8NoBomEncoding
         return $Content
     }
 }
 
-function Invoke-WriteAllLines {
+function Invoke-WriteAllText {
     <#
     .Description
     Using the .NET framework, save the provided content to the file
@@ -102,11 +102,11 @@ function Invoke-WriteAllLines {
         $Encoding = (New-Object System.Text.UTF8Encoding $False)
     )
     process {
-        [System.IO.File]::WriteAllLines($Path, $Content, $Encoding)
+        [System.IO.File]::WriteAllText($Path, $Content, $Encoding)
     }
 }
 
-function Invoke-ReadAllLines {
+function Invoke-ReadAllText {
     <#
     .Description
     Using the .NET framework, read content from the file
@@ -133,7 +133,7 @@ function Invoke-ReadAllLines {
         $Encoding = (New-Object System.Text.UTF8Encoding $False)
     )
     process {
-        $Content = [System.IO.File]::ReadAllLines($Path, $Encoding)
+        $Content = [System.IO.File]::ReadAllText($Path, $Encoding)
         return $Content
     }
 }

--- a/PowerShell/ScubaGear/Modules/Utility/Utility.psm1
+++ b/PowerShell/ScubaGear/Modules/Utility/Utility.psm1
@@ -64,7 +64,7 @@ function Get-Utf8NoBom {
 
         $ResolvedPath = $(Resolve-Path $FilePath).ProviderPath
         $Content = Invoke-ReadAllText -Path $ResolvedPath -Encoding $Utf8NoBomEncoding
-        return $Content
+        $Content
     }
 }
 

--- a/PowerShell/ScubaGear/Modules/Utility/Utility.psm1
+++ b/PowerShell/ScubaGear/Modules/Utility/Utility.psm1
@@ -134,7 +134,7 @@ function Invoke-ReadAllText {
     )
     process {
         $Content = [System.IO.File]::ReadAllText($Path, $Encoding)
-        return $Content
+        $Content
     }
 }
 

--- a/PowerShell/ScubaGear/Modules/Utility/Utility.psm1
+++ b/PowerShell/ScubaGear/Modules/Utility/Utility.psm1
@@ -114,7 +114,7 @@ function Invoke-ReadAllLines {
     .Functionality
     Internal
     .Parameter Path
-    The full file path to the file being written.
+    The full file path to the file being read.
     .Parameter Encoding
     An object of type System.Text.Encoding that determines how the
     content is encoded for output to file.

--- a/PowerShell/ScubaGear/Modules/Utility/Utility.psm1
+++ b/PowerShell/ScubaGear/Modules/Utility/Utility.psm1
@@ -137,3 +137,8 @@ function Invoke-ReadAllLines {
         return $Content
     }
 }
+
+Export-ModuleMember -Function @(
+    'Get-Utf8NoBom',
+    'Set-Utf8NoBom'
+)

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/CreateReport/New-Report.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/CreateReport/New-Report.Tests.ps1
@@ -5,9 +5,9 @@ InModuleScope CreateReport {
         BeforeAll {
             Mock -CommandName Write-Warning {}
 
-            New-Item -Path (Join-Path -Path "TestDrive:" -ChildPath "CreateReportStubs") -Name "CreateReportUnitFolder" -ItemType Directory
-            New-Item -Path (Join-Path -Path "TestDrive:" -ChildPath "CreateReportStubs/CreateReportUnitFolder") -Name "IndividualReports" -ItemType Directory
-            $TestOutPath = (Join-Path -Path "TestDrive:" -ChildPath "CreateReportStubs")
+            New-Item -Path (Join-Path -Path $TestDrive -ChildPath "CreateReportStubs") -Name "CreateReportUnitFolder" -ItemType Directory
+            New-Item -Path (Join-Path -Path $TestDrive -ChildPath "CreateReportStubs/CreateReportUnitFolder") -Name "IndividualReports" -ItemType Directory
+            $TestOutPath = (Join-Path -Path $TestDrive -ChildPath "CreateReportStubs")
             Copy-Item -Path (Join-Path -Path $PSScriptRoot -ChildPath "CreateReportStubs/*") -Destination $TestOutPath -Recurse
 
             [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'ArgToProd')]
@@ -30,7 +30,7 @@ InModuleScope CreateReport {
             }
         }
         BeforeEach {
-            $IndividualReportPath = (Join-Path -Path "TestDrive:" -ChildPath "CreateReportStubs/CreateReportUnitFolder/IndividualReports")
+            $IndividualReportPath = (Join-Path -Path $TestDrive -ChildPath "CreateReportStubs/CreateReportUnitFolder/IndividualReports")
             [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'CreateReportParams')]
             $CreateReportParams = @{
                 'IndividualReportPath' = $IndividualReportPath

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-ProviderList.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-ProviderList.Tests.ps1
@@ -23,6 +23,7 @@ Describe -Tag 'Orchestrator' -Name 'Invoke-ProviderList' {
         Mock -CommandName Join-Path {"."}
         Mock -CommandName Set-Content {}
         Mock -CommandName Get-TimeZone {}
+        Mock -CommandName Out-Utf8NoBom {}
     }
     Context 'When running the providers on commercial tenants' {
         BeforeAll {

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-ProviderList.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-ProviderList.Tests.ps1
@@ -23,7 +23,7 @@ Describe -Tag 'Orchestrator' -Name 'Invoke-ProviderList' {
         Mock -CommandName Join-Path {"."}
         Mock -CommandName Set-Content {}
         Mock -CommandName Get-TimeZone {}
-        Mock -CommandName Out-Utf8NoBom {}
+        Mock -CommandName Set-Utf8NoBom {}
         Mock -CommandName Write-Debug {}
     }
     Context 'When running the providers on commercial tenants' {

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-ProviderList.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-ProviderList.Tests.ps1
@@ -24,6 +24,7 @@ Describe -Tag 'Orchestrator' -Name 'Invoke-ProviderList' {
         Mock -CommandName Set-Content {}
         Mock -CommandName Get-TimeZone {}
         Mock -CommandName Out-Utf8NoBom {}
+        Mock -CommandName Write-Debug {}
     }
     Context 'When running the providers on commercial tenants' {
         BeforeAll {

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Out-Utf8NoBom.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Out-Utf8NoBom.Tests.ps1
@@ -30,7 +30,7 @@ InModuleScope Orchestrator {
         # # Requires ability to create SMB shares on your box to run
         # Context 'UNC path' {
         #     It 'Write to shared UNC path' {
-        #                         Out-Utf8NoBom -Content "test" -Location "$env:COMPUTERNAME\Shared" -FileName "output.json" `
+        #                         Out-Utf8NoBom -Content "test" -Location "\\$env:COMPUTERNAME\Shared" -FileName "output.json" `
         #         | Should -Be "\\$env:COMPUTERNAME\Shared\output.json"
         #     }
         # }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Out-Utf8NoBom.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Out-Utf8NoBom.Tests.ps1
@@ -1,0 +1,48 @@
+$OrchestratorPath = '../../../../Modules/Orchestrator.psm1'
+Import-Module (Join-Path -Path $PSScriptRoot -ChildPath $OrchestratorPath) -Function 'Out-Utf8NoBom' -Force
+
+InModuleScope Orchestrator {
+    Describe -Tag 'Orchestrator' -Name 'Out-Utf8NoBom' {
+        BeforeAll {
+            function Invoke-WriteAllLines {}
+            Mock -ModuleName Orchestrator Invoke-WriteAllLines
+
+            # Setup test directories for testing
+            New-Item -ItemType Directory './a/b' -Force -ErrorAction Ignore
+            New-Item -ItemType Directory './c' -Force -ErrorAction Ignore
+            New-Item -ItemType Directory './shared/a/b' -Force -ErrorAction Ignore
+            New-Item -ItemType Directory './shared/c' -Force -ErrorAction Ignore
+            # New-SmbShare -Name "Shared" -Path ".\shared" -ReadAccess "Everyone"
+
+            $pwd = Get-Location
+        }
+
+        Context 'local file' {
+            It 'Write to root drive path' {
+                Out-Utf8NoBom -Content "test" -Location "C:\" -FileName "output.json" `
+                | Should -Be "C:\output.json"
+            }
+
+            It 'Write to local subdirectory path' {
+                Out-Utf8NoBom -Content "test" -Location "a" -FileName "output.json" `
+                | Should -Be "$pwd\a\output.json"
+            }
+        }
+
+        # # Requires ability to create SMB shares on your box to run
+        # Context 'UNC path' {
+        #     It 'Write to shared UNC path' {
+        #                         Out-Utf8NoBom -Content "test" -Location "$env:COMPUTERNAME\Shared" -FileName "output.json" `
+        #         | Should -Be "\\$env:COMPUTERNAME\Shared\output.json"
+        #     }
+        # }
+    }
+}
+
+AfterAll {
+    Remove-Module Orchestrator -ErrorAction SilentlyContinue
+    Remove-SmbShare -Name Shared -ErrorAction Ignore
+    Remove-Item -Path "./c" -Force -ErrorAction Ignore
+    Remove-Item -Path "./a" -Recurse -Force -ErrorAction Ignore
+    Remove-Item -Path "./shared" -Recurse -Force -ErrorAction Ignore
+}

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Out-Utf8NoBom.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Out-Utf8NoBom.Tests.ps1
@@ -12,7 +12,7 @@ InModuleScope Orchestrator {
             New-Item -ItemType Directory './c' -Force -ErrorAction Ignore
             New-Item -ItemType Directory './shared/a/b' -Force -ErrorAction Ignore
             New-Item -ItemType Directory './shared/c' -Force -ErrorAction Ignore
-            # New-SmbShare -Name "Shared" -Path ".\shared" -ReadAccess "Everyone"
+            #New-SmbShare -Name "Shared" -Path ".\shared" -ReadAccess "Everyone"
         }
 
         Context 'local file' {
@@ -27,20 +27,17 @@ InModuleScope Orchestrator {
             }
         }
 
-        # # Requires ability to create SMB shares on your box to run
-        # Context 'UNC path' {
-        #     It 'Write to shared UNC path' {
-        #                         Out-Utf8NoBom -Content "test" -Location "\\$env:COMPUTERNAME\Shared" -FileName "output.json" `
-        #         | Should -Be "\\$env:COMPUTERNAME\Shared\output.json"
-        #     }
-        # }
+        # Requires ability to create SMB shares on your box to run
+        Context 'UNC path' {
+            It 'Write to shared UNC path' {
+                Out-Utf8NoBom -Content "test" -Location "\\$env:COMPUTERNAME\C$" -FileName "output.json" `
+                | Should -Be "\\$env:COMPUTERNAME\C$\output.json"
+            }
+        }
+        AfterAll {
+            Remove-Module Orchestrator -ErrorAction SilentlyContinue
+            Remove-Item -Path "./c" -Force -ErrorAction Ignore
+            Remove-Item -Path "./a" -Recurse -Force -ErrorAction Ignore
+        }
     }
-}
-
-AfterAll {
-    Remove-Module Orchestrator -ErrorAction SilentlyContinue
-    Remove-SmbShare -Name Shared -ErrorAction Ignore
-    Remove-Item -Path "./c" -Force -ErrorAction Ignore
-    Remove-Item -Path "./a" -Recurse -Force -ErrorAction Ignore
-    Remove-Item -Path "./shared" -Recurse -Force -ErrorAction Ignore
 }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Out-Utf8NoBom.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Out-Utf8NoBom.Tests.ps1
@@ -13,8 +13,6 @@ InModuleScope Orchestrator {
             New-Item -ItemType Directory './shared/a/b' -Force -ErrorAction Ignore
             New-Item -ItemType Directory './shared/c' -Force -ErrorAction Ignore
             # New-SmbShare -Name "Shared" -Path ".\shared" -ReadAccess "Everyone"
-
-            $pwd = Get-Location
         }
 
         Context 'local file' {

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Out-Utf8NoBom.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Out-Utf8NoBom.Tests.ps1
@@ -16,24 +16,64 @@ InModuleScope Orchestrator {
         }
 
         Context 'local file' {
-            It 'Write to root drive path' {
+            It 'Set to root drive path' {
                 Out-Utf8NoBom -Content "test" -Location "C:\" -FileName "output.json" `
                 | Should -Be "C:\output.json"
             }
 
-            It 'Write to local subdirectory path' {
-                Out-Utf8NoBom -Content "test" -Location "a" -FileName "output.json" `
+            It 'Set to absolute subdirectory path' {
+                Out-Utf8NoBom -Content "test" -Location "$pwd\a" -FileName "output.json" `
                 | Should -Be "$pwd\a\output.json"
             }
         }
 
-        # Requires ability to create SMB shares on your box to run
+        Context 'relative paths' {
+            It 'Set to subdirectory relative path' {
+                Out-Utf8NoBom -Content "test" -Location "a" -FileName "output.json" `
+                | Should -Be "$pwd\a\output.json"
+            }
+
+            It 'Set to subdirectory local relative path' {
+                Out-Utf8NoBom -Content "test" -Location ".\a" -FileName "output.json" `
+                | Should -Be "$pwd\a\output.json"
+            }
+
+            It 'Set to subdirectory processing .. and .' {
+                Out-Utf8NoBom -Content "test" -Location "a\b\..\..\c\." -FileName "output.json" `
+                | Should -Be "$pwd\c\output.json"
+            }
+        }
+
+        Context 'Check for re-root in path' {
+            It 'Does not re-root subdirectory' {
+                Out-Utf8NoBom -Content "test" -Location "a\d\..\b\." -FileName "output.json" `
+                | Should -Be "$pwd\a\b\output.json"
+            }
+
+            It 'Does not re-root subdirectory rooted at local' {
+                Out-Utf8NoBom -Content "test" -Location ".\a\d\..\b\." -FileName "output.json" `
+                | Should -Be "$pwd\a\b\output.json"
+            }
+
+            It 'Does not re-root parent' {
+                Out-Utf8NoBom -Content "test" -Location "..\$((Get-Item .).Name)\a\d\..\b\." -FileName "output.json" `
+                | Should -Be "$pwd\a\b\output.json"
+            }
+        }
+
+        # Uses default C$ share to test building UNC paths that exist
         Context 'UNC path' {
-            It 'Write to shared UNC path' {
+            It 'Set to shared UNC path' {
+                Out-Utf8NoBom -Content "test" -Location "\\$env:COMPUTERNAME\C$" -FileName "output.json" `
+                | Should -Be "\\$env:COMPUTERNAME\C$\output.json"
+            }
+
+            It 'Set to shared UNC path' {
                 Out-Utf8NoBom -Content "test" -Location "\\$env:COMPUTERNAME\C$" -FileName "output.json" `
                 | Should -Be "\\$env:COMPUTERNAME\C$\output.json"
             }
         }
+
         AfterAll {
             Remove-Module Orchestrator -ErrorAction SilentlyContinue
             Remove-Item -Path "./c" -Force -ErrorAction Ignore

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/New-SCuBAConfig.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/New-SCuBAConfig.Tests.ps1
@@ -20,7 +20,7 @@ InModuleScope Support {
             function ConvertTo-Yaml {throw 'this will be mocked'}
             Mock -ModuleName Support -CommandName ConvertTo-Yaml { $args[0] }
 
-            $TestPath = New-Item -Path (Join-Path -Path "TestDrive:" -ChildPath "SampleConfig") -Name "CreateSampleConfigFolder" -ItemType Directory
+            $TestPath = New-Item -Path (Join-Path -Path $TestDrive -ChildPath "SampleConfig") -Name "CreateSampleConfigFolder" -ItemType Directory
 
             [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'CMDArgs')]
             $CMDArgs = @{

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/Get-Utf8NoBom.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/Get-Utf8NoBom.Tests.ps1
@@ -1,74 +1,69 @@
 $UtilityPath = '../../../../Modules/Utility/Utility.psm1'
-Import-Module (Join-Path -Path $PSScriptRoot -ChildPath $UtilityPath) -Function 'Set-Utf8NoBom' -Force
+Import-Module (Join-Path -Path $PSScriptRoot -ChildPath $UtilityPath) -Function 'Get-Utf8NoBom' -Force
 
 InModuleScope Utility {
-    Describe -Tag 'Utility' -Name 'Set-Utf8NoBom Pathing' {
+    Describe -Tag 'Utility' -Name 'Get-Utf8NoBom Pathing' {
         BeforeAll {
-            function Invoke-WriteAllLines {}
-            Mock -ModuleName Utility Invoke-WriteAllLines
+            Mock -ModuleName Utility Invoke-ReadAllLines { return "Pass"}
 
             # Setup test directories for testing
             Push-Location $TestDrive
             New-Item -ItemType Directory "$TestDrive\a\b" -Force -ErrorAction Ignore
             New-Item -ItemType Directory "$TestDrive\c" -Force -ErrorAction Ignore
+
+            $Content = Invoke-ReadAllLines -Path "$TestDrive\a"
+            Write-Host "Invoke-ReadAllLines: $Content"
         }
 
         Context 'local file' {
             It 'Set to root drive path' {
-                Set-Utf8NoBom -Content "test" -Location "C:\" -FileName "output.json" `
-                | Should -Be "C:\output.json"
+                Get-Utf8NoBom -FilePath "C:\output.json" | Should -Be "Pass"
             }
 
             It 'Set to absolute subdirectory path' {
-                Set-Utf8NoBom -Content "test" -Location "$TestDrive\a" -FileName "output.json" `
-                | Should -Be "$TestDrive\a\output.json"
+                Get-Utf8NoBom -FilePath "$TestDrive\a\output.json" | Should -Be "Pass"
             }
         }
 
         Context 'relative paths' {
             It 'Set to subdirectory relative path' {
-                Set-Utf8NoBom -Content "test" -Location "a" -FileName "output.json" `
-                | Should -Be "$TestDrive\a\output.json"
+                Get-Utf8NoBom -FilePath "a\output.json" | Should -Be "Pass"
             }
 
             It 'Set to subdirectory local relative path' {
-                Set-Utf8NoBom -Content "test" -Location ".\a" -FileName "output.json" `
-                | Should -Be "$TestDrive\a\output.json"
+                Get-Utf8NoBom -FilePath ".\a\output.json" | Should -Be "Pass"
             }
 
             It 'Set to subdirectory processing .. and .' {
-                Set-Utf8NoBom -Content "test" -Location "a\b\..\..\c\." -FileName "output.json" `
-                | Should -Be "$TestDrive\c\output.json"
+                Get-Utf8NoBom -FilePath "a\b\..\..\c\.\output.json" | Should -Be "Pass"
             }
         }
 
         Context 'Check for re-root in path' {
             It 'Does not re-root subdirectory' {
-                Set-Utf8NoBom -Content "test" -Location "a\d\..\b\." -FileName "output.json" `
-                | Should -Be "$TestDrive\a\b\output.json"
+                Get-Utf8NoBom -FilePath "a\d\..\b\.\output.json" | Should -Be "Pass"
             }
 
             It 'Does not re-root subdirectory rooted at local' {
-                Set-Utf8NoBom -Content "test" -Location ".\a\d\..\b\." -FileName "output.json" `
-                | Should -Be "$TestDrive\a\b\output.json"
+                Get-Utf8NoBom -FilePath ".\a\d\..\b\.\output.json" | Should -Be "Pass"
             }
 
             It 'Does not re-root parent' {
-                Set-Utf8NoBom -Content "test" -Location "..\$((Get-Item .).Name)\a\d\..\b\." -FileName "output.json" `
-                | Should -Be "$TestDrive\a\b\output.json"
+                Get-Utf8NoBom -FilePath "..\$((Get-Item .).Name)\a\d\..\b\.\output.json" `
+                | Should -Be "Pass"
             }
         }
 
         # Uses default C$ share to test building UNC paths that exist
         Context 'UNC path' {
             It 'Set to shared UNC path' {
-                Set-Utf8NoBom -Content "test" -Location "\\$env:COMPUTERNAME\C$" -FileName "output.json" `
-                | Should -Be "\\$env:COMPUTERNAME\C$\output.json"
+                Get-Utf8NoBom -FilePath "\\$env:COMPUTERNAME\C$\output.json" `
+                | Should -Be "Pass"
             }
 
             It 'Set to shared UNC path' {
-                Set-Utf8NoBom -Content "test" -Location "\\$env:COMPUTERNAME\C$" -FileName "output.json" `
-                | Should -Be "\\$env:COMPUTERNAME\C$\output.json"
+                Get-Utf8NoBom -FilePath "\\$env:COMPUTERNAME\C$\output.json" `
+                | Should -Be "Pass"
             }
         }
 
@@ -77,7 +72,7 @@ InModuleScope Utility {
         }
     }
 
-    Describe -Tag 'Utility' -Name 'Set-Utf8NoBom Inputs' {
+    Describe -Tag 'Utility' -Name 'Get-Utf8NoBom Inputs' {
         BeforeAll {
             Push-Location $TestDrive
         }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/Get-Utf8NoBom.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/Get-Utf8NoBom.Tests.ps1
@@ -10,8 +10,6 @@ InModuleScope Utility {
             Push-Location $TestDrive
             New-Item -ItemType Directory "$TestDrive\a\b" -Force -ErrorAction Ignore
             New-Item -ItemType Directory "$TestDrive\c" -Force -ErrorAction Ignore
-
-            $Content = Invoke-ReadAllLines -Path "$TestDrive\a"
         }
 
         Context 'local file' {

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/Get-Utf8NoBom.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/Get-Utf8NoBom.Tests.ps1
@@ -66,12 +66,13 @@ InModuleScope Utility {
             }
         }
 
-        # Uses default C$ share to test building UNC paths that exist
-        # Assumes TestDrive is on C: drive
+        # Uses default system drive share to test building UNC paths that exist
+        # Assumes TestDrive is on system drive
         Context 'UNC path' {
             It 'Set to shared UNC path' {
                 $TempFolder = $($(Resolve-Path $TestDrive).ProviderPath).Substring(2)
-                $TestFile = "\\$env:COMPUTERNAME\C$\$TempFolder\output.json"
+                $ShareName = $env:SYSTEMDRIVE.Trim(':')
+                $TestFile = "\\$env:COMPUTERNAME\$ShareName$\$TempFolder\output.json"
                 New-Item -ItemType File $TestFile
                 Get-Utf8NoBom -FilePath $TestFile | Should -Be "Pass"
             }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/Get-Utf8NoBom.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/Get-Utf8NoBom.Tests.ps1
@@ -4,7 +4,7 @@ Import-Module (Join-Path -Path $PSScriptRoot -ChildPath $UtilityPath) -Function 
 InModuleScope Utility {
     Describe -Tag 'Utility' -Name 'Get-Utf8NoBom Pathing' {
         BeforeAll {
-            Mock -ModuleName Utility Invoke-ReadAllLines { return "Pass"}
+            Mock -ModuleName Utility Invoke-ReadAllText { return "Pass"}
 
             # Setup test directories for testing
             Push-Location $TestDrive
@@ -91,36 +91,31 @@ InModuleScope Utility {
                 It 'Backslashes properly escaped' {
                     $OrigString = "This string has \ in it." | ConvertTo-Json
                     $FilePath = Set-Utf8NoBom -Content $OrigString -Location $TestDrive -FileName output.txt
-                    $RestoredString = Get-Utf8NoBom -FilePath $FilePath | Out-String
-                    $RestoredString.Trim() | Should -Be $OrigString
+                    Get-Utf8NoBom -FilePath $FilePath | Should -Be $OrigString
                 }
 
                 It 'Escaped sequences properly escaped' {
                     $OrigString = "This string has \r\n in it." | ConvertTo-Json
                     $FilePath = Set-Utf8NoBom -Content $OrigString -Location $TestDrive -FileName output.txt
-                    $RestoredString = Get-Utf8NoBom -FilePath $FilePath | Out-String
-                    $RestoredString.Trim() | Should -Be $OrigString
+                    Get-Utf8NoBom -FilePath $FilePath | Should -Be $OrigString
                 }
 
                 It 'HTML escaped characters back converted properly' {
                     $OrigString = "This string has <, >, and ' in it." | ConvertTo-Json
                     $FilePath = Set-Utf8NoBom -Content $OrigString -Location $TestDrive -FileName output.txt
-                    $RestoredString = Get-Utf8NoBom -FilePath $FilePath | Out-String
-                    $RestoredString.Trim() | Should -Be $OrigString
+                    Get-Utf8NoBom -FilePath $FilePath | Should -Be $OrigString
                 }
 
                 It 'Non-ASCII unicode characters back converted properly' {
                     $OrigString = "This string has º, ¢, ∞,¢, and £ in it." | ConvertTo-Json
                     $FilePath = Set-Utf8NoBom -Content $OrigString -Location $TestDrive -FileName output.txt
-                    $RestoredString = Get-Utf8NoBom -FilePath $FilePath | Out-String
-                    $RestoredString.Trim() | Should -Be $OrigString
+                    Get-Utf8NoBom -FilePath $FilePath | Should -Be $OrigString
                 }
 
                 It 'DateTime string with backslash passes' {
                     $OrigString = $(Get-Date).Date | ConvertTo-JSON
                     $FilePath = Set-Utf8NoBom -Content $OrigString -Location $TestDrive -FileName output.txt
-                    $RestoredString = Get-Utf8NoBom -FilePath $FilePath | Out-String
-                    $RestoredString.Trim() | Should -Be "$OrigString"
+                    Get-Utf8NoBom -FilePath $FilePath | Should -Be "$OrigString"
                 }
         }
 

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/Get-Utf8NoBom.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/Get-Utf8NoBom.Tests.ps1
@@ -1,4 +1,4 @@
-$UtilityPath = '../../../../Modules/Utility/Utility.psm1'
+﻿$UtilityPath = '../../../../Modules/Utility/Utility.psm1'
 Import-Module (Join-Path -Path $PSScriptRoot -ChildPath $UtilityPath) -Function 'Get-Utf8NoBom' -Force
 
 InModuleScope Utility {
@@ -12,58 +12,70 @@ InModuleScope Utility {
             New-Item -ItemType Directory "$TestDrive\c" -Force -ErrorAction Ignore
 
             $Content = Invoke-ReadAllLines -Path "$TestDrive\a"
-            Write-Host "Invoke-ReadAllLines: $Content"
         }
 
         Context 'local file' {
             It 'Set to root drive path' {
-                Get-Utf8NoBom -FilePath "C:\output.json" | Should -Be "Pass"
+                $TestFile = "TestDrive:\output.json"
+                New-Item -ItemType File $TestFile -Force -ErrorAction Ignore
+                Get-Utf8NoBom -FilePath $TestFile | Should -Be "Pass"
             }
 
             It 'Set to absolute subdirectory path' {
-                Get-Utf8NoBom -FilePath "$TestDrive\a\output.json" | Should -Be "Pass"
+                $TestFile = "$TestDrive\a\output.json"
+                New-Item -ItemType File $TestFile -Force -ErrorAction Ignore
+                Get-Utf8NoBom -FilePath $TestFile | Should -Be "Pass"
             }
         }
 
         Context 'relative paths' {
             It 'Set to subdirectory relative path' {
-                Get-Utf8NoBom -FilePath "a\output.json" | Should -Be "Pass"
+                $TestFile = "a\output.json"
+                New-Item -ItemType File $TestFile -Force -ErrorAction Ignore
+                Get-Utf8NoBom -FilePath $TestFile | Should -Be "Pass"
             }
 
             It 'Set to subdirectory local relative path' {
-                Get-Utf8NoBom -FilePath ".\a\output.json" | Should -Be "Pass"
+                $TestFile = ".\a\output.json"
+                New-Item -ItemType File $TestFile -Force -ErrorAction Ignore
+                Get-Utf8NoBom -FilePath $TestFile | Should -Be "Pass"
             }
 
             It 'Set to subdirectory processing .. and .' {
-                Get-Utf8NoBom -FilePath "a\b\..\..\c\.\output.json" | Should -Be "Pass"
+                $TestFile = "a\b\..\..\c\.\output.json"
+                New-Item -ItemType File $TestFile -Force -ErrorAction Ignore
+                Get-Utf8NoBom -FilePath $TestFile | Should -Be "Pass"
             }
         }
 
         Context 'Check for re-root in path' {
             It 'Does not re-root subdirectory' {
-                Get-Utf8NoBom -FilePath "a\d\..\b\.\output.json" | Should -Be "Pass"
+                $TestFile = "a\d\..\b\.\output.json"
+                New-Item -ItemType File $TestFile -Force -ErrorAction Ignore
+                Get-Utf8NoBom -FilePath $TestFile | Should -Be "Pass"
             }
 
             It 'Does not re-root subdirectory rooted at local' {
-                Get-Utf8NoBom -FilePath ".\a\d\..\b\.\output.json" | Should -Be "Pass"
+                $TestFile = ".\a\d\..\b\.\output.json"
+                New-Item -ItemType File $TestFile -Force -ErrorAction Ignore
+                Get-Utf8NoBom -FilePath $TestFile | Should -Be "Pass"
             }
 
             It 'Does not re-root parent' {
-                Get-Utf8NoBom -FilePath "..\$((Get-Item .).Name)\a\d\..\b\.\output.json" `
-                | Should -Be "Pass"
+                $TestFile = "..\$((Get-Item .).Name)\a\d\..\b\.\output.json"
+                New-Item -ItemType File $TestFile -Force -ErrorAction Ignore
+                Get-Utf8NoBom -FilePath $TestFile | Should -Be "Pass"
             }
         }
 
         # Uses default C$ share to test building UNC paths that exist
+        # Assumes TestDrive is on C: drive
         Context 'UNC path' {
             It 'Set to shared UNC path' {
-                Get-Utf8NoBom -FilePath "\\$env:COMPUTERNAME\C$\output.json" `
-                | Should -Be "Pass"
-            }
-
-            It 'Set to shared UNC path' {
-                Get-Utf8NoBom -FilePath "\\$env:COMPUTERNAME\C$\output.json" `
-                | Should -Be "Pass"
+                $TempFolder = $($(Resolve-Path $TestDrive).ProviderPath).Substring(2)
+                $TestFile = "\\$env:COMPUTERNAME\C$\$TempFolder\output.json"
+                New-Item -ItemType File $TestFile
+                Get-Utf8NoBom -FilePath $TestFile | Should -Be "Pass"
             }
         }
 

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/Set-Utf8NoBom.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/Set-Utf8NoBom.Tests.ps1
@@ -4,8 +4,8 @@ Import-Module (Join-Path -Path $PSScriptRoot -ChildPath $UtilityPath) -Function 
 InModuleScope Utility {
     Describe -Tag 'Utility' -Name 'Set-Utf8NoBom Pathing' {
         BeforeAll {
-            function Invoke-WriteAllLines {}
-            Mock -ModuleName Utility Invoke-WriteAllLines
+            function Invoke-WriteAllText {}
+            Mock -ModuleName Utility Invoke-WriteAllText
 
             # Setup test directories for testing
             Push-Location $TestDrive
@@ -86,36 +86,31 @@ InModuleScope Utility {
                 It 'Backslashes properly escaped' {
                     $OrigString = "This string has \ in it." | ConvertTo-Json
                     $FilePath = Set-Utf8NoBom -Content $OrigString -Location $TestDrive -FileName output.txt
-                    $RestoredString = Get-Utf8NoBom -FilePath $FilePath | Out-String
-                    $RestoredString.Trim() | Should -Be $OrigString
+                    Get-Utf8NoBom -FilePath $FilePath |  Should -Be $OrigString
                 }
 
                 It 'Escaped sequences properly escaped' {
                     $OrigString = "This string has \r\n in it." | ConvertTo-Json
                     $FilePath = Set-Utf8NoBom -Content $OrigString -Location $TestDrive -FileName output.txt
-                    $RestoredString = Get-Utf8NoBom -FilePath $FilePath | Out-String
-                    $RestoredString.Trim() | Should -Be $OrigString
+                    Get-Utf8NoBom -FilePath $FilePath | Should -Be $OrigString
                 }
 
                 It 'HTML escaped characters back converted properly' {
                     $OrigString = "This string has <, >, and ' in it." | ConvertTo-Json
                     $FilePath = Set-Utf8NoBom -Content $OrigString -Location $TestDrive -FileName output.txt
-                    $RestoredString = Get-Utf8NoBom -FilePath $FilePath | Out-String
-                    $RestoredString.Trim() | Should -Be $OrigString
+                    Get-Utf8NoBom -FilePath $FilePath | Should -Be $OrigString
                 }
 
                 It 'Non-ASCII unicode characters back converted properly' {
                     $OrigString = "This string has º, ¢, ∞,¢, and £ in it." | ConvertTo-Json
                     $FilePath = Set-Utf8NoBom -Content $OrigString -Location $TestDrive -FileName output.txt
-                    $RestoredString = Get-Utf8NoBom -FilePath $FilePath | Out-String
-                    $RestoredString.Trim() | Should -Be $OrigString
+                    Get-Utf8NoBom -FilePath $FilePath | Should -Be $OrigString
                 }
 
                 It 'DateTime string with backslash passes' {
                     $OrigString = $(Get-Date).Date | ConvertTo-JSON
                     $FilePath = Set-Utf8NoBom -Content $OrigString -Location $TestDrive -FileName output.txt
-                    $RestoredString = Get-Utf8NoBom -FilePath $FilePath | Out-String
-                    $RestoredString.Trim() | Should -Be "$OrigString"
+                    Get-Utf8NoBom -FilePath $FilePath | Should -Be "$OrigString"
                 }
         }
 

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/Set-Utf8NoBom.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/Set-Utf8NoBom.Tests.ps1
@@ -1,11 +1,11 @@
-$OrchestratorPath = '../../../../Modules/Orchestrator.psm1'
-Import-Module (Join-Path -Path $PSScriptRoot -ChildPath $OrchestratorPath) -Function 'Out-Utf8NoBom' -Force
+$UtilityPath = '../../../../Modules/Utility/Utility.psm1'
+Import-Module (Join-Path -Path $PSScriptRoot -ChildPath $UtilityPath) -Function 'Set-Utf8NoBom' -Force
 
-InModuleScope Orchestrator {
-    Describe -Tag 'Orchestrator' -Name 'Out-Utf8NoBom' {
+InModuleScope Utility {
+    Describe -Tag 'Utility' -Name 'Set-Utf8NoBom' {
         BeforeAll {
             function Invoke-WriteAllLines {}
-            Mock -ModuleName Orchestrator Invoke-WriteAllLines
+            Mock -ModuleName Utility Invoke-WriteAllLines
 
             # Setup test directories for testing
             New-Item -ItemType Directory './a/b' -Force -ErrorAction Ignore
@@ -17,46 +17,46 @@ InModuleScope Orchestrator {
 
         Context 'local file' {
             It 'Set to root drive path' {
-                Out-Utf8NoBom -Content "test" -Location "C:\" -FileName "output.json" `
+                Set-Utf8NoBom -Content "test" -Location "C:\" -FileName "output.json" `
                 | Should -Be "C:\output.json"
             }
 
             It 'Set to absolute subdirectory path' {
-                Out-Utf8NoBom -Content "test" -Location "$pwd\a" -FileName "output.json" `
+                Set-Utf8NoBom -Content "test" -Location "$pwd\a" -FileName "output.json" `
                 | Should -Be "$pwd\a\output.json"
             }
         }
 
         Context 'relative paths' {
             It 'Set to subdirectory relative path' {
-                Out-Utf8NoBom -Content "test" -Location "a" -FileName "output.json" `
+                Set-Utf8NoBom -Content "test" -Location "a" -FileName "output.json" `
                 | Should -Be "$pwd\a\output.json"
             }
 
             It 'Set to subdirectory local relative path' {
-                Out-Utf8NoBom -Content "test" -Location ".\a" -FileName "output.json" `
+                Set-Utf8NoBom -Content "test" -Location ".\a" -FileName "output.json" `
                 | Should -Be "$pwd\a\output.json"
             }
 
             It 'Set to subdirectory processing .. and .' {
-                Out-Utf8NoBom -Content "test" -Location "a\b\..\..\c\." -FileName "output.json" `
+                Set-Utf8NoBom -Content "test" -Location "a\b\..\..\c\." -FileName "output.json" `
                 | Should -Be "$pwd\c\output.json"
             }
         }
 
         Context 'Check for re-root in path' {
             It 'Does not re-root subdirectory' {
-                Out-Utf8NoBom -Content "test" -Location "a\d\..\b\." -FileName "output.json" `
+                Set-Utf8NoBom -Content "test" -Location "a\d\..\b\." -FileName "output.json" `
                 | Should -Be "$pwd\a\b\output.json"
             }
 
             It 'Does not re-root subdirectory rooted at local' {
-                Out-Utf8NoBom -Content "test" -Location ".\a\d\..\b\." -FileName "output.json" `
+                Set-Utf8NoBom -Content "test" -Location ".\a\d\..\b\." -FileName "output.json" `
                 | Should -Be "$pwd\a\b\output.json"
             }
 
             It 'Does not re-root parent' {
-                Out-Utf8NoBom -Content "test" -Location "..\$((Get-Item .).Name)\a\d\..\b\." -FileName "output.json" `
+                Set-Utf8NoBom -Content "test" -Location "..\$((Get-Item .).Name)\a\d\..\b\." -FileName "output.json" `
                 | Should -Be "$pwd\a\b\output.json"
             }
         }
@@ -64,18 +64,18 @@ InModuleScope Orchestrator {
         # Uses default C$ share to test building UNC paths that exist
         Context 'UNC path' {
             It 'Set to shared UNC path' {
-                Out-Utf8NoBom -Content "test" -Location "\\$env:COMPUTERNAME\C$" -FileName "output.json" `
+                Set-Utf8NoBom -Content "test" -Location "\\$env:COMPUTERNAME\C$" -FileName "output.json" `
                 | Should -Be "\\$env:COMPUTERNAME\C$\output.json"
             }
 
             It 'Set to shared UNC path' {
-                Out-Utf8NoBom -Content "test" -Location "\\$env:COMPUTERNAME\C$" -FileName "output.json" `
+                Set-Utf8NoBom -Content "test" -Location "\\$env:COMPUTERNAME\C$" -FileName "output.json" `
                 | Should -Be "\\$env:COMPUTERNAME\C$\output.json"
             }
         }
 
         AfterAll {
-            Remove-Module Orchestrator -ErrorAction SilentlyContinue
+            Remove-Module Utility -ErrorAction SilentlyContinue
             Remove-Item -Path "./c" -Force -ErrorAction Ignore
             Remove-Item -Path "./a" -Recurse -Force -ErrorAction Ignore
         }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/Set-Utf8NoBom.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/Set-Utf8NoBom.Tests.ps1
@@ -1,4 +1,4 @@
-$UtilityPath = '../../../../Modules/Utility/Utility.psm1'
+﻿$UtilityPath = '../../../../Modules/Utility/Utility.psm1'
 Import-Module (Join-Path -Path $PSScriptRoot -ChildPath $UtilityPath) -Function 'Set-Utf8NoBom' -Force
 
 InModuleScope Utility {

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/Set-Utf8NoBom.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/Set-Utf8NoBom.Tests.ps1
@@ -4,7 +4,7 @@ Import-Module (Join-Path -Path $PSScriptRoot -ChildPath $UtilityPath) -Function 
 InModuleScope Utility {
     Describe -Tag 'Utility' -Name 'Set-Utf8NoBom Pathing' {
         BeforeAll {
-            function Invoke-WriteAllText {}
+            function Invoke-WriteAllText { return "Pass" }
             Mock -ModuleName Utility Invoke-WriteAllText
 
             # Setup test directories for testing

--- a/Testing/Functional/Products/FunctionalTestUtils.ps1
+++ b/Testing/Functional/Products/FunctionalTestUtils.ps1
@@ -1,5 +1,5 @@
 $UtilityModulePath = Join-Path -Path $PSScriptRoot -ChildPath "../../../PowerShell/ScubaGear/Modules/Utility/Utility.psm1" -Resolve
-Import-Module $UtilityModulePath
+Import-Module $UtilityModulePath -Function Get-Utf8NoBom, Set-Utf8NoBom
 
 # Helper functions for functional test
 function IsEquivalence{

--- a/Testing/Functional/Products/FunctionalTestUtils.ps1
+++ b/Testing/Functional/Products/FunctionalTestUtils.ps1
@@ -93,11 +93,8 @@ function LoadProviderExport() {
       Copy-Item -Path "$OutputFolder/ProviderSettingsExport.json" -Destination "$OutputFolder/ModifiedProviderSettingsExport.json"
   }
 
-  # $ProviderExport = $(Get-Utf8NoBom -FilePath "$OutputFolder/ProviderSettingsExport.json" | Out-String).Trim() | ConvertFrom-Json
-  $content = Get-Utf8NoBom -FilePath "$OutputFolder/ProviderSettingsExport.json"
-  $stringContent = $content | Out-String
-  $stringContentTrimmed = $stringContent.Trim()
-  $ProviderExport = $stringContentTrimmed | ConvertFrom-Json
+  $Content = Get-Utf8NoBom -FilePath "$OutputFolder/ProviderSettingsExport.json"
+  $ProviderExport = $Content | ConvertFrom-Json
   $ProviderExport
 }
 
@@ -133,7 +130,6 @@ function PublishProviderExport() {
       $Export
   )
   $Json = $Export | ConvertTo-Json -Depth 10 | Out-String
-  #Set-Content -Path "$OutputFolder/ModifiedProviderSettingsExport.json" -Value $Json
   Set-Utf8NoBom -Content $Json -Location "$OutputFolder" -FileName "ModifiedProviderSettingsExport.json"
 }
 

--- a/Testing/Functional/Products/FunctionalTestUtils.ps1
+++ b/Testing/Functional/Products/FunctionalTestUtils.ps1
@@ -1,3 +1,6 @@
+$UtilityModulePath = Join-Path -Path $PSScriptRoot -ChildPath "../../../PowerShell/ScubaGear/Modules/Utility/Utility.psm1" -Resolve
+Import-Module $UtilityModulePath
+
 # Helper functions for functional test
 function IsEquivalence{
   <#
@@ -90,7 +93,7 @@ function LoadProviderExport() {
       Copy-Item -Path "$OutputFolder/ProviderSettingsExport.json" -Destination "$OutputFolder/ModifiedProviderSettingsExport.json"
   }
 
-  $ProviderExport = Get-Content -Raw "$OutputFolder/ModifiedProviderSettingsExport.json" | ConvertFrom-Json
+  $ProviderExport = $(Get-Utf8NoBom -FilePath "$OutputFolder/ProviderSettingsExport.json" | Out-String).Trim() | ConvertFrom-Json
   $ProviderExport
 }
 
@@ -126,7 +129,8 @@ function PublishProviderExport() {
       $Export
   )
   $Json = $Export | ConvertTo-Json -Depth 10 | Out-String
-  Set-Content -Path "$OutputFolder/ModifiedProviderSettingsExport.json" -Value $Json
+  #Set-Content -Path "$OutputFolder/ModifiedProviderSettingsExport.json" -Value $Json
+  Set-Utf8NoBom -Content $Json -Location "$OutputFolder" -FileName "ModifiedProviderSettingsExport.json"
 }
 
 function UpdateProviderExport{

--- a/Testing/Functional/Products/FunctionalTestUtils.ps1
+++ b/Testing/Functional/Products/FunctionalTestUtils.ps1
@@ -1,4 +1,6 @@
 $UtilityModulePath = Join-Path -Path $PSScriptRoot -ChildPath "../../../PowerShell/ScubaGear/Modules/Utility/Utility.psm1" -Resolve
+Write-Output "The Utility Module Path is"
+Write-Output $UtilityModulePath
 Import-Module $UtilityModulePath -Function Get-Utf8NoBom, Set-Utf8NoBom -Scope Global
 
 # Helper functions for functional test

--- a/Testing/Functional/Products/FunctionalTestUtils.ps1
+++ b/Testing/Functional/Products/FunctionalTestUtils.ps1
@@ -1,7 +1,7 @@
-$UtilityModulePath = Join-Path -Path $PSScriptRoot -ChildPath "../../../PowerShell/ScubaGear/Modules/Utility/Utility.psm1" -Resolve
-Write-Host "The Utility Module Path is"
-Write-Host $UtilityModulePath
-Import-Module $UtilityModulePath -Function Get-Utf8NoBom, Set-Utf8NoBom -Scope Global
+# $UtilityModulePath = Join-Path -Path $PSScriptRoot -ChildPath "../../../PowerShell/ScubaGear/Modules/Utility/Utility.psm1" -Resolve
+# Write-Host "The Utility Module Path is"
+# Write-Host $UtilityModulePath
+# Import-Module $UtilityModulePath -Function Get-Utf8NoBom, Set-Utf8NoBom -Scope Global
 
 # Helper functions for functional test
 function IsEquivalence{

--- a/Testing/Functional/Products/FunctionalTestUtils.ps1
+++ b/Testing/Functional/Products/FunctionalTestUtils.ps1
@@ -1,5 +1,5 @@
 $UtilityModulePath = Join-Path -Path $PSScriptRoot -ChildPath "../../../PowerShell/ScubaGear/Modules/Utility/Utility.psm1" -Resolve
-Import-Module $UtilityModulePath -Function Get-Utf8NoBom, Set-Utf8NoBom
+Import-Module $UtilityModulePath -Function Get-Utf8NoBom, Set-Utf8NoBom -Scope Global
 
 # Helper functions for functional test
 function IsEquivalence{

--- a/Testing/Functional/Products/FunctionalTestUtils.ps1
+++ b/Testing/Functional/Products/FunctionalTestUtils.ps1
@@ -1,7 +1,8 @@
 $UtilityModulePath = Join-Path -Path $PSScriptRoot -ChildPath "../../../PowerShell/ScubaGear/Modules/Utility/Utility.psm1" -Resolve
-Write-Output "The Utility Module Path is"
-Write-Output $UtilityModulePath
+Write-Host "The Utility Module Path is"
+Write-Host $UtilityModulePath
 Import-Module $UtilityModulePath -Function Get-Utf8NoBom, Set-Utf8NoBom -Scope Global
+Get-Command -Module $UtilityModulePath
 
 # Helper functions for functional test
 function IsEquivalence{

--- a/Testing/Functional/Products/FunctionalTestUtils.ps1
+++ b/Testing/Functional/Products/FunctionalTestUtils.ps1
@@ -1,7 +1,5 @@
-# $UtilityModulePath = Join-Path -Path $PSScriptRoot -ChildPath "../../../PowerShell/ScubaGear/Modules/Utility/Utility.psm1" -Resolve
-# Write-Host "The Utility Module Path is"
-# Write-Host $UtilityModulePath
-# Import-Module $UtilityModulePath -Function Get-Utf8NoBom, Set-Utf8NoBom -Scope Global
+$UtilityModulePath = Join-Path -Path $PSScriptRoot -ChildPath "../../../PowerShell/ScubaGear/Modules/Utility/Utility.psm1" -Resolve
+Import-Module $UtilityModulePath -Function Get-Utf8NoBom, Set-Utf8NoBom
 
 # Helper functions for functional test
 function IsEquivalence{
@@ -97,8 +95,6 @@ function LoadProviderExport() {
 
   # $ProviderExport = $(Get-Utf8NoBom -FilePath "$OutputFolder/ProviderSettingsExport.json" | Out-String).Trim() | ConvertFrom-Json
   $content = Get-Utf8NoBom -FilePath "$OutputFolder/ProviderSettingsExport.json"
-  Write-Host "The content is"
-  Write-Host $content
   $stringContent = $content | Out-String
   $stringContentTrimmed = $stringContent.Trim()
   $ProviderExport = $stringContentTrimmed | ConvertFrom-Json
@@ -161,7 +157,6 @@ function UpdateProviderExport{
       $OutputFolder
   )
 
-  Write-Host "Calling LoadProviderExport..."
   $ProviderExport = LoadProviderExport($OutputFolder)
 
   $Updates.Keys | ForEach-Object{

--- a/Testing/Functional/Products/FunctionalTestUtils.ps1
+++ b/Testing/Functional/Products/FunctionalTestUtils.ps1
@@ -1,5 +1,6 @@
 $UtilityModulePath = Join-Path -Path $PSScriptRoot -ChildPath "../../../PowerShell/ScubaGear/Modules/Utility/Utility.psm1" -Resolve
 Import-Module $UtilityModulePath -Function Get-Utf8NoBom, Set-Utf8NoBom
+Write-Host "DEBUG Utility Module Path: $UtilityModulePath"
 
 # Helper functions for functional test
 function IsEquivalence{

--- a/Testing/Functional/Products/FunctionalTestUtils.ps1
+++ b/Testing/Functional/Products/FunctionalTestUtils.ps1
@@ -2,7 +2,6 @@ $UtilityModulePath = Join-Path -Path $PSScriptRoot -ChildPath "../../../PowerShe
 Write-Host "The Utility Module Path is"
 Write-Host $UtilityModulePath
 Import-Module $UtilityModulePath -Function Get-Utf8NoBom, Set-Utf8NoBom -Scope Global
-Get-Command -Module $UtilityModulePath
 
 # Helper functions for functional test
 function IsEquivalence{

--- a/Testing/Functional/Products/FunctionalTestUtils.ps1
+++ b/Testing/Functional/Products/FunctionalTestUtils.ps1
@@ -1,6 +1,5 @@
 $UtilityModulePath = Join-Path -Path $PSScriptRoot -ChildPath "../../../PowerShell/ScubaGear/Modules/Utility/Utility.psm1" -Resolve
 Import-Module $UtilityModulePath -Function Get-Utf8NoBom, Set-Utf8NoBom
-Write-Host "DEBUG Utility Module Path: $UtilityModulePath"
 
 # Helper functions for functional test
 function IsEquivalence{

--- a/Testing/Functional/Products/FunctionalTestUtils.ps1
+++ b/Testing/Functional/Products/FunctionalTestUtils.ps1
@@ -95,7 +95,13 @@ function LoadProviderExport() {
       Copy-Item -Path "$OutputFolder/ProviderSettingsExport.json" -Destination "$OutputFolder/ModifiedProviderSettingsExport.json"
   }
 
-  $ProviderExport = $(Get-Utf8NoBom -FilePath "$OutputFolder/ProviderSettingsExport.json" | Out-String).Trim() | ConvertFrom-Json
+  # $ProviderExport = $(Get-Utf8NoBom -FilePath "$OutputFolder/ProviderSettingsExport.json" | Out-String).Trim() | ConvertFrom-Json
+  $content = Get-Utf8NoBom -FilePath "$OutputFolder/ProviderSettingsExport.json"
+  Write-Host "The content is"
+  Write-Host $content
+  $stringContent = $content | Out-String
+  $stringContentTrimmed = $stringContent.Trim()
+  $ProviderExport = $stringContentTrimmed | ConvertFrom-Json
   $ProviderExport
 }
 

--- a/Testing/Functional/Products/FunctionalTestUtils.ps1
+++ b/Testing/Functional/Products/FunctionalTestUtils.ps1
@@ -161,6 +161,7 @@ function UpdateProviderExport{
       $OutputFolder
   )
 
+  Write-Host "Calling LoadProviderExport..."
   $ProviderExport = LoadProviderExport($OutputFolder)
 
   $Updates.Keys | ForEach-Object{

--- a/Testing/Functional/Products/Products.Tests.ps1
+++ b/Testing/Functional/Products/Products.Tests.ps1
@@ -165,12 +165,7 @@ BeforeAll{
     }
 
     # Dot source utility functions
-    Write-Host "Source the utility functions"
     . (Join-Path -Path $PSScriptRoot -ChildPath "FunctionalTestUtils.ps1")
-    $UtilityModulePath = Join-Path -Path $PSScriptRoot -ChildPath "../../../PowerShell/ScubaGear/Modules/Utility/Utility.psm1" -Resolve
-    Write-Host "The Utility Module Path is still"
-    Write-Host $UtilityModulePath
-    Import-Module $UtilityModulePath -Function Get-Utf8NoBom, Set-Utf8NoBom -Scope Global
 
     function SetConditions {
         [CmdletBinding(DefaultParameterSetName = 'Actual')]

--- a/Testing/Functional/Products/Products.Tests.ps1
+++ b/Testing/Functional/Products/Products.Tests.ps1
@@ -167,6 +167,10 @@ BeforeAll{
     # Dot source utility functions
     Write-Host "Source the utility functions"
     . (Join-Path -Path $PSScriptRoot -ChildPath "FunctionalTestUtils.ps1")
+    $UtilityModulePath = Join-Path -Path $PSScriptRoot -ChildPath "../../../PowerShell/ScubaGear/Modules/Utility/Utility.psm1" -Resolve
+    Write-Host "The Utility Module Path is still"
+    Write-Host $UtilityModulePath
+    Import-Module $UtilityModulePath -Function Get-Utf8NoBom, Set-Utf8NoBom -Scope Global
 
     function SetConditions {
         [CmdletBinding(DefaultParameterSetName = 'Actual')]
@@ -182,8 +186,6 @@ BeforeAll{
         )
 
         ForEach($Condition in $Conditions){
-            Write-Host "The condition is"
-            Write-Host $Condition
             $Splat = $Condition.Splat
             if ('Cached' -eq $PSCmdlet.ParameterSetName){
                 $Splat.Add("OutputFolder", [string]$OutputFolder)

--- a/Testing/Functional/Products/Products.Tests.ps1
+++ b/Testing/Functional/Products/Products.Tests.ps1
@@ -194,6 +194,12 @@ BeforeAll{
             try {
                 Write-Host "The Script Block is"
                 Write-Host $ScriptBlock
+                Write-Host "PSSCriptRoot is"
+                Write-Host $PSScriptRoot
+                $UtilityModulePath = Join-Path -Path $PSScriptRoot -ChildPath "../../../PowerShell/ScubaGear/Modules/Utility/Utility.psm1" -Resolve
+                Write-Host "The Utility Module Path is"
+                Write-Host $UtilityModulePath
+                Import-Module $UtilityModulePath -Function Get-Utf8NoBom, Set-Utf8NoBom -Scope Global
                 $ScriptBlock.Invoke()
             }
             catch {

--- a/Testing/Functional/Products/Products.Tests.ps1
+++ b/Testing/Functional/Products/Products.Tests.ps1
@@ -149,7 +149,6 @@ BeforeDiscovery {
 
 BeforeAll {
     # Shared Data for functional test
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'ProductDetails', Justification = 'False positive as rule does not scan child scopes')]
     $ScubaModulePath = Join-Path -Path $PSScriptRoot -ChildPath "../../../PowerShell/ScubaGear/Modules"
     $ScubaModule = Join-Path -Path $ScubaModulePath -ChildPath "../ScubaGear.psd1"
     $ConnectionModule = Join-Path -Path $ScubaModulePath -ChildPath "Connection/Connection.psm1"
@@ -157,6 +156,7 @@ BeforeAll {
     Import-Module $ConnectionModule
     Import-Module Selenium
 
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'ProductDetails', Justification = 'False positive as rule does not scan child scopes')]
     $ProductDetails = @{
         aad = "Azure Active Directory"
         defender = "Microsoft 365 Defender"

--- a/Testing/Functional/Products/Products.Tests.ps1
+++ b/Testing/Functional/Products/Products.Tests.ps1
@@ -214,9 +214,9 @@ BeforeAll {
 }
 
 Describe "Policy Checks for <ProductName>"{
+
     Context "Start tests for policy <PolicyId>" -ForEach $TestPlan{
-        BeforeEach{
-            . (Join-Path -Path $PSScriptRoot -ChildPath "FunctionalTestUtils.ps1")
+        BeforeEach {
             # Select which TestDriver to use for a given test plan. TestDriver names (e.g. RunScuba, ScubaCached) must
             # match exactly (including case) the ones used in TestPlans.
             if ($ConfigFileName -and ('RunScuba' -eq $TestDriver)){

--- a/Testing/Functional/Products/Products.Tests.ps1
+++ b/Testing/Functional/Products/Products.Tests.ps1
@@ -100,8 +100,10 @@ param (
 $ScubaModulePath = Join-Path -Path $PSScriptRoot -ChildPath "../../../PowerShell/ScubaGear/Modules"
 $ScubaModule = Join-Path -Path $ScubaModulePath -ChildPath "../ScubaGear.psd1"
 $ConnectionModule = Join-Path -Path $ScubaModulePath -ChildPath "Connection/Connection.psm1"
+$UtilityModule = Join-Path -Path $ScubaModulePath -ChildPath "Utility/Utility.psm1"
 Import-Module $ScubaModule
 Import-Module $ConnectionModule
+Import-Module $UtilityModule
 Import-Module Selenium
 
 BeforeDiscovery{

--- a/Testing/Functional/Products/Products.Tests.ps1
+++ b/Testing/Functional/Products/Products.Tests.ps1
@@ -181,27 +181,23 @@ BeforeAll{
         )
 
         ForEach($Condition in $Conditions){
-
+            Write-Output "The condition is"
+            Write-Output $Condition
             $Splat = $Condition.Splat
-
             if ('Cached' -eq $PSCmdlet.ParameterSetName){
                 $Splat.Add("OutputFolder", [string]$OutputFolder)
             }
-
-            if ($Splat ) {
+            if ($Splat) {
                 $ScriptBlock = [ScriptBlock]::Create("$($Condition.Command) @Splat")
             }
             else {
                 $ScriptBlock = [ScriptBlock]::Create("$($Condition.Command)")
             }
-
-
             try {
                 $ScriptBlock.Invoke()
             }
             catch {
                 Write-Error "Exception: SetConditions failed. $_"
-
             }
         }
     }

--- a/Testing/Functional/Products/Products.Tests.ps1
+++ b/Testing/Functional/Products/Products.Tests.ps1
@@ -192,6 +192,8 @@ BeforeAll{
                 $ScriptBlock = [ScriptBlock]::Create("$($Condition.Command)")
             }
             try {
+                Write-Host "The Script Block is"
+                Write-Host $ScriptBlock
                 $ScriptBlock.Invoke()
             }
             catch {

--- a/Testing/Functional/Products/Products.Tests.ps1
+++ b/Testing/Functional/Products/Products.Tests.ps1
@@ -97,16 +97,11 @@ param (
     $Variant = [string]::Empty
 )
 
-$ScubaModulePath = Join-Path -Path $PSScriptRoot -ChildPath "../../../PowerShell/ScubaGear/Modules"
-$ScubaModule = Join-Path -Path $ScubaModulePath -ChildPath "../ScubaGear.psd1"
-$ConnectionModule = Join-Path -Path $ScubaModulePath -ChildPath "Connection/Connection.psm1"
-$UtilityModule = Join-Path -Path $ScubaModulePath -ChildPath "Utility/Utility.psm1"
-Import-Module $ScubaModule
-Import-Module $ConnectionModule
-Import-Module $UtilityModule
-Import-Module Selenium
+BeforeDiscovery {
+    $ScubaModulePath = Join-Path -Path $PSScriptRoot -ChildPath "../../../PowerShell/ScubaGear/Modules"
+    $ScubaModule = Join-Path -Path $ScubaModulePath -ChildPath "../ScubaGear.psd1"
+    Import-Module $ScubaModule
 
-BeforeDiscovery{
     if ($Variant) {
         $TestPlanFileName = "TestPlans/$ProductName.$Variant.testplan.yaml"
     }
@@ -152,9 +147,16 @@ BeforeDiscovery{
     }
 }
 
-BeforeAll{
+BeforeAll {
     # Shared Data for functional test
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'ProductDetails', Justification = 'False positive as rule does not scan child scopes')]
+    $ScubaModulePath = Join-Path -Path $PSScriptRoot -ChildPath "../../../PowerShell/ScubaGear/Modules"
+    $ScubaModule = Join-Path -Path $ScubaModulePath -ChildPath "../ScubaGear.psd1"
+    $ConnectionModule = Join-Path -Path $ScubaModulePath -ChildPath "Connection/Connection.psm1"
+    Import-Module $ScubaModule
+    Import-Module $ConnectionModule
+    Import-Module Selenium
+
     $ProductDetails = @{
         aad = "Azure Active Directory"
         defender = "Microsoft 365 Defender"
@@ -165,7 +167,7 @@ BeforeAll{
     }
 
     # Dot source utility functions
-    . (Join-Path -Path $PSScriptRoot -ChildPath "FunctionalTestUtils.ps1")
+#    . (Join-Path -Path $PSScriptRoot -ChildPath "FunctionalTestUtils.ps1")
 
     function SetConditions {
         [CmdletBinding(DefaultParameterSetName = 'Actual')]
@@ -192,14 +194,6 @@ BeforeAll{
                 $ScriptBlock = [ScriptBlock]::Create("$($Condition.Command)")
             }
             try {
-                Write-Host "The Script Block is"
-                Write-Host $ScriptBlock
-                Write-Host "PSSCriptRoot is"
-                Write-Host $PSScriptRoot
-                $UtilityModulePath = Join-Path -Path $PSScriptRoot -ChildPath "../../../PowerShell/ScubaGear/Modules/Utility/Utility.psm1" -Resolve
-                Write-Host "The Utility Module Path is"
-                Write-Host $UtilityModulePath
-                Import-Module $UtilityModulePath -Function Get-Utf8NoBom, Set-Utf8NoBom -Scope Global
                 $ScriptBlock.Invoke()
             }
             catch {
@@ -222,6 +216,7 @@ BeforeAll{
 Describe "Policy Checks for <ProductName>"{
     Context "Start tests for policy <PolicyId>" -ForEach $TestPlan{
         BeforeEach{
+            . (Join-Path -Path $PSScriptRoot -ChildPath "FunctionalTestUtils.ps1")
             # Select which TestDriver to use for a given test plan. TestDriver names (e.g. RunScuba, ScubaCached) must
             # match exactly (including case) the ones used in TestPlans.
             if ($ConfigFileName -and ('RunScuba' -eq $TestDriver)){

--- a/Testing/Functional/Products/Products.Tests.ps1
+++ b/Testing/Functional/Products/Products.Tests.ps1
@@ -167,7 +167,7 @@ BeforeAll {
     }
 
     # Dot source utility functions
-#    . (Join-Path -Path $PSScriptRoot -ChildPath "FunctionalTestUtils.ps1")
+    . (Join-Path -Path $PSScriptRoot -ChildPath "FunctionalTestUtils.ps1")
 
     function SetConditions {
         [CmdletBinding(DefaultParameterSetName = 'Actual')]

--- a/Testing/Functional/Products/Products.Tests.ps1
+++ b/Testing/Functional/Products/Products.Tests.ps1
@@ -165,6 +165,7 @@ BeforeAll{
     }
 
     # Dot source utility functions
+    Write-Host "Source the utility functions"
     . (Join-Path -Path $PSScriptRoot -ChildPath "FunctionalTestUtils.ps1")
 
     function SetConditions {
@@ -181,8 +182,8 @@ BeforeAll{
         )
 
         ForEach($Condition in $Conditions){
-            Write-Output "The condition is"
-            Write-Output $Condition
+            Write-Host "The condition is"
+            Write-Host $Condition
             $Splat = $Condition.Splat
             if ('Cached' -eq $PSCmdlet.ParameterSetName){
                 $Splat.Add("OutputFolder", [string]$OutputFolder)


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

This update changes ScubaGear such that its tenant configuration captured in the provider output JSON (ProviderSettingsExport.json, by default) is encoded as a UTF-8 file without a byte order mark (BOM) rather than including a BOM.  

Updates to the code include:
 * New functions Get-Utf8NoBOM and Set-Utf8NoBOM for reading and writing utf-8 encoded files without a BOM
 * Wrapper functions Invoke-ReadAllLines and Invoke-WriteAllLines that provide testability for use of the associated .NET System.IO functions
 * A new Utility powershell module for the above functions to support use across ScubaGear modules
 * PowerShell unit tests for the new methods covering pathing and escape sequence handling

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

OPA Rego (as of 0.68) does not recognize the byte order mark (BOM).  As a result, parsing of the file can fail when some character sequences, such as unescaped backslashes, are present in the input.  These characters are common in certain tenant configurations, such as Exchange transport rule regular expressions or Windows file paths.  By removing the BOM from provider output files and encoding as UTF-8 without a BOM, Rego can properly handle the provider JSON as input without issue.

Closes #935
Closes #990 
Closes #1138 
Closes #1214
Closes #1242
Closes #1299


## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

To test this PR, first configure a test tenant such that it contains an input that triggers the existing bug.  This can be done by adding or modifying an existing DLP policy description to include the string:
```Create a "\/Date(1698260458733)\/" custom policy from )\/scratch. You "\/Date will choose the type of content to protect and how you want to protect it.```

Run ScubaGear against the test tenant including the Defender product, at a minimum.
``` Invoke-Scuba -p defender ```

This should result in an error similar to the one shown here:
![image](https://github.com/user-attachments/assets/9d1d0fcb-1c1d-4e24-b2b9-2a4042926fd8)

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [x] Resolved all merge conflicts on branch
- [ ] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
