### PR TITLE
Fix functional testing and cached output errors

### DIFF
--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -422,7 +422,7 @@ function Invoke-SCuBA {
             }
             # Craft the csv version of just the results
             $CsvParams = @{
-                'ProductNames' = $ProductNames;
+                'ProductNames' = $ScubaConfig.ProductNames;
                 'OutFolderPath' = $OutFolderPath;
                 'OutJsonFileName' = $ScubaConfig.OutJsonFileName;
                 'OutCsvFileName' = $ScubaConfig.OutCsvFileName;
@@ -1745,7 +1745,7 @@ function Invoke-SCuBACached {
                 # Uses the custom UTF8 NoBOM function to reoutput the Provider JSON file
                 $ProviderContent = $SettingsExport | ConvertTo-Json -Depth 20
                 $ActualSavedLocation = Set-Utf8NoBom -Content $ProviderContent `
-                -Location $ProviderJSONFilePath -FileName "$OutProviderFileName.json"
+                -Location $OutPath -FileName "$OutProviderFileName.json"
                 Write-Debug $ActualSavedLocation
             }
             $SettingsExport = Get-Content $ProviderJSONFilePath | ConvertFrom-Json

--- a/Testing/Functional/Products/FunctionalTestUtils.ps1
+++ b/Testing/Functional/Products/FunctionalTestUtils.ps1
@@ -93,7 +93,7 @@ function LoadProviderExport() {
       Copy-Item -Path "$OutputFolder/ProviderSettingsExport.json" -Destination "$OutputFolder/ModifiedProviderSettingsExport.json"
   }
 
-  $Content = Get-Utf8NoBom -FilePath "$OutputFolder/ProviderSettingsExport.json"
+  $Content = Get-Utf8NoBom -FilePath "$OutputFolder/ModifiedProviderSettingsExport.json"
   $ProviderExport = $Content | ConvertFrom-Json
   $ProviderExport
 }

--- a/Testing/Functional/Products/TestPlans/sharepoint.pnp.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/sharepoint.pnp.testplan.yaml
@@ -123,6 +123,8 @@ TestPlan:
           - Command: Set-PnPTenant
             Splat:
               SharingCapability: ExternalUserAndGuestSharing
+          - Command: Set-PnPTenant
+            Splat:
               DefaultSharingLinkType: AnonymousAccess
         Postconditions: []
         ExpectedResult: false
@@ -131,6 +133,8 @@ TestPlan:
           - Command: Set-PnPTenant
             Splat:
               SharingCapability: Disabled
+          - Command: Set-PnPTenant
+            Splat:
               DefaultSharingLinkType: Direct
         Postconditions: []
         ExpectedResult: true


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->
This request contains updates to fix failures when running tests that modify configuration setting export results prior to testing.  Specifically this update:
* Makes sure that Invoke-SCuBACached outputs CSV results for only the configured products
* Modified provider settings file is output to the correct filename
* The filepath of the export settings file is correctly specified when writing to disk
* Modifies two MS.SHAREPOINT.2.1v1 test pre-conditions to ensure strict ordering

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->
Some testing requires manual changes to represent uncommon or undesirable test results.  Doing so means the functional test harness may intercept and change those results before running a test.  The bug was preventing the modified results from being used in the tests and causing tests to fail when they should pass.  We want tests to accurately report their results.

Closes #1328
Closes #1329 
Closes #1333
Closes #1337 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

To test this PR, either run the nightly functional test pipeline to validate that all tests using cached results (UpdateProviderExport in preconditions) pass as expected, particularly MS.AAD.3.2v1 and MS.AAD.3.3v1 tests.  Or run the functional tests using the ScubaGearCheck.ps1 script as follows (note: this is for internal dev use only and requires additional configuration):

```ScubaGearCheck.ps1 -Baseline aad -Tenant 2 -UserAuth:$false -Filter "MS.AAD.3.[23]v1*"```

All tests should pass.

Also test via:
    Create output with merged json using the default invoke options, then run the following:
    Invoke-ScubaCached -OutPath .\path-to-output-folder-from-original-run\ -ExportProvider $false

Also, when running functional tests verify that this error is not present in Defender tests:
```
WARNING: Error involving the creation of CSV version of output. See the exception message for more details: Cannot find
path 'D:\a\ScubaGear\ScubaGear\repo\M365BaselineConformance_2024_09_24_11_43_30\IndividualReports\AADReport.json' 
because it does not exist.
```

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [x] Resolved all merge conflicts on branch
- [x] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
