### PR TITLE
Save omitted rego evaulation results

### DIFF
--- a/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
+++ b/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
@@ -170,7 +170,7 @@ function New-Report {
 
             if ($null -ne $Test){
                 $MissingCommands = $Test.Commandlet | Where-Object {$SettingsExport."$($BaselineName)_successful_commands" -notcontains $_}
-                $Result = Get-TestResult $Test $MissingCommands
+                $Result = Get-TestResult $Test $MissingCommands $Control
 
                 # Check if the config file indicates the control should be omitted
                 $Config = $SettingsExport.scuba_config
@@ -205,6 +205,8 @@ function New-Report {
                     "Result"= $Result.DisplayString
                     "Criticality"=if ($Control.Deleted -or $Control.MalformedDescription) {"-"} else {$Test.Criticality}
                     "Details"= $Result.Details
+                    "OmittedEvaluationResult"="N/A"
+                    "OmittedEvaluationDetails"="N/A"
                 }
             }
             else {
@@ -216,6 +218,8 @@ function New-Report {
                     "Result"= "Error - Test results missing"
                     "Criticality"= "-"
                     "Details"= "Report issue on <a href=`"$ScubaGitHubUrl/issues`" target=`"_blank`">GitHub</a>"
+                    "OmittedEvaluationResult"="N/A"
+                    "OmittedEvaluationDetails"="N/A"
                 }
                 Write-Warning -Message "WARNING: No test results found for Control Id $($Control.Id)"
             }
@@ -228,6 +232,8 @@ function New-Report {
         $GroupAnchor = New-MarkdownAnchor -GroupNumber $BaselineGroup.GroupNumber -GroupName $BaselineGroup.GroupName
         $GroupReferenceURL = "$($ScubaGitHubUrl)/blob/v$($SettingsExport.module_version)/PowerShell/ScubaGear/baselines/$($BaselineName.ToLower()).md$GroupAnchor"
         $MarkdownLink = "<a class='control_group' href=`"$($GroupReferenceURL)`" target=`"_blank`">$Name</a>"
+        # Create a version of the object without the omitted evaluation keys, otherwise they
+        # would show up as columns on the HTML report.
         $FragmentWithoutOmitted = $Fragment | ForEach-Object -Process {[pscustomobject]@{
             "Control ID" = $_."Control ID";
             "Requirement" = $_."Requirement";

--- a/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
+++ b/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
@@ -1,6 +1,6 @@
 Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath "..\Utility")
 
-function Get-TestResult {
+function Get-RegoResult {
      <#
     .Description
     Given the Rego output for a specific test, determine the result (e.g. "Pass"/"Fail").
@@ -170,7 +170,7 @@ function New-Report {
 
             if ($null -ne $Test){
                 $MissingCommands = $Test.Commandlet | Where-Object {$SettingsExport."$($BaselineName)_successful_commands" -notcontains $_}
-                $Result = Get-TestResult $Test $MissingCommands $Control
+                $Result = Get-RegoResult $Test $MissingCommands $Control
 
                 # Check if the config file indicates the control should be omitted
                 $Config = $SettingsExport.scuba_config

--- a/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
+++ b/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
@@ -1,7 +1,7 @@
 Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath "..\Utility")
 
 function Get-RegoResult {
-     <#
+    <#
     .Description
     Given the Rego output for a specific test, determine the result (e.g. "Pass"/"Fail").
     .Functionality

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/CreateReport/Get-RegoResult.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/CreateReport/Get-RegoResult.Tests.ps1
@@ -1,8 +1,8 @@
 Import-Module (Join-Path -Path $PSScriptRoot -ChildPath '../../../../Modules/CreateReport') `
-    -Function 'Get-TestResult' -Force
+    -Function 'Get-RegoResult' -Force
 
 InModuleScope CreateReport {
-    Describe -Tag CreateReport -Name 'Get-TestResult' {
+    Describe -Tag CreateReport -Name 'Get-RegoResult' {
         Context "When the control is valid" {
             BeforeAll {
                 # PS Script Analyzer doesn't play well with Pester scoping and can't tell that
@@ -23,7 +23,7 @@ InModuleScope CreateReport {
                     }
                     $MissingCommands = $null
                     $Control = $NormalControl
-                    $Result = Get-TestResult $Test $MissingCommands $Control
+                    $Result = Get-RegoResult $Test $MissingCommands $Control
                     $Result.DisplayString | Should -Be "Pass"
                     $Result.SummaryKey | Should -Be "Passes"
                     $Result.Details | Should -Be $ExampleReportDetails
@@ -36,7 +36,7 @@ InModuleScope CreateReport {
                     }
                     $MissingCommands = $null
                     $Control = $NormalControl
-                    $Result = Get-TestResult $Test $MissingCommands $Control
+                    $Result = Get-RegoResult $Test $MissingCommands $Control
                     $Result.DisplayString | Should -Be "Pass"
                     $Result.SummaryKey | Should -Be "Passes"
                     $Result.Details | Should -Be $ExampleReportDetails
@@ -49,7 +49,7 @@ InModuleScope CreateReport {
                     }
                     $MissingCommands = $null
                     $Control = $NormalControl
-                    $Result = Get-TestResult $Test $MissingCommands $Control
+                    $Result = Get-RegoResult $Test $MissingCommands $Control
                     $Result.DisplayString | Should -Be "Fail"
                     $Result.SummaryKey | Should -Be "Failures"
                     $Result.Details | Should -Be $ExampleReportDetails
@@ -62,7 +62,7 @@ InModuleScope CreateReport {
                     }
                     $MissingCommands = $null
                     $Control = $NormalControl
-                    $Result = Get-TestResult $Test $MissingCommands $Control
+                    $Result = Get-RegoResult $Test $MissingCommands $Control
                     $Result.DisplayString | Should -Be "Warning"
                     $Result.SummaryKey | Should -Be "Warnings"
                     $Result.Details | Should -Be $ExampleReportDetails
@@ -77,7 +77,7 @@ InModuleScope CreateReport {
                     }
                     $MissingCommands = $null
                     $Control = $NormalControl
-                    $Result = Get-TestResult $Test $MissingCommands $Control
+                    $Result = Get-RegoResult $Test $MissingCommands $Control
                     $Result.DisplayString | Should -Be "N/A"
                     $Result.SummaryKey | Should -Be "Manual"
                     $Result.Details | Should -Be $ExampleReportDetails
@@ -90,7 +90,7 @@ InModuleScope CreateReport {
                     }
                     $MissingCommands = $null
                     $Control = $NormalControl
-                    $Result = Get-TestResult $Test $MissingCommands $Control
+                    $Result = Get-RegoResult $Test $MissingCommands $Control
                     $Result.DisplayString | Should -Be "N/A"
                     $Result.SummaryKey | Should -Be "Manual"
                     $Result.Details | Should -Be $ExampleReportDetails
@@ -103,7 +103,7 @@ InModuleScope CreateReport {
                     }
                     $MissingCommands = $null
                     $Control = $NormalControl
-                    $Result = Get-TestResult $Test $MissingCommands $Control
+                    $Result = Get-RegoResult $Test $MissingCommands $Control
                     $Result.DisplayString | Should -Be "N/A"
                     $Result.SummaryKey | Should -Be "Manual"
                     $Result.Details | Should -Be $ExampleReportDetails
@@ -116,7 +116,7 @@ InModuleScope CreateReport {
                     }
                     $MissingCommands = $null
                     $Control = $NormalControl
-                    $Result = Get-TestResult $Test $MissingCommands $Control
+                    $Result = Get-RegoResult $Test $MissingCommands $Control
                     $Result.DisplayString | Should -Be "N/A"
                     $Result.SummaryKey | Should -Be "Manual"
                     $Result.Details | Should -Be $ExampleReportDetails
@@ -143,7 +143,7 @@ InModuleScope CreateReport {
                     MalformedDescription=$false;
                     Deleted=$false;
                 }
-                $Result = Get-TestResult $Test $MissingCommands $Control
+                $Result = Get-RegoResult $Test $MissingCommands $Control
                 $Result.DisplayString | Should -Be "Error"
                 $Result.SummaryKey | Should -Be "Errors"
                 $Result.Details | Should -Be $ExampleMissingDetails
@@ -159,7 +159,7 @@ InModuleScope CreateReport {
                     MalformedDescription=$false;
                     Deleted=$false;
                 }
-                $Result = Get-TestResult $Test $MissingCommands $Control
+                $Result = Get-RegoResult $Test $MissingCommands $Control
                 $Result.DisplayString | Should -Be "Error"
                 $Result.SummaryKey | Should -Be "Errors"
                 $Result.Details | Should -Be $ExampleMissingDetails
@@ -175,7 +175,7 @@ InModuleScope CreateReport {
                     MalformedDescription=$false;
                     Deleted=$true;
                 }
-                $Result = Get-TestResult $Test $MissingCommands $Control
+                $Result = Get-RegoResult $Test $MissingCommands $Control
                 $Result.DisplayString | Should -Be "-"
                 $Result.SummaryKey | Should -Be "-"
                 $Result.Details | Should -Be "-"
@@ -191,7 +191,7 @@ InModuleScope CreateReport {
                     MalformedDescription=$true;
                     Deleted=$true;
                 }
-                $Result = Get-TestResult $Test $MissingCommands $Control
+                $Result = Get-RegoResult $Test $MissingCommands $Control
                 $Result.DisplayString | Should -Be "Error"
                 $Result.SummaryKey | Should -Be "Errors"
                 $Result.Details | Should -Be "Report issue on <a href=`"$ScubaGitHubUrl/issues`" target=`"_blank`">GitHub</a>"

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/CreateReport/Get-TestResult.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/CreateReport/Get-TestResult.Tests.ps1
@@ -1,0 +1,204 @@
+Import-Module (Join-Path -Path $PSScriptRoot -ChildPath '../../../../Modules/CreateReport')
+
+InModuleScope CreateReport {
+    Describe -Tag CreateReport -Name 'Get-TestResult' {
+        Context "When the control is valid" {
+            BeforeAll {
+                # PS Script Analyzer doesn't play well with Pester scoping and can't tell that
+                # these variables *are* used. Using the script scope is the suggested workaround.
+                # See https://github.com/PowerShell/PSScriptAnalyzer/issues/946.
+                $script:ExampleReportDetails = "Example details"
+                $script:NormalControl = [PSCustomObject]@{
+                    MalformedDescription=$false;
+                    Deleted=$false;
+                }
+            }
+            Context "When the control is implemented" {
+                It 'Returns pass if the test passed for SHALLs' {
+                    $Test = [PSCustomObject]@{
+                        RequirementMet=$true;
+                        Criticality="Shall";
+                        ReportDetails=$ExampleReportDetails;
+                    }
+                    $MissingCommands = $null
+                    $Control = $NormalControl
+                    $Result = Get-TestResult $Test $MissingCommands $Control
+                    $Result.DisplayString | Should -Be "Pass"
+                    $Result.SummaryKey | Should -Be "Passes"
+                    $Result.Details | Should -Be $ExampleReportDetails
+                }
+                It 'Returns pass if the test passed for SHOULDs' {
+                    $Test = [PSCustomObject]@{
+                        RequirementMet=$true;
+                        Criticality="Should";
+                        ReportDetails=$ExampleReportDetails;
+                    }
+                    $MissingCommands = $null
+                    $Control = $NormalControl
+                    $Result = Get-TestResult $Test $MissingCommands $Control
+                    $Result.DisplayString | Should -Be "Pass"
+                    $Result.SummaryKey | Should -Be "Passes"
+                    $Result.Details | Should -Be $ExampleReportDetails
+                }
+                It 'Returns fail for failed SHALLs' {
+                    $Test = [PSCustomObject]@{
+                        RequirementMet=$false;
+                        Criticality="Shall";
+                        ReportDetails=$ExampleReportDetails;
+                    }
+                    $MissingCommands = $null
+                    $Control = $NormalControl
+                    $Result = Get-TestResult $Test $MissingCommands $Control
+                    $Result.DisplayString | Should -Be "Fail"
+                    $Result.SummaryKey | Should -Be "Failures"
+                    $Result.Details | Should -Be $ExampleReportDetails
+                }
+                It 'Returns warning for failed SHOULDs' {
+                    $Test = [PSCustomObject]@{
+                        RequirementMet=$false;
+                        Criticality="Should";
+                        ReportDetails=$ExampleReportDetails;
+                    }
+                    $MissingCommands = $null
+                    $Control = $NormalControl
+                    $Result = Get-TestResult $Test $MissingCommands $Control
+                    $Result.DisplayString | Should -Be "Warning"
+                    $Result.SummaryKey | Should -Be "Warnings"
+                    $Result.Details | Should -Be $ExampleReportDetails
+                }
+            }
+            Context "When the control is not implemented" {
+                It 'Returns N/A for not implemented SHALLs' {
+                    $Test = [PSCustomObject]@{
+                        RequirementMet=$false;
+                        Criticality="Shall/Not-Implemented";
+                        ReportDetails=$ExampleReportDetails;
+                    }
+                    $MissingCommands = $null
+                    $Control = $NormalControl
+                    $Result = Get-TestResult $Test $MissingCommands $Control
+                    $Result.DisplayString | Should -Be "N/A"
+                    $Result.SummaryKey | Should -Be "Manual"
+                    $Result.Details | Should -Be $ExampleReportDetails
+                }
+                It 'Returns N/A for not implemented SHOULDs' {
+                    $Test = [PSCustomObject]@{
+                        RequirementMet=$false;
+                        Criticality="Should/Not-Implemented";
+                        ReportDetails=$ExampleReportDetails;
+                    }
+                    $MissingCommands = $null
+                    $Control = $NormalControl
+                    $Result = Get-TestResult $Test $MissingCommands $Control
+                    $Result.DisplayString | Should -Be "N/A"
+                    $Result.SummaryKey | Should -Be "Manual"
+                    $Result.Details | Should -Be $ExampleReportDetails
+                }
+                It 'Returns N/A for third-party SHALLs' {
+                    $Test = [PSCustomObject]@{
+                        RequirementMet=$false;
+                        Criticality="Shall/3rd Party";
+                        ReportDetails=$ExampleReportDetails;
+                    }
+                    $MissingCommands = $null
+                    $Control = $NormalControl
+                    $Result = Get-TestResult $Test $MissingCommands $Control
+                    $Result.DisplayString | Should -Be "N/A"
+                    $Result.SummaryKey | Should -Be "Manual"
+                    $Result.Details | Should -Be $ExampleReportDetails
+                }
+                It 'Returns N/A for third-party SHOULDs' {
+                    $Test = [PSCustomObject]@{
+                        RequirementMet=$false;
+                        Criticality="Should/3rd Party";
+                        ReportDetails=$ExampleReportDetails;
+                    }
+                    $MissingCommands = $null
+                    $Control = $NormalControl
+                    $Result = Get-TestResult $Test $MissingCommands $Control
+                    $Result.DisplayString | Should -Be "N/A"
+                    $Result.SummaryKey | Should -Be "Manual"
+                    $Result.Details | Should -Be $ExampleReportDetails
+                }
+            }
+        }
+
+        Context "When the control/test has errors" {
+            BeforeAll {
+                $script:ScubaGitHubUrl = "https://github.com/cisagov/ScubaGear"
+                $script:ExampleMissingCommand1 = "Get-Example1"
+                $script:ExampleMissingCommand2 = "Get-Example2"
+                $script:ExampleMissingDetails = @("This test depends on the following command(s) which did not execute ",
+                    "successfully: Get-Example1, Get-Example2. See terminal output for more details.") -Join ""
+            }
+            It 'When the test has missing commands and passed' {
+                $Test = [PSCustomObject]@{
+                    RequirementMet=$true;
+                    Criticality="Should";
+                    ReportDetails=$ExampleReportDetails;
+                }
+                $MissingCommands = @($ExampleMissingCommand1, $ExampleMissingCommand2)
+                $Control = [PSCustomObject]@{
+                    MalformedDescription=$false;
+                    Deleted=$false;
+                }
+                $Result = Get-TestResult $Test $MissingCommands $Control
+                $Result.DisplayString | Should -Be "Error"
+                $Result.SummaryKey | Should -Be "Errors"
+                $Result.Details | Should -Be $ExampleMissingDetails
+            }
+            It 'When the test has missing commands and failed' {
+                $Test = [PSCustomObject]@{
+                    RequirementMet=$true;
+                    Criticality="Should";
+                    ReportDetails=$ExampleReportDetails;
+                }
+                $MissingCommands = @($ExampleMissingCommand1, $ExampleMissingCommand2)
+                $Control = [PSCustomObject]@{
+                    MalformedDescription=$false;
+                    Deleted=$false;
+                }
+                $Result = Get-TestResult $Test $MissingCommands $Control
+                $Result.DisplayString | Should -Be "Error"
+                $Result.SummaryKey | Should -Be "Errors"
+                $Result.Details | Should -Be $ExampleMissingDetails
+            }
+            It 'When the control has been deleted' {
+                $Test = [PSCustomObject]@{
+                    RequirementMet=$true;
+                    Criticality="Should";
+                    ReportDetails=$ExampleReportDetails;
+                }
+                $MissingCommands = @($ExampleMissingCommand1, $ExampleMissingCommand2)
+                $Control = [PSCustomObject]@{
+                    MalformedDescription=$false;
+                    Deleted=$true;
+                }
+                $Result = Get-TestResult $Test $MissingCommands $Control
+                $Result.DisplayString | Should -Be "-"
+                $Result.SummaryKey | Should -Be "-"
+                $Result.Details | Should -Be "-"
+            }
+            It 'When the control description is malformed' {
+                $Test = [PSCustomObject]@{
+                    RequirementMet=$true;
+                    Criticality="Should";
+                    ReportDetails=$ExampleReportDetails;
+                }
+                $MissingCommands = @($ExampleMissingCommand1, $ExampleMissingCommand2)
+                $Control = [PSCustomObject]@{
+                    MalformedDescription=$true;
+                    Deleted=$true;
+                }
+                $Result = Get-TestResult $Test $MissingCommands $Control
+                $Result.DisplayString | Should -Be "Error"
+                $Result.SummaryKey | Should -Be "Errors"
+                $Result.Details | Should -Be "Report issue on <a href=`"$ScubaGitHubUrl/issues`" target=`"_blank`">GitHub</a>"
+            }
+        }
+    }
+
+    AfterAll {
+        Remove-Module CreateReport -ErrorAction SilentlyContinue
+    }
+}

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/CreateReport/Get-TestResult.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/CreateReport/Get-TestResult.Tests.ps1
@@ -1,4 +1,5 @@
-Import-Module (Join-Path -Path $PSScriptRoot -ChildPath '../../../../Modules/CreateReport')
+Import-Module (Join-Path -Path $PSScriptRoot -ChildPath '../../../../Modules/CreateReport') `
+    -Function 'Get-TestResult' -Force
 
 InModuleScope CreateReport {
     Describe -Tag CreateReport -Name 'Get-TestResult' {


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##
Save what the result would have been for controls that are omitted if they had not been omitted to the JSON output (HTML output is unchanged). Two new keys are added for each test result:
- `OmittedEvaluationResult`: What the result would have been, e.g., "Fail"
- `OmittedEvaluationDetails`: What the report details string would have been, e.g., "1 agency domain(s) found in violation: example.com"

For tests that are not omitted, those keys will be set to "N/A". See screenshot below for an example.

## 💭 Motivation and context ##
Closes #1458.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
- Add 12 new unit tests
- Ran ScubaGear with a control omitted, ensured that
  - The HTML output is unaffected by the new JSON keys
  - The `OmittedEvaluationResult` and `OmittedEvaluationDetails` values are correct for the omitted control.
  - The `OmittedEvaluationResult` and `OmittedEvaluationDetails` values are "N/A" for the controls that were not omitted.
- Compared the results with reports produced on main for two test tenants, verified that the results are consistent.

## 📷 Screenshots (if appropriate) ##
New keys indicated in red:
![image](https://github.com/user-attachments/assets/9e969e98-ea60-462b-ab3b-caa2356e9083)


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [x] Resolved all merge conflicts on branch
- [x] Notified merge coordinator that PR is ready for merge via comment mention
- [x] Demonstrate changes to the team for questions and comments. 
    (Note: Only required for issues of size `Medium` or larger)

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [x] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
