### PR TITLE
Test the output of ScubaGear's basic commands

### DIFF
--- a/.github/workflows/publish_private_package.yaml
+++ b/.github/workflows/publish_private_package.yaml
@@ -14,6 +14,7 @@ on:
         required: true
       KeyVaultInfo:
         required: true
+  workflow_dispatch:
 
 permissions:
   id-token: write
@@ -96,7 +97,10 @@ jobs:
           Invoke-Pester -Configuration $Config
       - name: Initialize ScubaGear
         run: |
+          Write-Output "Preparing to install..."
           Install-Module -Name ScubaGear -Repository $env:GalleryName -SkipPublisherCheck
+          Write-Output "Finished installing..."
+          # Source the function
           . repo/utils/workflow/Initialize-ScubaGearForTesting.ps1
           Initialize-ScubaGearForTesting
           # This is a manual test that simply writes the version to the console.

--- a/.github/workflows/publish_private_package.yaml
+++ b/.github/workflows/publish_private_package.yaml
@@ -101,16 +101,13 @@ jobs:
           Invoke-Pester -Configuration $Config
       - name: Initialize ScubaGear
         run: |
-          # Name and description are two of the expected output values that result from
-          # installing the module.  These checks are intended to help verify that the module
-          # installed correctly.
+          # This step initializes SG and runs some checks to verify that it installed correctly.
           $ExpectedName = 'ScubaGear'
           # Read the description value from the manifest file (ScubaGear.psd1)
           $ManifestFilePath = Join-Path -Path repo/PowerShell/ScubaGear -ChildPath 'ScubaGear.psd1' -Resolve
           $Manifest = Import-PowerShellDataFile $ManifestFilePath
           $ExpectedDescription = $Manifest.Description
-          # The -PassThru paramaters allows us to read the output
-          # value from Install-Module
+          # The -PassThru parameters allows us to read the output value from Install-Module
           $InstallOutput = Install-Module -Name ScubaGear -Repository $env:GalleryName -SkipPublisherCheck -PassThru
           # Check for the expected name.
           if ($InstallOutput.Name -ne $ExpectedName) {
@@ -126,11 +123,9 @@ jobs:
             Write-Output "::error::The description of the published module should be $ExpectedDescription"
             exit 1
           }
-          # Source the function
           . repo/utils/workflow/Initialize-ScubaGearForTesting.ps1
           Initialize-ScubaGearForTesting
