### PR TITLE
Allow Users to Specify Installing to AllUsers via new $Scope Variable in Initialize-SCuBA

### DIFF
--- a/PowerShell/ScubaGear/Modules/Support/Support.psm1
+++ b/PowerShell/ScubaGear/Modules/Support/Support.psm1
@@ -50,6 +50,9 @@ function Initialize-SCuBA {
         existing module will not be updated to th latest version.
     .EXAMPLE
         Initialize-SCuBA
+    .EXAMPLE
+        Initalize-SCuBA -Scope AllUsers
+        Install all dependent PowerShell modules in a location that's accessible to all users of the computer.
     .NOTES
         Executing the script with no switches set will install the latest
         version of a module if not already installed.

--- a/PowerShell/ScubaGear/Modules/Support/Support.psm1
+++ b/PowerShell/ScubaGear/Modules/Support/Support.psm1
@@ -91,7 +91,12 @@ function Initialize-SCuBA {
         [Parameter(Mandatory=$false, HelpMessage = 'Directory to contain ScubaGear artifacts. Defaults to <home>.')]
         [ValidateScript({Test-Path -Path $_ -PathType Container})]
         [string]
-        $ScubaParentDirectory = $env:USERPROFILE
+        $ScubaParentDirectory = $env:USERPROFILE,
+
+        [Parameter(Mandatory=$false, HelpMessage = 'Specifies the Install-Module scope of the dependent PowerShell modules. Acceptable values are AllUsers and CurrentUser. Defaults to CurrentUser')]
+        [ValidateSet('CurrentUser','AllUsers')]
+        [string]
+        $Scope = 'CurrentUser'
     )
 
     Write-Output 'Initializing ScubaGear...'
@@ -164,7 +169,7 @@ function Initialize-SCuBA {
                     Install-Module -Name $ModuleName `
                         -Force `
                         -AllowClobber `
-                        -Scope CurrentUser `
+                        -Scope "$($Scope)" `
                         -MaximumVersion $Module.MaximumVersion
                     Write-Information -MessageData "Re-installing module to latest acceptable version: ${ModuleName}."
                 }
@@ -177,7 +182,7 @@ function Initialize-SCuBA {
                     Install-Module -Name $ModuleName `
                         -Force `
                         -AllowClobber `
-                        -Scope CurrentUser `
+                        -Scope "$($Scope)" `
                         -MaximumVersion $Module.MaximumVersion
                     $MaxInstalledVersion = (Get-Module -ListAvailable -Name $ModuleName | Sort-Object Version -Descending | Select-Object Version -First 1).Version
                     Write-Information -MessageData "${ModuleName}: ${HighestInstalledVersion} updated to version ${MaxInstalledVersion}."
@@ -187,7 +192,7 @@ function Initialize-SCuBA {
         else {
             Install-Module -Name $ModuleName `
                 -AllowClobber `
-                -Scope CurrentUser `
+                -Scope "$($Scope)" `
                 -MaximumVersion $Module.MaximumVersion
                 $MaxInstalledVersion = (Get-Module -ListAvailable -Name $ModuleName | Sort-Object Version -Descending | Select-Object Version -First 1).Version
             Write-Information -MessageData "Installed the latest acceptable version of ${ModuleName}: ${MaxInstalledVersion}."


### PR DESCRIPTION
## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->
- Add `$Scope` to Initialize-SCuBA to let users install to `AllUsers`, a place where all users can access the dependent PowerShell modules, rather than just the `CurrentUser` on their system. 

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->
Closes #882 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
- Run `Initalize-SCuBA` by itself. Should be the normal behavior.
- Then run `Initialize-SCuBA -Scope AllUsers`. 

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [x] Resolved all merge conflicts on branch
- [x] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [x] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
