### PR TITLE
Remove reference to removed VersionCheckFile

### DIFF
--- a/PowerShell/ScubaGear/CheckVersion.ps1
+++ b/PowerShell/ScubaGear/CheckVersion.ps1
@@ -16,7 +16,7 @@ function Invoke-CheckScubaGearVersionPSGallery {
     $LatestVersion = [System.Version]$ModuleInfo.Version
 
     if ($CurrentVersion -lt $LatestVersion) {
-        Write-Warning "A new version of ScubaGear ($LatestVersion) is available on PowerShell Gallery. This notification can be disabled by setting `$env:SCUBAGEAR_SKIP_VERSION_CHECK = `$true before running ScubaGear."
+        Write-Warning "A newer version of ScubaGear ($LatestVersion) is available on PowerShell Gallery. This notification can be disabled by setting `$env:SCUBAGEAR_SKIP_VERSION_CHECK = `$true before running ScubaGear."
 
     }
 }

--- a/PowerShell/ScubaGear/CheckVersion.ps1
+++ b/PowerShell/ScubaGear/CheckVersion.ps1
@@ -19,9 +19,6 @@ function Invoke-CheckScubaGearVersionPSGallery {
         Write-Warning "A new version of ScubaGear ($LatestVersion) is available on PowerShell Gallery. This notification can be disabled by setting `$env:SCUBAGEAR_SKIP_VERSION_CHECK = `$true before running ScubaGear."
 
     }
-
-    # Store the current time in the file to mark the last check time
-    (Get-Date -ErrorAction 'Stop').ToString() | Set-Content $VersionCheckFile -ErrorAction 'Stop'
 }
 
 

