### PR TITLE
Fix syntax error bug in nightly functional test workflow

### DIFF
--- a/.github/workflows/test_production_function.yaml
+++ b/.github/workflows/test_production_function.yaml
@@ -61,7 +61,7 @@ jobs:
       contents: write
       id-token: write
     with:
-      EmailOnFailure: ${{ inputs.EmailOnFailure }}
+      EmailOnFailure: ${{ fromJSON(inputs.EmailOnFailure) }}
       GitHubEventSchedule: ${{ github.event.schedule }}
       GitHubEventName: ${{ github.event_name }}
     secrets:
@@ -81,7 +81,7 @@ jobs:
       contents: write
       id-token: write
     with:
-      EmailOnFailure: ${{ inputs.EmailOnFailure }}
+      EmailOnFailure: ${{ fromJSON(inputs.EmailOnFailure) }}
       GitHubEventSchedule: ${{ github.event.schedule }}
       GitHubEventName: ${{ github.event_name }}
     secrets:
@@ -101,7 +101,7 @@ jobs:
       contents: write
       id-token: write
     with:
-      EmailOnFailure: ${{ inputs.EmailOnFailure }}
+      EmailOnFailure: ${{ fromJSON(inputs.EmailOnFailure) }}
       GitHubEventSchedule: ${{ github.event.schedule }}
       GitHubEventName: ${{ github.event_name }}
     secrets:
@@ -121,7 +121,7 @@ jobs:
       contents: write
       id-token: write
     with:
-      EmailOnFailure: ${{ inputs.EmailOnFailure }}
+      EmailOnFailure: ${{ fromJSON(inputs.EmailOnFailure) }}
       GitHubEventSchedule: ${{ github.event.schedule }}
       GitHubEventName: ${{ github.event_name }}
     secrets:
@@ -141,7 +141,7 @@ jobs:
       contents: write
       id-token: write
     with:
-      EmailOnFailure: ${{ inputs.EmailOnFailure }}
+      EmailOnFailure: ${{ fromJSON(inputs.EmailOnFailure) }}
       GitHubEventSchedule: ${{ github.event.schedule }}
       GitHubEventName: ${{ github.event_name }}
     secrets:
@@ -161,7 +161,7 @@ jobs:
       contents: write
       id-token: write
     with:
-      EmailOnFailure: ${{ inputs.EmailOnFailure }}
+      EmailOnFailure: ${{ fromJSON(inputs.EmailOnFailure) }}
       GitHubEventSchedule: ${{ github.event.schedule }}
       GitHubEventName: ${{ github.event_name }}
     secrets:


### PR DESCRIPTION
## 🗣 Description ##

Added the fromJSON method to parameter calls for booleans.

## 💭 Motivation and context ##

Closes: #1381 

## 🧪 Testing ##

Ran nightly tests manually with and without checking for email.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

- [x] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed
- [x] Resolved all merge conflicts on branch
- [x] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
