### PR TITLE
Fix import path for Support Initialize-SCuBA

### DIFF
--- a/PowerShell/ScubaGear/Modules/Support/Support.psm1
+++ b/PowerShell/ScubaGear/Modules/Support/Support.psm1
@@ -114,9 +114,14 @@ function Initialize-SCuBA {
     # Start a stopwatch to time module installation elapsed time
     $Stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
-    # Need to determine where module is so we can get required versions info
-    $ModuleParentDir = Split-Path -Path (Get-Module ScubaGear).Path -Parent
-    $SupportPath = Join-Path -Path $ModuleParentDir -ChildPath 'Modules\Support\Support.psm1'
+    # Since this method is called from the Support module, script root
+    # points to the Support module location
+    # Use script root rather than Get-Module as this may be called by
+    # a script that only imports the function and not the whole module
+    $SupportPath = $PSScriptRoot
+
+    # Scuba module structure means module home is grandparent of support
+    $ScubaModuleDir = Split-Path -Path $(Split-Path -Path $SupportPath -Parent) -Parent
 
     # Removing the import below causes issues with testing, let it be.
     # Import module magic may be helping by:
@@ -125,11 +130,11 @@ function Initialize-SCuBA {
     Import-Module $SupportPath -Function Initialize-Scuba
 
     try {
-        ($RequiredModulesPath = Join-Path -Path $ModuleParentDir -ChildPath 'RequiredVersions.ps1') *> $null
+        ($RequiredModulesPath = Join-Path -Path $ScubaModuleDir -ChildPath 'RequiredVersions.ps1') *> $null
         . $RequiredModulesPath
     }
     catch {
-        throw "Unable to find RequiredVersions.ps1 in expected directory:`n`t$ModuleParentDir"
+        throw "Unable to find RequiredVersions.ps1 in expected directory:`n`t$ScubaModuleDir"
     }
 
     if ($ModuleList) {


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->
Add fixes to resolve the error that is thrown during an `Initiailze-SCuBA` cmdlet run after installing ScubaGear from its nuget package (via PSGallery).


## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->
Prevents extraneous error and red text from being thrown during ScubaGear initialization.

Closes #1361 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

  1. Start with a clean test system without ScubaGear or its dependencies installed.
  2. Run `Install-Module -Name ScubaGear -AllowPrerelease -RequiredVersion 1.4.0-test2024101002` (note: this module version corresponds to a packaging of the PR fix branch)
  3. Run `Initialize-SCuBA` and review output for presence of red text shown in screenshot below.

## 📷 Screenshots (if appropriate) ##

Showing the issue when present (the red text should not be present in the fix)
<img width="640" alt="UnexpectedSGInitializePSGallery" src="https://github.com/user-attachments/assets/023642fa-45b9-4062-86fe-f40a56067f04">


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [x] Resolved all merge conflicts on branch
- [x] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