-          # This is the expected output value that results from running the module.
-          # This check is intended to help verify that ScubaGear installed correctly.
+          # Check for expected version.
           $VersionOutput = Invoke-SCuBA -Version
           $ExpectedVersion = "SCuBA Gear v${{ steps.sign-publish-module.outputs.ModuleVersion }}"
           if ($VersionOutput -ne $ExpectedVersion) {

--- a/.github/workflows/publish_private_package.yaml
+++ b/.github/workflows/publish_private_package.yaml
@@ -14,7 +14,6 @@ on:
         required: true
       KeyVaultInfo:
         required: true
-  workflow_dispatch:
 
 permissions:
   id-token: write
@@ -55,6 +54,8 @@ jobs:
         id: key-vault-info
         env:
           KEY_VAULT_INFO: ${{ secrets.KeyVaultInfo }}
+        # Do not attempt to access the Key Vault if logging into Azure failed.
+        if: ${{ success() }}
         run: |
           $KeyVaultInfo = ${env:KEY_VAULT_INFO} | ConvertFrom-Json
           echo "KeyVaultUrl=$($KeyVaultInfo.KeyVault.URL)" >> $env:GITHUB_OUTPUT
@@ -65,6 +66,7 @@ jobs:
           cd repo
           New-PrivateGallery -GalleryName $env:GalleryName -Trusted
       - name: Sign and Publish Module
+        id: sign-publish-module
         run: |
             . repo/utils/workflow/Publish-ScubaGear.ps1
             # Remove non-release files
@@ -79,7 +81,9 @@ jobs:
             # This publishes to a private gallery, from which we will pull in a future step.
             # This step helps us verify that ScubaGear is in a state where it can be
             # published to PSGallery.
-            Publish-ScubaGearModule @Parameters
+            $ModuleVersion = Publish-ScubaGearModule @Parameters
+            Write-Output "The module version is $ModuleVersion"
+            echo "ModuleVersion=$ModuleVersion" >> $env:GITHUB_OUTPUT
       - name: Test Module Publish
         run: |
           Get-Location
@@ -97,15 +101,42 @@ jobs:
           Invoke-Pester -Configuration $Config
       - name: Initialize ScubaGear
         run: |
-          Write-Output "Preparing to install..."
-          Install-Module -Name ScubaGear -Repository $env:GalleryName -SkipPublisherCheck
-          Write-Output "Finished installing..."
+          # Name and description are two of the expected output values that result from
+          # installing the module.  These checks are intended to help verify that the module
+          # installed correctly.
+          $ExpectedName = 'ScubaGear'
+          # Read the description value from the manifest file (ScubaGear.psd1)
+          $ManifestFilePath = Join-Path -Path repo/PowerShell/ScubaGear -ChildPath 'ScubaGear.psd1' -Resolve
+          $Manifest = Import-PowerShellDataFile $ManifestFilePath
+          $ExpectedDescription = $Manifest.Description
+          # The -PassThru paramaters allows us to read the output
+          # value from Install-Module
+          $InstallOutput = Install-Module -Name ScubaGear -Repository $env:GalleryName -SkipPublisherCheck -PassThru
+          # Check for the expected name.
+          if ($InstallOutput.Name -ne $ExpectedName) {
+            Write-Output "::error::The name of the published module should be $ExpectedName"
+            exit 1
+          }
+          # Because reasons, the description has a newline character.
+          # Strip all whitespace before comparing the descriptions.
+          $DescriptionFixed = $InstallOutput.Description -replace "\s", ""
+          $ExpectedFixed = $ExpectedDescription -replace "\s", ""
+          # Check for the expected description.
+          if ($DescriptionFixed -ne $ExpectedFixed) {
+            Write-Output "::error::The description of the published module should be $ExpectedDescription"
+            exit 1
+          }
           # Source the function
           . repo/utils/workflow/Initialize-ScubaGearForTesting.ps1
           Initialize-ScubaGearForTesting
-          # This is a manual test that simply writes the version to the console.
-          Invoke-SCuBA -Version
-          Test-Path -Path "C:\Program Files\WindowsPowerShell\Modules\ScubaGear"
+          # This is the expected output value that results from running the module.
+          # This check is intended to help verify that ScubaGear installed correctly.
+          $VersionOutput = Invoke-SCuBA -Version
+          $ExpectedVersion = "SCuBA Gear v${{ steps.sign-publish-module.outputs.ModuleVersion }}"
+          if ($VersionOutput -ne $ExpectedVersion) {
+            Write-Output "::error::The version of the published module should be $ExpectedVersion"
+            exit 1
+          }
       - name: Install Selenium
         run: |
           . repo/utils/workflow/Install-SeleniumForTesting.ps1

--- a/PowerShell/ScubaGear/Modules/Support/Support.psm1
+++ b/PowerShell/ScubaGear/Modules/Support/Support.psm1
@@ -122,7 +122,6 @@ function Initialize-SCuBA {
 
     if ($DoNotAutoTrustRepository) {
         $RepositoryDetails = Get-PSRepository -Name "PSGallery"
-        Get-PSRepository -Name "PSGallery"
         Write-Output "PSGallery is $($RepositoryDetails.Trusted)."
     }
     else {

--- a/Testing/workflow/Initialize-ScubaGearForTesting.Tests.ps1
+++ b/Testing/workflow/Initialize-ScubaGearForTesting.Tests.ps1
@@ -14,7 +14,9 @@ BeforeDiscovery {
   $global:DownloadedOPAVersion = $false
   $global:SetupTime = $false
   $global:SetupTimeValue = 0
-  # Loop over the various outputs in the output array, looking for strings.
+  # Loop over the various outputs in the PowerShell pipeline, looking for outputs
+  # that start with these exact strings.  For more info:
+  # https://www.scriptrunner.com/en/blog/pipeline-ready-advanced-powershell
   foreach ($Output in $Outputs) {
     if ($Output.GetType().Name -eq "String") {
       Write-Warning $Output

--- a/Testing/workflow/Initialize-ScubaGearForTesting.Tests.ps1
+++ b/Testing/workflow/Initialize-ScubaGearForTesting.Tests.ps1
@@ -1,5 +1,4 @@
-# The purpose of this test is to verify that the required
-# PS modules were installed.
+# The purpose of this test is to verify that the required PS modules were installed.
 
 # Suppress PSSA warnings here at the root of the test file.
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', '')]
@@ -9,11 +8,32 @@ BeforeDiscovery {
   # Source the function
   . $PSScriptRoot/../../utils/workflow/Initialize-ScubaGearForTesting.ps1
   # Initialize SG
-  Initialize-ScubaGearForTesting
+  $Outputs = Initialize-ScubaGearForTesting
+  # Whitelist the outputs that we are interested in finding
+  $global:PSGallery = $false
+  $global:DownloadedOPAVersion = $false
+  $global:SetupTime = $false
+  $global:SetupTimeValue = 0
+  # Loop over the various outputs in the output array, looking for strings.
+  foreach ($Output in $Outputs) {
+    if ($Output.GetType().Name -eq "String") {
+      Write-Warning $Output
+      if ($Output.StartsWith("PSGallery is trusted")) {
+        $global:PSGallery = $true
+      }
+      elseif ($Output.StartsWith("Downloaded OPA version")) {
+        $global:DownloadedOPAVersion = $true
+      }
+      elseif ($Output.StartsWith("ScubaGear setup time elapsed")) {
+        $global:SetupTime = $true
+        $global:SetupTimeValue = [int]$Output.split(":")[1].Trim()
+      }
+    }
+  }
 }
 
 # Use Write-Warning b/c other writes don't actually write
-Write-Warning 'Getting required modules...'
+Write-Warning "Getting required modules..."
 try {
   . PowerShell\ScubaGear\RequiredVersions.ps1
 }
@@ -21,18 +41,31 @@ catch {
   throw "Unable to find RequiredVersions.ps1"
 }
 if ($ModuleList) {
-  Write-Warning 'Found list of modules!'
+  Write-Warning "Found list of modules!"
 }
 else {
   Write-Warning 'Did NOT find list of modules!!'
 }
 
-Describe "PowerShell Modules Check" {
+Describe "Initialize-ScubaGear Modules Check" {
   foreach ($Module in $ModuleList) {
     $global:ModuleName = $Module.ModuleName
     It "Module $global:moduleName should be installed" {
       $module = Get-Module -ListAvailable -Name $global:ModuleName
       $module | Should -Not -BeNullOrEmpty
     }
+  }
+}
+
+Describe "Initialize-ScubaGear Output Check" {
+  It "PSGallery should be trusted" {
+    $global:PSGallery | Should -Be $true
+  }
+  It "OPA should be downloaded" {
+    $global:DownloadedOPAVersion | Should -Be $true
+  }
+  It "Setup time should be minimal" {
+    $global:SetupTime | Should -Be $true
+    $global:SetupTimeValue | Should -BeLessThan 1000
   }
 }

--- a/Testing/workflow/Initialize-ScubaGearForTesting.Tests.ps1
+++ b/Testing/workflow/Initialize-ScubaGearForTesting.Tests.ps1
@@ -14,6 +14,7 @@ BeforeDiscovery {
   $global:DownloadedOPAVersion = $false
   $global:SetupTime = $false
   $global:SetupTimeValue = 0
+  $global:SetupTimeThreshold = 1000 # The max time it should take to initialize SG
   # Loop over the various outputs in the PowerShell pipeline, looking for outputs
   # that start with these exact strings.  For more info:
   # https://www.scriptrunner.com/en/blog/pipeline-ready-advanced-powershell
@@ -68,6 +69,6 @@ Describe "Initialize-ScubaGear Output Check" {
   }
   It "Setup time should be minimal" {
     $global:SetupTime | Should -Be $true
-    $global:SetupTimeValue | Should -BeLessThan 1000
+    $global:SetupTimeValue | Should -BeLessThan $global:SetupTimeThreshold
   }
 }

--- a/utils/workflow/Initialize-ScubaGearForTesting.ps1
+++ b/utils/workflow/Initialize-ScubaGearForTesting.ps1
@@ -4,12 +4,9 @@ function Initialize-ScubaGearForTesting {
       Initializes ScubaGear, which installs the necessary modules and tools to run ScubaGear.
   #>
 
-  Write-Output 'Initializing ScubaGear for testing...'
   $RepoRootPath = Join-Path -Path $PSScriptRoot -ChildPath '..\..' -Resolve
-  Write-Output 'The repo root path is'
-  Write-Output $RepoRootPath
-  Write-Output 'Importing function Initialize-Scuba...'
   Import-Module (Join-Path -Path $RepoRootPath -ChildPath 'PowerShell/ScubaGear') -Function Initialize-Scuba
-  Write-Output 'Calling Initialize ScubaGear...'
-  Initialize-SCuBA
+  Write-Debug 'Calling Initialize ScubaGear...'
+  $Outputs = Initialize-SCuBA
+  return $Outputs
 }

--- a/utils/workflow/Publish-ScubaGear.ps1
+++ b/utils/workflow/Publish-ScubaGear.ps1
@@ -130,10 +130,15 @@ function Publish-ScubaGearModule {
     # The parens and [-1] are designed to suppress everything but the module version number.
     # Yes, this is a kludge, but PowerShell doesn't have a graceful way of handling this.
     Write-Warning "Editing the manifest file..."
+    # $ModuleVersion = (Edit-ManifestFile `
+    # -ModuleDestinationPath $ModuleDestinationPath `
+    # -OverrideModuleVersion $OverrideModuleVersion `
+    # -PrereleaseTag $PrereleaseTag)[-1]
+
     $ModuleVersion = (Edit-ManifestFile `
     -ModuleDestinationPath $ModuleDestinationPath `
     -OverrideModuleVersion $OverrideModuleVersion `
-    -PrereleaseTag $PrereleaseTag)[-1]
+    -PrereleaseTag $PrereleaseTag) | Select-Object -Last 1
 
     Write-Warning "Creating an array of the files to sign..."
     $ArrayOfFilePaths = New-ArrayOfFilePaths `

--- a/utils/workflow/Publish-ScubaGear.ps1
+++ b/utils/workflow/Publish-ScubaGear.ps1
@@ -127,14 +127,9 @@ function Publish-ScubaGearModule {
 
     # Somewhere in the Edit-ManifestFile method something is adding implicit expression output.
     # The only output that I want from this method is the module version number.
-    # The parens and [-1] are designed to suppress everything but the module version number.
+    # The Select-Object -Last 1 is designed to suppress everything but the module version number.
     # Yes, this is a kludge, but PowerShell doesn't have a graceful way of handling this.
     Write-Warning "Editing the manifest file..."
-    # $ModuleVersion = (Edit-ManifestFile `
-    # -ModuleDestinationPath $ModuleDestinationPath `
-    # -OverrideModuleVersion $OverrideModuleVersion `
-    # -PrereleaseTag $PrereleaseTag)[-1]
-
     $ModuleVersion = (Edit-ManifestFile `
     -ModuleDestinationPath $ModuleDestinationPath `
     -OverrideModuleVersion $OverrideModuleVersion `


### PR DESCRIPTION
## 🗣 Description ##

Added tests for checking the textual outputs that result from running ScubaGear's most basic commands:

```
Install-Module -Name ScubaGear
Initialize-SCuBA = check for outputs
Invoke-SCuBA -Version
```

The idea is to add additional checks to make sure SG is running as expected.

## 💭 Motivation and context ##

Closes #1490 

## 🧪 Testing ##

The tests for Initialize-Scuba can be found by running the workflow pipeline and checking under Workflow Units Tests for the Pester Test called "Describing Initialize-ScubaGear Output Check." There should be 3 successful tests:

- PSGallery should be trusted
- OPA should be downloaded
- Setup time should be minimal

The tests for Install-Module can be found by running the nightly functional tests (test_production_function.yaml), finding the first job (publish package/private repo), and checking under Initialize ScubaGear.   There should not be any errors that start with:

- The name of the published module should be....
- The description of the published module should be...
- The version of the published module should be...

These would create annotation errors, so they should be easy to see.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*

I did do some extra cleaning up while wandering around, like fixing input parameter for function help comments, removing random newlines, and setting better outputing.

- [x] Changes are sized such that they do not touch excessive number of files.
- [x] These code changes follow the ScubaGear [content style guide]
- [x] Related issues these changes resolve are linked preferably via [closing keywords]
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [x] Resolved all merge conflicts on branch
- [x] Notified merge coordinator that PR is ready for merge via comment mention
- [ ] Demonstrate changes to the team for questions and comments. 
    (Note: Only required for issues of size `Medium` or larger)

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [x] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
