### PR TITLE
Disable MS.SHAREPOINT.3.2v1 functional tests temporarily

### DIFF
--- a/Testing/Functional/Products/TestPlans/sharepoint.pnp.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/sharepoint.pnp.testplan.yaml
@@ -247,69 +247,69 @@ TestPlan:
         IsNotChecked: true
         ExpectedResult: false
 
-  - PolicyId: MS.SHAREPOINT.3.2v1
-    TestDriver: RunScuba
-    Tests:
-      - TestDescription: MS.SHAREPOINT.3.2v1 Compliant - SharingCapability = ExternalUserAndGuestSharing (Anyone); FileAnonymousLinkType = View; FolderAnonymousLinkType = View
-        Preconditions:
-          - Command: Set-PnPTenant
-            Splat:
-              SharingCapability: ExternalUserAndGuestSharing
-              FileAnonymousLinkType: View
-              FolderAnonymousLinkType: View
-        Postconditions: []
-        ExpectedResult: true
-      - TestDescription: MS.SHAREPOINT.3.2v1 Non-compliant - SharingCapability = ExternalUserAndGuestSharing (Anyone); FileAnonymousLinkType = Edit; FolderAnonymousLinkType = View
-        Preconditions:
-          - Command: Set-PnPTenant
-            Splat:
-              SharingCapability: ExternalUserAndGuestSharing
-              FileAnonymousLinkType: Edit
-              FolderAnonymousLinkType: View
-        Postconditions: []
-        ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.3.2v1 Non-compliant - SharingCapability = ExternalUserAndGuestSharing (Anyone); FileAnonymousLinkType = View; FolderAnonymousLinkType = Edit
-        Preconditions:
-          - Command: Set-PnPTenant
-            Splat:
-              SharingCapability: ExternalUserAndGuestSharing
-              FileAnonymousLinkType: View
-              FolderAnonymousLinkType: Edit
-        Postconditions: []
-        ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.3.2v1 Non-compliant - SharingCapability = ExternalUserAndGuestSharing (Anyone); FileAnonymousLinkType = Edit; FolderAnonymousLinkType = Edit
-        Preconditions:
-          - Command: Set-PnPTenant
-            Splat:
-              SharingCapability: ExternalUserAndGuestSharing
-              FileAnonymousLinkType: Edit
-              FolderAnonymousLinkType: Edit
-        Postconditions: []
-        ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.3.2v1 Non-Applicable - SharingCapability = Disabled (Only people in your organization)
-        Preconditions:
-          - Command: Set-PnPTenant
-            Splat:
-              SharingCapability: Disabled
-        Postconditions: []
-        IsNotChecked: true
-        ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.3.2v1 Non-Applicable - SharingCapability = ExistingExternalUserSharingOnly (Existing guests)
-        Preconditions:
-          - Command: Set-PnPTenant
-            Splat:
-              SharingCapability: ExistingExternalUserSharingOnly
-        Postconditions: []
-        IsNotChecked: true
-        ExpectedResult: false
-      - TestDescription: MS.SHAREPOINT.3.2v1 Non-Applicable - SharingCapability = ExternalUserSharingOnly (New and existing guests)
-        Preconditions:
-          - Command: Set-PnPTenant
-            Splat:
-              SharingCapability: ExternalUserSharingOnly
-        Postconditions: []
-        IsNotChecked: true
-        ExpectedResult: false
+  # - PolicyId: MS.SHAREPOINT.3.2v1
+  #   TestDriver: RunScuba
+  #   Tests:
+  #     - TestDescription: MS.SHAREPOINT.3.2v1 Compliant - SharingCapability = ExternalUserAndGuestSharing (Anyone); FileAnonymousLinkType = View; FolderAnonymousLinkType = View
+  #       Preconditions:
+  #         - Command: Set-PnPTenant
+  #           Splat:
+  #             SharingCapability: ExternalUserAndGuestSharing
+  #             FileAnonymousLinkType: View
+  #             FolderAnonymousLinkType: View
+  #       Postconditions: []
+  #       ExpectedResult: true
+  #     - TestDescription: MS.SHAREPOINT.3.2v1 Non-compliant - SharingCapability = ExternalUserAndGuestSharing (Anyone); FileAnonymousLinkType = Edit; FolderAnonymousLinkType = View
+  #       Preconditions:
+  #         - Command: Set-PnPTenant
+  #           Splat:
+  #             SharingCapability: ExternalUserAndGuestSharing
+  #             FileAnonymousLinkType: Edit
+  #             FolderAnonymousLinkType: View
+  #       Postconditions: []
+  #       ExpectedResult: false
+  #     - TestDescription: MS.SHAREPOINT.3.2v1 Non-compliant - SharingCapability = ExternalUserAndGuestSharing (Anyone); FileAnonymousLinkType = View; FolderAnonymousLinkType = Edit
+  #       Preconditions:
+  #         - Command: Set-PnPTenant
+  #           Splat:
+  #             SharingCapability: ExternalUserAndGuestSharing
+  #             FileAnonymousLinkType: View
+  #             FolderAnonymousLinkType: Edit
+  #       Postconditions: []
+  #       ExpectedResult: false
+  #     - TestDescription: MS.SHAREPOINT.3.2v1 Non-compliant - SharingCapability = ExternalUserAndGuestSharing (Anyone); FileAnonymousLinkType = Edit; FolderAnonymousLinkType = Edit
+  #       Preconditions:
+  #         - Command: Set-PnPTenant
+  #           Splat:
+  #             SharingCapability: ExternalUserAndGuestSharing
+  #             FileAnonymousLinkType: Edit
+  #             FolderAnonymousLinkType: Edit
+  #       Postconditions: []
+  #       ExpectedResult: false
+  #     - TestDescription: MS.SHAREPOINT.3.2v1 Non-Applicable - SharingCapability = Disabled (Only people in your organization)
+  #       Preconditions:
+  #         - Command: Set-PnPTenant
+  #           Splat:
+  #             SharingCapability: Disabled
+  #       Postconditions: []
+  #       IsNotChecked: true
+  #       ExpectedResult: false
+  #     - TestDescription: MS.SHAREPOINT.3.2v1 Non-Applicable - SharingCapability = ExistingExternalUserSharingOnly (Existing guests)
+  #       Preconditions:
+  #         - Command: Set-PnPTenant
+  #           Splat:
+  #             SharingCapability: ExistingExternalUserSharingOnly
+  #       Postconditions: []
+  #       IsNotChecked: true
+  #       ExpectedResult: false
+  #     - TestDescription: MS.SHAREPOINT.3.2v1 Non-Applicable - SharingCapability = ExternalUserSharingOnly (New and existing guests)
+  #       Preconditions:
+  #         - Command: Set-PnPTenant
+  #           Splat:
+  #             SharingCapability: ExternalUserSharingOnly
+  #       Postconditions: []
+  #       IsNotChecked: true
+  #       ExpectedResult: false
 
   - PolicyId: MS.SHAREPOINT.3.3v1
     TestDriver: RunScuba


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->
Comments out the MS.SHAREPOINT.3.2v1 functional tests until the issue with toggling settings via the API can be resolved.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->
Should ensure the scheduled automated functional test runs don't regularly fail due to false positives when the SharePoint API does not toggle the test setting appropriately prior to this test.  Long term, pursuing other workarounds and solutions such that these tests can be re-enabled.  For now, manual testing is still possible using these tests.

Closes #1459
 
## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
In order the validate that this improves the running of SharePoint functional tests, run the SharePoint PnP variant plan manually and repeat on as many tenants as necessary to ensure it finishes without error.

Can use ScubaGearCheck.ps1 script to automate run with following command line.  Assumes that you already have service principal setup and have added thumbprint as default for ScubaGearCheck.ps1 you are running by editing the script.

```
ScubaGearCheck.ps1 -baseline sharepoint -Tenant 2 -UserAuth:$false -Variant pnp
```

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] ~*All* future TODOs are captured in issues, which are referenced in code comments.~
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] ~All relevant repo and/or project documentation updated to reflect these changes.~
- [x] ~Unit tests added/updated to cover PowerShell and Rego changes.~
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [x] Resolved all merge conflicts on branch
- [x] Notified merge coordinator that PR is ready for merge via comment mention
- [ ] Demonstrate changes to the team for questions and comments. 
    (Note: Only required for issues of size `Medium` or larger)

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [x] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
