### PR TITLE
Enhance AAD provider to handle nested PIM groups and refactor Get-PrivilegedUser to reduce code duplication

### DIFF
--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -381,8 +381,7 @@ function LoadObjectDataIntoPrivilegedUserHashtable {
         if (-Not $PrivilegedUsers.ContainsKey($ObjectId)) {
             $AADUser = Get-MgBetaUser -ErrorAction Stop -UserId $ObjectId
             $PrivilegedUsers[$ObjectId] = @{"DisplayName"=$AADUser.DisplayName; "OnPremisesImmutableId"=$AADUser.OnPremisesImmutableId; "roles"=@()}
-# Write-Warning "Processing role: $($Role.DisplayName) User: $($AADUser.DisplayName)"
-Write-Debug "Processing role: $($Role.DisplayName) User: $($AADUser.DisplayName)"
+Write-Warning "Processing role: $($Role.DisplayName) User: $($AADUser.DisplayName)"
         }
         # If the current role has not already been added to the user's roles array then add the role
         if ($PrivilegedUsers[$ObjectId].roles -notcontains $Role.DisplayName) {

--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -372,7 +372,7 @@ function LoadObjectDataIntoPrivilegedUserHashtable {
                 throw $_
             }
         }
-        
+
         $Objecttype = $DirectoryObject.AdditionalProperties."@odata.type" -replace "#microsoft.graph."
     }
 
