### PR TITLE
Correct omission in documentation about importing module when downloading from GitHub

### DIFF
--- a/docs/execution/execution.md
+++ b/docs/execution/execution.md
@@ -8,8 +8,10 @@ If ScubaGear was installed by [downloading from GitHub](../installation/github.m
 
 ```powershell
 # Import the module into the session
-Import-Module -Name .\PowerShell\ScubaGear 
+Import-Module .\PowerShell\ScubaGear 
 ```
+
+> **Note**: Do not add a \ to the end of the `Import-Module`.
 
 ## Install Dependencies
 

--- a/docs/execution/execution.md
+++ b/docs/execution/execution.md
@@ -11,7 +11,7 @@ If ScubaGear was installed by [downloading from GitHub](../installation/github.m
 Import-Module .\PowerShell\ScubaGear 
 ```
 
-> **Note**: Do not add a \ to the end of the `Import-Module`.
+> **Note**: Do not add a \ to the end of the `.\PowerShell\ScubaGear` path.
 
 ## Install Dependencies
 

--- a/docs/installation/github.md
+++ b/docs/installation/github.md
@@ -6,7 +6,16 @@ The recommended way to install ScubaGear is from [PSGallery](psgallery.md), but 
 2. Under the `Assets` header, click `ScubaGear-v1.4.0.zip`to download the zip file.
 3. Extract the zip file into the folder of your choice.
 
-Once ScubaGear has been downloaded, the required [dependencies](../prerequisites/dependencies.md) can be installed.
+## Import Module
+
+When ScubaGear is installed by downloading (or cloning) from GitHub, it must be imported into every new PowerShell terminal session before it can be executed. To import the module, open a PowerShell 5.1 terminal, navigate to the repository folder, and run this command:
+
+```powershell
+# Import the module into the session
+Import-Module -Name .\PowerShell\ScubaGear 
+```
+
+Once ScubaGear has been downloaded and imported, the required [dependencies](../prerequisites/dependencies.md) can be installed.
 
 ## PowerShell Execution Policy
 

--- a/docs/installation/github.md
+++ b/docs/installation/github.md
@@ -12,8 +12,10 @@ When ScubaGear is installed by downloading from GitHub, it must be imported into
 
 ```powershell
 # Import the module into the session
-Import-Module -Name .\PowerShell\ScubaGear 
+Import-Module .\PowerShell\ScubaGear 
 ```
+
+> **Note**: Do not add a \ to the end of the `Import-Module`.
 
 Once ScubaGear has been downloaded and imported, the required [dependencies](../prerequisites/dependencies.md) can be installed.
 

--- a/docs/installation/github.md
+++ b/docs/installation/github.md
@@ -8,7 +8,7 @@ The recommended way to install ScubaGear is from [PSGallery](psgallery.md), but 
 
 ## Import Module
 
-When ScubaGear is installed by downloading (or cloning) from GitHub, it must be imported into every new PowerShell terminal session before it can be executed. To import the module, open a PowerShell 5.1 terminal, navigate to the repository folder, and run this command:
+When ScubaGear is installed by downloading from GitHub, it must be imported into every new PowerShell terminal session before it can be executed. To import the module, open a PowerShell 5.1 terminal, navigate to the repository folder, and run this command:
 
 ```powershell
 # Import the module into the session

--- a/docs/installation/github.md
+++ b/docs/installation/github.md
@@ -15,7 +15,7 @@ When ScubaGear is installed by downloading from GitHub, it must be imported into
 Import-Module .\PowerShell\ScubaGear 
 ```
 
-> **Note**: Do not add a \ to the end of the `Import-Module`.
+> **Note**: Do not add a \ to the end of the `.\PowerShell\ScubaGear` path.
 
 Once ScubaGear has been downloaded and imported, the required [dependencies](../prerequisites/dependencies.md) can be installed.
 


### PR DESCRIPTION
## 🗣 Description ##

Added a section on importing the module before installing dependencies.

## 💭 Motivation and context ##

Closes: #1411 

## 🧪 Testing ##

Viewed the docs on GitHub

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] Related issues these changes resolve are linked preferably via [closing keywords]
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

- [x] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed
- [x] Resolved all merge conflicts on branch
- [x] Notified merge coordinator that PR is ready for merge via comment mention

## ✅ Post-merge checklist ##

- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