--- a/PowerShell/ScubaGear/CheckVersion.ps1
+++ b/PowerShell/ScubaGear/CheckVersion.ps1
@@ -24,9 +24,9 @@ function Invoke-CheckScubaGearVersionPSGallery {
 
 function Invoke-CheckScubaGearVersionGithub {
     $ScubaManifest = Import-PowerShellDataFile (Join-Path -Path $PSScriptRoot -ChildPath 'ScubaGear.psd1' -Resolve  -ErrorAction 'Stop' ) -ErrorAction 'Stop'
-    $CurrentVersion = $ScubaManifest.ModuleVersion
-    $LatestVersion = $(Invoke-RestMethod -Uri "https://api.github.com/repos/cisagov/ScubaGear/releases/latest" -ErrorAction 'Stop').tag_name.TrimStart("v")
-    if ($CurrentVersion -ne $LatestVersion) {
+    $CurrentVersion = [System.Version]$ScubaManifest.ModuleVersion
+    $LatestVersion = [System.Version]$(Invoke-RestMethod -Uri "https://api.github.com/repos/cisagov/ScubaGear/releases/latest" -ErrorAction 'Stop').tag_name.TrimStart("v")
+    if ($CurrentVersion -lt $LatestVersion) {
         Write-Warning "A new version of ScubaGear ($latestVersion) is available. Please consider updating at: https://github.com/cisagov/ScubaGear/releases. This notification can be disabled by setting `$env:SCUBAGEAR_SKIP_VERSION_CHECK = `$true before running ScubaGear."
     }
 }

--- a/PowerShell/ScubaGear/CheckVersion.ps1
+++ b/PowerShell/ScubaGear/CheckVersion.ps1
@@ -5,7 +5,7 @@ function Invoke-CheckScubaGearVersion {
 
     # If multiple different versions are installed, get the most recent.
     if ($InstalledModule -is [array]) {
-        $InstalledModule = $InstalledModule | Sort-Object | Select-Object -First 1
+        $InstalledModule = $InstalledModule | Sort-Object -Property Version | Select-Object -Last 1
     }
 
     # Check if no results found.

--- a/PowerShell/ScubaGear/CheckVersion.ps1
+++ b/PowerShell/ScubaGear/CheckVersion.ps1
@@ -5,7 +5,7 @@ function Invoke-CheckScubaGearVersion {
     Complain if a newer version of ScubaGear is available from the Github release page.
 
     .DESCRIPTION
-    Checks latest version available on the github release page and compares it to the current running verison.
+    Checks latest version available on the Github release page and compares it to the current running version.
     #>
     $ScubaManifest = Import-PowerShellDataFile (Join-Path -Path $PSScriptRoot -ChildPath 'ScubaGear.psd1' -Resolve  -ErrorAction 'Stop' ) -ErrorAction 'Stop'
     $CurrentVersion = [System.Version]$ScubaManifest.ModuleVersion

--- a/PowerShell/ScubaGear/CheckVersion.ps1
+++ b/PowerShell/ScubaGear/CheckVersion.ps1
@@ -1,42 +1,5 @@
+
 function Invoke-CheckScubaGearVersion {
-    <#
-    .SYNOPSIS
-    Complain if a newer version of ScubaGear is available on PSGallery.
-
-    .DESCRIPTION
-    Checks PSGallery latest version and compares it to the latest version installed
-    from PSGallery.
-    #>
-
-    # Retrieve the installed version of ScubaGear from the system
-    $InstalledModule = Get-Module -Name ScubaGear -ListAvailable -ErrorAction 'Stop'
-
-    # If multiple different versions are installed, get the most recent.
-    if ($InstalledModule -is [array]) {
-        $InstalledModule = $InstalledModule | Sort-Object -Property Version | Select-Object -Last 1
-    }
-
-    # Check if no results found.
-    if (!$InstalledModule) {
-        # If we are here, ScubaGear is not installed from PSGallery.
-        # Or it may have been installed a different way in a nonstandard folder,
-        # or is running in an extracted release folder. Check github instead.
-        return Invoke-CheckScubaGearVersionGithub -ErrorAction 'Stop'
-    }
-
-    $LatestInstalledVersion = [System.Version]$InstalledModule.Version
-
-    # Retrieve the latest version from PowerShell Gallery
-    $ModuleInfo = Find-Module -Name ScubaGear -ErrorAction 'Stop'
-    $LatestPSGalleryVersion = [System.Version]$ModuleInfo.Version
-
-    if ($LatestInstalledVersion -lt $LatestPSGalleryVersion) {
-        Write-Warning "A newer version of ScubaGear ($LatestPSGalleryVersion) is available on PowerShell Gallery. This notification can be disabled by setting `$env:SCUBAGEAR_SKIP_VERSION_CHECK = `$true before running ScubaGear."
-    }
-}
-
-
-function Invoke-CheckScubaGearVersionGithub {
     <#
     .SYNOPSIS
     Complain if a newer version of ScubaGear is available from the Github release page.

--- a/PowerShell/ScubaGear/CheckVersion.ps1
+++ b/PowerShell/ScubaGear/CheckVersion.ps1
@@ -11,7 +11,7 @@ function Invoke-CheckScubaGearVersion {
     $CurrentVersion = [System.Version]$ScubaManifest.ModuleVersion
     $LatestVersion = [System.Version]$(Invoke-RestMethod -Uri "https://api.github.com/repos/cisagov/ScubaGear/releases/latest" -ErrorAction 'Stop').tag_name.TrimStart("v")
     if ($CurrentVersion -lt $LatestVersion) {
-        Write-Warning "A new version of ScubaGear ($latestVersion) is available. Please consider updating at: https://github.com/cisagov/ScubaGear/releases. This notification can be disabled by setting `$env:SCUBAGEAR_SKIP_VERSION_CHECK = `$true before running ScubaGear."
+        Write-Warning "A newer version of ScubaGear ($latestVersion) is available. Please consider updating at: https://github.com/cisagov/ScubaGear/releases. This notification can be disabled by setting `$env:SCUBAGEAR_SKIP_VERSION_CHECK = `$true before running ScubaGear."
     }
 }
 

--- a/PowerShell/ScubaGear/CheckVersion.ps1
+++ b/PowerShell/ScubaGear/CheckVersion.ps1
@@ -1,4 +1,12 @@
 function Invoke-CheckScubaGearVersion {
+    <#
+    .SYNOPSIS
+    Complain if a newer version of ScubaGear is available on PSGallery.
+
+    .DESCRIPTION
+    Checks PSGallery latest version and compares it to the latest version installed
+    from PSGallery.
+    #>
 
     # Retrieve the installed version of ScubaGear from the system
     $InstalledModule = Get-Module -Name ScubaGear -ListAvailable -ErrorAction 'Stop'
@@ -29,6 +37,13 @@ function Invoke-CheckScubaGearVersion {
 
 
 function Invoke-CheckScubaGearVersionGithub {
+    <#
+    .SYNOPSIS
+    Complain if a newer version of ScubaGear is available from the Github release page.
+
+    .DESCRIPTION
+    Checks latest version available on the github release page and compares it to the current running verison.
+    #>
     $ScubaManifest = Import-PowerShellDataFile (Join-Path -Path $PSScriptRoot -ChildPath 'ScubaGear.psd1' -Resolve  -ErrorAction 'Stop' ) -ErrorAction 'Stop'
     $CurrentVersion = [System.Version]$ScubaManifest.ModuleVersion
     $LatestVersion = [System.Version]$(Invoke-RestMethod -Uri "https://api.github.com/repos/cisagov/ScubaGear/releases/latest" -ErrorAction 'Stop').tag_name.TrimStart("v")


### PR DESCRIPTION
# Fix Version Check Path Bug #
The version check code has a reference to a removed variable still present. This PR deletes it and closes #1480 

## 🗣 Description ##

Deleted two lines of code writing out the version check file, which was removed for Kraken.

## 💭 Motivation and context ##

Currently this bug causes a error and stack trace on import.
Closes #1480 

## 🧪 Testing ##

```
# Download 1.3
Invoke-WebRequest -Uri "https://github.com/cisagov/ScubaGear/releases/download/v1.3.0/ScubaGear-1.3.0.zip" -Outfile scuba-1.3.0.zip
Expand-Archive -Path "scuba-1.3.0.zip" -DestinationPath "scuba-1.3.0"

# Copy the check versions script over.
Copy-Item -Path "{path to git checkout}\Powershell\ScubaGear\CheckVersion.ps1" -Destination "scuba-1.3.0\Powershell\ScubaGear\CheckVersion.ps1"

# Finally, open Powershell\ScubaGear\ScubaGear.psd1 and add the CheckVersion.ps1 script to the ScriptsToProcess array. 

# Import scuba and view the warning.
Import-Module "scuba-1.3.0\Powershell\ScubaGear\CheckVersion.ps1"
```
Alternatively, you can just decrement the ModuleVersion in the scuba manifest and import from the git branch to view the warning.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [x] Resolved all merge conflicts on branch
- [x] Notified merge coordinator that PR is ready for merge via comment mention
- [x] Demonstrate changes to the team for questions and comments. 
    (Note: Only required for issues of size `Medium` or larger)

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [x] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