@@ -381,7 +381,8 @@ function LoadObjectDataIntoPrivilegedUserHashtable {
         if (-Not $PrivilegedUsers.ContainsKey($ObjectId)) {
             $AADUser = Get-MgBetaUser -ErrorAction Stop -UserId $ObjectId
             $PrivilegedUsers[$ObjectId] = @{"DisplayName"=$AADUser.DisplayName; "OnPremisesImmutableId"=$AADUser.OnPremisesImmutableId; "roles"=@()}
-Write-Warning "Processing role: $($Role.DisplayName) User: $($AADUser.DisplayName)"
+# Write-Warning "Processing role: $($Role.DisplayName) User: $($AADUser.DisplayName)"
+Write-Debug "Processing role: $($Role.DisplayName) User: $($AADUser.DisplayName)"
         }
         # If the current role has not already been added to the user's roles array then add the role
         if ($PrivilegedUsers[$ObjectId].roles -notcontains $Role.DisplayName) {

--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -126,7 +126,7 @@ function Export-AADProvider {
         # While ConvertTo-Json won't mess up a dict as described in the above comment,
         # on error, $TryCommand returns an empty list, not a dictionary.
         $PrivilegedUsers = if ($null -eq $PrivilegedUsers) {"{}"} else {$PrivilegedUsers}
-        
+
         # Get-PrivilegedRole provides a list of security configurations for each privileged role and information about Active user assignments
         if ($RequiredServicePlan){
             # If the tenant has the premium license then we also include calls to PIM APIs
@@ -352,7 +352,7 @@ function LoadObjectDataIntoPrivilegedUserHashtable {
     )
     # Write-Warning "Recursion level: $recursioncount"
 
-    # We support group nesting up to 2 levels deep (stops after processing levels 0 and 1). 
+    # We support group nesting up to 2 levels deep (stops after processing levels 0 and 1).
     # Safeguard: Also protects against infinite loops if there is a circular group assignment in PIM.
     if ($recursioncount -ge 2) {
         return
@@ -424,7 +424,7 @@ function LoadObjectDataIntoPrivilegedUserHashtable {
             $PIMGroupMembers = Invoke-GraphDirectly @graphArgs
             foreach ($GroupMember in $PIMGroupMembers) {
                 # Write-Warning "Processing role: $($RoleName) PIM group Eligible member: $($GroupMember.PrincipalId)"
-                
+
                 # If the user is not a member of the PIM group (i.e. they are an owner) then skip them
                 if ($GroupMember.AccessId -ne "member") { continue }
                 $PIMEligibleUserId = $GroupMember.PrincipalId

--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -350,7 +350,8 @@ function LoadObjectDataIntoPrivilegedUserHashtable {
         [Parameter()]
         [int]$Recursioncount = 0
     )
-Write-Warning "Recursion level: $recursioncount"
+    # Write-Warning "Recursion level: $recursioncount"
+
     # We support group nesting up to 2 levels deep (stops after processing levels 0 and 1). 
     # Safeguard: Also protects against infinite loops if there is a circular group assignment in PIM.
     if ($recursioncount -ge 2) {
@@ -382,7 +383,7 @@ Write-Warning "Recursion level: $recursioncount"
         if (-Not $PrivilegedUsers.ContainsKey($ObjectId)) {
             $AADUser = Get-MgBetaUser -ErrorAction Stop -UserId $ObjectId
             $PrivilegedUsers[$ObjectId] = @{"DisplayName"=$AADUser.DisplayName; "OnPremisesImmutableId"=$AADUser.OnPremisesImmutableId; "roles"=@()}
-Write-Warning "Processing role: $($RoleName) User: $($AADUser.DisplayName)"
+            # Write-Warning "Processing role: $($RoleName) User: $($AADUser.DisplayName)"
         }
         # If the current role has not already been added to the user's roles array then add the role
         if ($PrivilegedUsers[$ObjectId].roles -notcontains $RoleName) {
@@ -395,7 +396,7 @@ Write-Warning "Processing role: $($RoleName) User: $($AADUser.DisplayName)"
         $GroupId = $ObjectId
         # Get all of the group members that are transitively assigned to the current role via group membership
         $GroupMembers = Get-MgBetaGroupMember -All -ErrorAction Stop -GroupId $GroupId
-Write-Warning "Processing role: $($RoleName) Group: $($GroupId)"
+        # Write-Warning "Processing role: $($RoleName) Group: $($GroupId)"
 
         foreach ($GroupMember in $GroupMembers) {
             $Membertype = $GroupMember.AdditionalProperties."@odata.type" -replace "#microsoft.graph."
@@ -422,7 +423,8 @@ Write-Warning "Processing role: $($RoleName) Group: $($GroupId)"
                 "M365Environment" = $M365Environment }
             $PIMGroupMembers = Invoke-GraphDirectly @graphArgs
             foreach ($GroupMember in $PIMGroupMembers) {
-Write-Warning "Processing role: $($RoleName) PIM group Eligible member: $($GroupMember.PrincipalId)"
+                # Write-Warning "Processing role: $($RoleName) PIM group Eligible member: $($GroupMember.PrincipalId)"
+                
                 # If the user is not a member of the PIM group (i.e. they are an owner) then skip them
                 if ($GroupMember.AccessId -ne "member") { continue }
                 $PIMEligibleUserId = $GroupMember.PrincipalId

--- a/PowerShell/ScubaGear/RequiredVersions.ps1
+++ b/PowerShell/ScubaGear/RequiredVersions.ps1
@@ -56,6 +56,11 @@ $ModuleList = @(
         MaximumVersion = [version] '2.99.99999'
     },
     @{
+        ModuleName = 'Microsoft.Graph.Beta.DirectoryObjects'
+        ModuleVersion = [version] '2.0.0'
+        MaximumVersion = [version] '2.99.99999'
+    },
+    @{
         ModuleName = 'powershell-yaml'
         ModuleVersion = [version] '0.4.2'
         MaximumVersion = [version] '0.99.99999'

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/AADProvider/LoadObjectDataIntoPrivilegedUserHashtable.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/AADProvider/LoadObjectDataIntoPrivilegedUserHashtable.Tests.ps1
@@ -1,0 +1,38 @@
+$ProviderPath = '../../../../../Modules/Providers'
+Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "$($ProviderPath)/ExportAADProvider.psm1") -Function 'LoadObjectDataIntoPrivilegedUserHashtable' -Force
+
+InModuleScope ExportAADProvider {
+    Describe -Tag 'LoadObjectDataIntoPrivilegedUserHashtable' -Name 'Not Found' {
+        BeforeAll {
+        }
+        It 'Deleted user Request_ResourceNotFound' {
+            # Set up the parameters for the test
+            $Role = [PSCustomObject]@{ DisplayName = "Global Administrator" }  # Mock role with DisplayName
+            $PrivilegedUsers = @{}  # Empty hashtable for privileged users
+            $ObjectId = [Guid]::NewGuid().Guid  # Random GUID for ObjectId
+            $TenantHasPremiumLicense = $true
+
+            # Simulate the "Request_ResourceNotFound" exception
+            Mock Get-MgBetaDirectoryObject {
+                # Write-Host "Inside Get-MgBetaDirectoryObject"
+                throw [System.Exception]::new("Request_ResourceNotFound")
+            }
+
+            # Track warnings using Assert-MockCalled further down
+            Mock Write-Warning
+
+            # Call the function under test
+            LoadObjectDataIntoPrivilegedUserHashtable -Role $Role -PrivilegedUsers $PrivilegedUsers -ObjectId $ObjectId -TenantHasPremiumLicense $TenantHasPremiumLicense
+
+            # Ensure the Write-Warning was called because Get-MgBetaDirectoryObject throws an exception
+            Should -Invoke -CommandName Write-Warning -Times 1
+
+            # Check that the function returned early and did not add anything to $PrivilegedUsers
+            $PrivilegedUsers.Count | Should -Be 0
+        }
+    }
+}
+
+AfterAll {
+    Remove-Module ExportAADProvider -Force -ErrorAction SilentlyContinue
+}

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/AADProvider/LoadObjectDataIntoPrivilegedUserHashtable.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/AADProvider/LoadObjectDataIntoPrivilegedUserHashtable.Tests.ps1
@@ -5,12 +5,14 @@ InModuleScope ExportAADProvider {
     Describe -Tag 'LoadObjectDataIntoPrivilegedUserHashtable' -Name 'Not Found' {
         BeforeAll {
         }
-        It 'Deleted user Request_ResourceNotFound' {
+
+        It 'Deleted user triggers Request_ResourceNotFound exception' {
             # Set up the parameters for the test
-            $Role = [PSCustomObject]@{ DisplayName = "Global Administrator" }  # Mock role with DisplayName
+            $RoleName = "Global Administrator"  # Mock role
             $PrivilegedUsers = @{}  # Empty hashtable for privileged users
             $ObjectId = [Guid]::NewGuid().Guid  # Random GUID for ObjectId
             $TenantHasPremiumLicense = $true
+            $M365Environment = "commercial"
 
             # Simulate the "Request_ResourceNotFound" exception
             Mock Get-MgBetaDirectoryObject {
@@ -22,13 +24,164 @@ InModuleScope ExportAADProvider {
             Mock Write-Warning
 
             # Call the function under test
-            LoadObjectDataIntoPrivilegedUserHashtable -Role $Role -PrivilegedUsers $PrivilegedUsers -ObjectId $ObjectId -TenantHasPremiumLicense $TenantHasPremiumLicense
+            LoadObjectDataIntoPrivilegedUserHashtable -RoleName $RoleName -PrivilegedUsers $PrivilegedUsers -ObjectId $ObjectId -TenantHasPremiumLicense $TenantHasPremiumLicense -M365Environment $M365Environment
 
             # Ensure the Write-Warning was called because Get-MgBetaDirectoryObject throws an exception
             Should -Invoke -CommandName Write-Warning -Times 1
 
             # Check that the function returned early and did not add anything to $PrivilegedUsers
             $PrivilegedUsers.Count | Should -Be 0
+        }
+
+        It 'Objecttype is is a user' {
+            # Set up the parameters for the test
+            $RoleName = "Global Administrator"  # Mock role
+            $PrivilegedUsers = @{}  # Empty hashtable for privileged users
+            $ObjectId = [Guid]::NewGuid().Guid  # Random GUID for ObjectId
+            $TenantHasPremiumLicense = $true
+            $M365Environment = "commercial"
+
+            # Mock Get-MgBetaDirectoryObject to return a user-type object
+            Mock Get-MgBetaDirectoryObject {
+                [PSCustomObject]@{
+                    AdditionalProperties = @{
+                        "@odata.type" = "#microsoft.graph.user"  # Simulates a user type
+                    }
+                }
+            }
+
+            # Mock Get-MgBetaUser to return a user with DisplayName and OnPremisesImmutableId
+            Mock Get-MgBetaUser {
+                [PSCustomObject]@{
+                    DisplayName            = "John Doe"
+                    OnPremisesImmutableId  = "ABC123"
+                }
+            }
+
+            # Test 1 - Do NOT pass ObjectType
+            LoadObjectDataIntoPrivilegedUserHashtable -RoleName $RoleName -PrivilegedUsers $PrivilegedUsers -ObjectId $ObjectId -TenantHasPremiumLicense $TenantHasPremiumLicense -M365Environment $M365Environment
+            # Assertions to ensure the user was processed correctly
+             $PrivilegedUsers[$ObjectId].DisplayName | Should -Be "John Doe"
+             $PrivilegedUsers[$ObjectId].OnPremisesImmutableId | Should -Be "ABC123"
+             $PrivilegedUsers[$ObjectId].roles | Should -Contain $RoleName
+
+            # Test 2 - Pass ObjectType
+            $PrivilegedUsers = @{}
+            $Objecttype = "user"
+            LoadObjectDataIntoPrivilegedUserHashtable -Objecttype $Objecttype -RoleName $RoleName -PrivilegedUsers $PrivilegedUsers -ObjectId $ObjectId -TenantHasPremiumLicense $TenantHasPremiumLicense  -M365Environment $M365Environment
+
+            # Assertions to ensure the user was processed correctly
+            $PrivilegedUsers[$ObjectId].DisplayName | Should -Be "John Doe"
+            $PrivilegedUsers[$ObjectId].OnPremisesImmutableId | Should -Be "ABC123"
+            $PrivilegedUsers[$ObjectId].roles | Should -Contain $RoleName
+        }
+
+
+        It 'Objecttype is a group' {
+            # Set up the parameters for the test
+            $RoleName = "Global Administrator"  # Mock role
+            $PrivilegedUsers = @{}  # Empty hashtable for privileged users
+            $ObjectId = [Guid]::NewGuid().Guid  # Random GUID for ObjectId, simulating a group ID
+            $TenantHasPremiumLicense = $true
+            $M365Environment = "commercial"
+
+            # Mock Get-MgBetaDirectoryObject to return a group-type object
+            Mock Get-MgBetaDirectoryObject {
+                [PSCustomObject]@{
+                    AdditionalProperties = @{
+                        "@odata.type" = "#microsoft.graph.group"  # Simulates a group type
+                    }
+                }
+            }
+
+            # Mock Get-MgBetaGroupMember to return two group members (users)
+            Mock Get-MgBetaGroupMember {
+                @(
+                    [PSCustomObject]@{
+                        Id = [Guid]::NewGuid().Guid
+                        AdditionalProperties = @{
+                            "@odata.type" = "#microsoft.graph.user"  # First user in the group
+                        }
+                    },
+                    [PSCustomObject]@{
+                        Id = [Guid]::NewGuid().Guid
+                        AdditionalProperties = @{
+                            "@odata.type" = "#microsoft.graph.user"  # Second user in the group
+                        }
+                    }
+                )
+            }
+
+            # Mock Get-MgBetaUser to return a user object with DisplayName and OnPremisesImmutableId for both users
+            Mock Get-MgBetaUser {
+                param ($UserId)
+                [PSCustomObject]@{
+                    DisplayName            = "User $UserId"
+                    OnPremisesImmutableId  = "ImmutableId-$UserId"
+                }
+            }
+
+            # Mock Invoke-GraphDirectly to return no PIM eligible members
+            Mock Invoke-GraphDirectly {
+                @()  # Returns an empty array
+            }
+
+            ########## Test 1 - Do NOT pass ObjectType
+            LoadObjectDataIntoPrivilegedUserHashtable -RoleName $RoleName -PrivilegedUsers $PrivilegedUsers -ObjectId $ObjectId -TenantHasPremiumLicense $TenantHasPremiumLicense -M365Environment $M365Environment
+
+            # Assertions to ensure the group members were processed correctly
+            $PrivilegedUsers.Count | Should -Be 2  # Two users should have been added
+
+            # Ensure both users have their properties set correctly
+            $PrivilegedUsers.Values | ForEach-Object {
+                $_.roles | Should -Contain $RoleName
+                $_.DisplayName | Should -Match "User"
+                $_.OnPremisesImmutableId | Should -Match "ImmutableId"
+            }
+
+            ########## Test 2 - Pass ObjectType
+            $PrivilegedUsers = @{}
+            $Objecttype = "group"
+            LoadObjectDataIntoPrivilegedUserHashtable -Objecttype $Objecttype -RoleName $RoleName -PrivilegedUsers $PrivilegedUsers -ObjectId $ObjectId -TenantHasPremiumLicense $TenantHasPremiumLicense -M365Environment $M365Environment
+
+            # Assertions to ensure the group members were processed correctly
+            $PrivilegedUsers.Count | Should -Be 2  # Two users should have been added
+
+            # Ensure both users have their properties set correctly
+            $PrivilegedUsers.Values | ForEach-Object {
+                $_.roles | Should -Contain $RoleName
+                $_.DisplayName | Should -Match "User"
+                $_.OnPremisesImmutableId | Should -Match "ImmutableId"
+            }
+
+            ########## Test 3 - Trigger recursion by mocking Invoke-GraphDirectly to return some users
+            $PrivilegedUsers = @{}
+            $Objecttype = "group"
+             # Mock Invoke-GraphDirectly to return two PIM eligible users (simulating a recursion case)
+             Mock Invoke-GraphDirectly {
+                @(
+                    [PSCustomObject]@{
+                        PrincipalId = [Guid]::NewGuid().Guid  # First PIM eligible user
+                        AccessId    = "member"  # Simulates eligible PIM member
+                    },
+                    [PSCustomObject]@{
+                        PrincipalId = [Guid]::NewGuid().Guid  # Second PIM eligible user
+                        AccessId    = "member"  # Simulates eligible PIM member
+                    }
+                )
+            }
+
+            LoadObjectDataIntoPrivilegedUserHashtable -Objecttype $Objecttype -RoleName $RoleName -PrivilegedUsers $PrivilegedUsers -ObjectId $ObjectId -TenantHasPremiumLicense $TenantHasPremiumLicense -M365Environment $M365Environment
+
+            # Two group members that each trigger the recursion 2 levels deep = 2 + 2 + 2 = 6
+            $PrivilegedUsers.Count | Should -Be 6
+
+            # Ensure all users have their properties set correctly
+            $PrivilegedUsers.Values | ForEach-Object {
+                $_.roles | Should -Contain $RoleName
+                $_.DisplayName | Should -Match "User"
+                $_.OnPremisesImmutableId | Should -Match "ImmutableId"
+            }
         }
     }
 }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/AADProvider/LoadObjectDataIntoPrivilegedUserHashtable.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/AADProvider/LoadObjectDataIntoPrivilegedUserHashtable.Tests.ps1
@@ -15,12 +15,13 @@ InModuleScope ExportAADProvider {
             $M365Environment = "commercial"
 
             # Simulate the "Request_ResourceNotFound" exception
+            function  Get-MgBetaDirectoryObject { }
             Mock Get-MgBetaDirectoryObject {
                 throw [System.Exception]::new("Request_ResourceNotFound")
             }
 
             # Track warnings using Assert-MockCalled further down
-            Mock Write-Warning
+            Mock Write-Warning { }
 
             # Call the function under test
             LoadObjectDataIntoPrivilegedUserHashtable -RoleName $RoleName -PrivilegedUsers $PrivilegedUsers -ObjectId $ObjectId -TenantHasPremiumLicense $TenantHasPremiumLicense -M365Environment $M365Environment
@@ -41,6 +42,7 @@ InModuleScope ExportAADProvider {
             $M365Environment = "commercial"
 
             # Mock Get-MgBetaDirectoryObject to return a user-type object
+            function  Get-MgBetaDirectoryObject { }
             Mock Get-MgBetaDirectoryObject {
                 [PSCustomObject]@{
                     AdditionalProperties = @{
@@ -50,6 +52,7 @@ InModuleScope ExportAADProvider {
             }
 
             # Mock Get-MgBetaUser to return a user with DisplayName and OnPremisesImmutableId
+            function Get-MgBetaUser { }
             Mock Get-MgBetaUser {
                 [PSCustomObject]@{
                     DisplayName            = "John Doe"
@@ -75,7 +78,6 @@ InModuleScope ExportAADProvider {
             $PrivilegedUsers[$ObjectId].roles | Should -Contain $RoleName
         }
 
-
         It 'Objecttype is a group' {
             # Set up the parameters for the test
             $RoleName = "Global Administrator"  # Mock role
@@ -85,6 +87,7 @@ InModuleScope ExportAADProvider {
             $M365Environment = "commercial"
 
             # Mock Get-MgBetaDirectoryObject to return a group-type object
+            function  Get-MgBetaDirectoryObject { }
             Mock Get-MgBetaDirectoryObject {
                 [PSCustomObject]@{
                     AdditionalProperties = @{
@@ -94,6 +97,7 @@ InModuleScope ExportAADProvider {
             }
 
             # Mock Get-MgBetaGroupMember to return two group members (users)
+            function Get-MgBetaGroupMember { }
             Mock Get-MgBetaGroupMember {
                 @(
                     [PSCustomObject]@{
@@ -112,6 +116,7 @@ InModuleScope ExportAADProvider {
             }
 
             # Mock Get-MgBetaUser to return a user object with DisplayName and OnPremisesImmutableId for both users
+            function Get-MgBetaUser { }
             Mock Get-MgBetaUser {
                 param ($UserId)
                 [PSCustomObject]@{
@@ -121,6 +126,7 @@ InModuleScope ExportAADProvider {
             }
 
             # Mock Invoke-GraphDirectly to return no PIM eligible members
+            function Invoke-GraphDirectly { }
             Mock Invoke-GraphDirectly {
                 @()  # Returns an empty array
             }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/AADProvider/LoadObjectDataIntoPrivilegedUserHashtable.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/AADProvider/LoadObjectDataIntoPrivilegedUserHashtable.Tests.ps1
@@ -16,7 +16,6 @@ InModuleScope ExportAADProvider {
 
             # Simulate the "Request_ResourceNotFound" exception
             Mock Get-MgBetaDirectoryObject {
-                # Write-Host "Inside Get-MgBetaDirectoryObject"
                 throw [System.Exception]::new("Request_ResourceNotFound")
             }
 

--- a/utils/UninstallModules.ps1
+++ b/utils/UninstallModules.ps1
@@ -26,6 +26,7 @@ $ModuleList = @(
     "Microsoft.Graph.Beta.Identity.DirectoryManagement",
     "Microsoft.Graph.Beta.Identity.SignIns",
     "Microsoft.Graph.Beta.Users",
+    "Microsoft.Graph.Beta.DirectoryObjects",
     "powershell-yaml"
     )
 


### PR DESCRIPTION
## 🗣 Description ##

The general impetus for this PR was a publicly reported edge case where the **AAD provider crashes when an admin assigns a nested group to an AAD PIM group** as an Eligible assignment. In order to implement the fix, I determined that augmenting the current code in Get-PrivilegedUser was a bad idea because it had already become hard to maintain with lots of duplication, so I refactored Get-PrivilegedUser to call a new helper function named LoadObjectDataIntoPrivilegedUserHashtable which takes a user or a group as an argument, fetches the metadata about the object and loads the metadata into the PrivilegedUsers hashtable which is used to form the privileged_users section of the provider JSON document. The other major defect that this PR addresses is that the code now handles a scenario **where a user or a group is deleted from the directory in the hours before running ScubaGear, this can cause ScubaGear to crash if the object was Eligible assigned to a PIM group**.

Both of the defects described above, the nested groups and the deleted objects cause ScubaGear to crash with a 404 (NotFound) Request_ResourceNotFound error, even though the root cause is completely unrelated.

*I have some Write-Warning statements dispersed in the code right now which are only to assist the pull request reviewers with testing the various scenarios. These will be removed.

**Iterative list of code changes**:
- Added helper function LoadObjectDataIntoPrivilegedUserHashtable to handle fetching of metadata for users and groups
- Added code in helper function to handle nested PIM groups causing 404 crash
- Added code in helper function to handle deleted objects causing 404 crash
- Refactored Get-PrivilegedUser to reduce code duplication and simplify the logic
- Added usage of Get-MgBetaDirectoryObject to helper function to determine if an object is a user or a group (which is needed in some code paths). Thanks to @thetolkienblackguy for this recommendation.
- Changed TenantHasPremiumLicense parameter used in multiple functions from type "switch" to "bool" because we are using the parameter as a bool in the way we are calling the respective functions.
- Added new ScubaGear dependency for Graph Powershell module Microsoft.Graph.Beta.DirectoryObjects which is needed for Get-MgBetaDirectoryObject cmdlet

Closes #1288
Closes #1306
Closes #1305
Closes #1303

**ToDo**
- [x] Add more comments into the code since there is a lot going on
- [ ] Remove Write-Warning which are there for PR testing before merging to main

## 🧪 Testing ##

Due to the size of the PR description, I provide testing instructions as detailed comments. Each reviewer should have a comment template with multiple test cases associated with your name.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [ ] All relevant functional tests passed.
- [ ] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] PR passed smoke test check.
- [ ] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [ ] Resolved all merge conflicts on branch
- [ ] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
