### PR TITLE
improve performance of Defender query to count users without advanced auditing

### DIFF
--- a/PowerShell/ScubaGear/Modules/Providers/ExportDefenderProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportDefenderProvider.psm1
@@ -143,13 +143,13 @@ function Export-DefenderProvider {
         $DLPLicense = ConvertTo-Json $false
     }
 
-    # Run commands to get count of users with Advanced auditing enabled
+    # Get count of users without Advanced auditing enabled
     # GUID below is service plan ID for M365_ADVANCED_AUDITING as defined
     # on Microsoft Licensing Reference shown here:
     # https://learn.microsoft.com/en-us/entra/identity/users/licensing-service-plan-reference
     $UserParameters = @{ConsistencyLevel = 'eventual'
                         Count = 'UsersWithoutAdvancedAuditCount'
-                        All = $true
+                        Top = 1
                         Filter = "not assignedPlans/any(a:a/servicePlanId eq 2f442157-a11c-46b9-ae5b-6e39ff4e5849 and a/capabilityStatus eq 'Enabled')"
                        }
 


### PR DESCRIPTION
## 🗣 Description ##

This PR fixes a bug in Defender that is observed in larger tenants. Defender runs a query via Get-MgBetaUser to get a count of users that do not have the advanced auditing feature assigned to them. Instead of just retrieving the count from the REST API, the current query downloads all the users that match the filter. If a tenant has thousands of users without advanced audit this can result in significant slowness. I added the Top = 1 parameter so that only a single record is returned and verified that the count still works. See the linked issue below for full details and screenshots.

Closes #1404 

## 🧪 Testing ##

See the screenshots in the linked issue above for details on the before and after testing that I performed with the fix against a tenant with over 2,000 users.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [x] Resolved all merge conflicts on branch
- [ ] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
