### PR TITLE
Create new Entra Id policy 3.9 block device code authentication

### DIFF
--- a/PowerShell/ScubaGear/Modules/Support/Support.psm1
+++ b/PowerShell/ScubaGear/Modules/Support/Support.psm1
@@ -864,7 +864,8 @@ function New-SCuBAConfig {
         "MS.AAD.3.3v1",
         "MS.AAD.3.6v1",
         "MS.AAD.3.7v1",
-        "MS.AAD.3.8v1"
+        "MS.AAD.3.8v1",
+        "MS.AAD.3.9v1"
         )
     $RoleExclusionNamespace = "MS.AAD.7.4v1"
 

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -583,7 +583,6 @@ RequireDeviceCodeBlock contains CAPolicy.DisplayName if {
     ###
 
     # Only match policies with user and group exclusions per the confile file
-    print(CAPolicy.DisplayName)
     UserExclusionsFullyExempt(CAPolicy, "MS.AAD.3.9v1") == true
     GroupExclusionsFullyExempt(CAPolicy, "MS.AAD.3.9v1") == true
 }

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -560,6 +560,49 @@ tests contains {
     Status := Count(RequireManagedDeviceMFA) > 0
 }
 #--
+# MS.AAD.3.9v1
+#--
+
+# Checks to ensure a managed device is required to perform MFA registration
+RequireDeviceCodeBlock contains CAPolicy.DisplayName if {
+    some CAPolicy in input.conditional_access_policies
+
+    ### Common checks for conditional access policies
+    ### We don't check IncludeApplications and ExcludeApplications because they are not relevant when you have an IncludeUserActions node
+    # Contains(CAPolicy.Conditions.Users.IncludeUsers, "All") == true
+    Contains(CAPolicy.Conditions.Applications.IncludeApplications, "All") == true
+    Contains(CAPolicy.Conditions.AuthenticationFlows.TransferMethods, "deviceCodeFlow") == true
+    CAPolicy.State == "enabled"
+    ###
+
+    ### Conditional access checks specific to this policy
+    ### "block" in CAPolicy.GrantControls.BuiltInControls
+    ### "deviceCodeFlow" in CAPolicy.Conditions.AuthenticationMethods.TransferMethods
+    ###
+
+    Conditions := [     
+        "block" in CAPolicy.GrantControls.BuiltInControls,
+    ]
+    Count(FilterArray(Conditions, true)) > 0    
+
+    # Only match policies with user and group exclusions per the confile file
+    UserExclusionsFullyExempt(CAPolicy, "MS.AAD.3.9v1") == true
+    GroupExclusionsFullyExempt(CAPolicy, "MS.AAD.3.9v1") == true
+}
+
+# Pass if at least 1 policy meets all conditions
+tests contains {
+    "PolicyId": "MS.AAD.3.9v1",
+    "Criticality": "Should",
+    "Commandlet": ["Get-MgBetaIdentityConditionalAccessPolicy"],
+    "ActualValue": RequireDeviceCodeBlock,
+    "ReportDetails": concat(". ", [ReportFullDetailsArray(RequireDeviceCodeBlock, DescriptionString), CAPLINK]),
+    "RequirementMet": Status
+} if {
+    DescriptionString := "conditional access policy(s) found that meet(s) all requirements"
+    Status := Count(RequireDeviceCodeBlock) > 0
+}
+#--
 
 ############
 # MS.AAD.4 #

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -570,7 +570,7 @@ RequireDeviceCodeBlock contains CAPolicy.DisplayName if {
     some CAPolicy in input.conditional_access_policies
 
     ### Common checks for conditional access policies
-    # Contains(CAPolicy.Conditions.Users.IncludeUsers, "All") == true
+    Contains(CAPolicy.Conditions.Users.IncludeUsers, "All") == true
     Contains(CAPolicy.Conditions.Applications.IncludeApplications, "All") == true
     Count(CAPolicy.Conditions.Users.ExcludeRoles) == 0
     Count(CAPolicy.Conditions.Applications.ExcludeApplications) == 0
@@ -583,6 +583,7 @@ RequireDeviceCodeBlock contains CAPolicy.DisplayName if {
     ###
 
     # Only match policies with user and group exclusions per the confile file
+    print(CAPolicy.DisplayName)
     UserExclusionsFullyExempt(CAPolicy, "MS.AAD.3.9v1") == true
     GroupExclusionsFullyExempt(CAPolicy, "MS.AAD.3.9v1") == true
 }

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -560,6 +560,8 @@ tests contains {
     Status := Count(RequireManagedDeviceMFA) > 0
 }
 #--
+
+#--
 # MS.AAD.3.9v1
 #--
 
@@ -568,22 +570,17 @@ RequireDeviceCodeBlock contains CAPolicy.DisplayName if {
     some CAPolicy in input.conditional_access_policies
 
     ### Common checks for conditional access policies
-    ### We don't check IncludeApplications and ExcludeApplications because they are not relevant when you have an IncludeUserActions node
     # Contains(CAPolicy.Conditions.Users.IncludeUsers, "All") == true
     Contains(CAPolicy.Conditions.Applications.IncludeApplications, "All") == true
-    Contains(CAPolicy.Conditions.AuthenticationFlows.TransferMethods, "deviceCodeFlow") == true
+    Count(CAPolicy.Conditions.Users.ExcludeRoles) == 0
+    Count(CAPolicy.Conditions.Applications.ExcludeApplications) == 0
     CAPolicy.State == "enabled"
     ###
 
     ### Conditional access checks specific to this policy
-    ### "block" in CAPolicy.GrantControls.BuiltInControls
-    ### "deviceCodeFlow" in CAPolicy.Conditions.AuthenticationMethods.TransferMethods
+    CAPolicy.Conditions.AuthenticationFlows.TransferMethods == "deviceCodeFlow"
+    "block" in CAPolicy.GrantControls.BuiltInControls
     ###
-
-    Conditions := [     
-        "block" in CAPolicy.GrantControls.BuiltInControls,
-    ]
-    Count(FilterArray(Conditions, true)) > 0    
 
     # Only match policies with user and group exclusions per the confile file
     UserExclusionsFullyExempt(CAPolicy, "MS.AAD.3.9v1") == true

--- a/PowerShell/ScubaGear/Rego/Utils/KeyFunctions.rego
+++ b/PowerShell/ScubaGear/Rego/Utils/KeyFunctions.rego
@@ -85,7 +85,7 @@ TestResultContains(PolicyId, Output, ReportDetailArrayStrings, RequirementMet) :
 
     # regal ignore: print-or-trace-call
     print("** Checking RequirementMet **")
-    assert.Equals(RuleOutput[0].RequirementMet, RequirementMet)
+    assert.Equals(RequirementMet, RuleOutput[0].RequirementMet)
 
     # regal ignore: print-or-trace-call
     print("** Checking ReportDetails **")

--- a/PowerShell/ScubaGear/Sample-Config-Files/aad_config.yaml
+++ b/PowerShell/ScubaGear/Sample-Config-Files/aad_config.yaml
@@ -44,6 +44,7 @@ Aad:
   MS.AAD.3.6v1: *CommonExclusions
   MS.AAD.3.7v1: *CommonExclusions
   MS.AAD.3.8v1: *CommonExclusions
+  MS.AAD.3.9v1: *CommonExclusions
   MS.AAD.7.4v1: &CommonRoleExclusions
     RoleExclusions:
       Users:

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/CreateReport/CreateReportStubs/TestResults.json
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/CreateReport/CreateReportStubs/TestResults.json
@@ -279,6 +279,18 @@
     },
     {
         "ActualValue":  [
+
+                        ],
+        "Commandlet":  [
+                           "Get-MgBetaIdentityConditionalAccessPolicy"
+                       ],
+        "Criticality":  "Should",
+        "PolicyId":  "MS.AAD.3.9v1",
+        "ReportDetails":  "0 conditional access policy(s) found that meet(s) all requirements. \u003ca href=\u0027#caps\u0027\u003eView all CA policies\u003c/a\u003e.",
+        "RequirementMet":  false
+    },
+    {
+        "ActualValue":  [
                         ],
         "Commandlet":  [
                            "Get-MgBetaSubscribedSku",

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADBaseConfig.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADBaseConfig.rego
@@ -36,7 +36,10 @@ ConditionalAccessPolicies := {
         "ClientAppTypes": [
             "other",
             "exchangeActiveSync"
-        ]
+        ],
+        "AuthenticationFlows": {
+            "TransferMethods":  null
+        },
     },
     "GrantControls": {
         "BuiltInControls": [

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_03_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_03_test.rego
@@ -1738,3 +1738,102 @@ test_ApplicationExclusions_Incorrect_V4 if {
     TestResult("MS.AAD.3.8v1", Output, ReportDetailStr, false) == true
 }
 #--
+
+#
+# Policy MS.AAD.3.9v1
+#--
+test_Entra_3_9_Correct_V1 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "replace", "path": "Conditions/AuthenticationFlows/TransferMethods", "value": "deviceCodeFlow"}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+
+    ReportDetailArrayStrs := ["conditional access policy(s) found that meet(s) all requirements:"]
+    TestResultContains("MS.AAD.3.9v1", Output, ReportDetailArrayStrs, true) == true
+}
+
+test_Entra_3_9_User_Group_Exclusions_Correct_V1 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "replace", "path": "Conditions/AuthenticationFlows/TransferMethods", "value": "deviceCodeFlow"},
+                {"op": "add", "path": "Conditions/Users/ExcludeUsers", "value": ["SpecialPerson1", "SpecialPerson2"]},
+                {"op": "add", "path": "Conditions/Users/ExcludeGroups", "value": ["SpecialGroup1", "SpecialGroup2"]}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+                        with input.scuba_config.Aad["MS.AAD.3.9v1"] as ScubaConfig
+                        with input.scuba_config.Aad["MS.AAD.3.9v1"].CapExclusions.Users as ["SpecialPerson1", "SpecialPerson2"]
+                        with input.scuba_config.Aad["MS.AAD.3.9v1"].CapExclusions.Groups as ["SpecialGroup1", "SpecialGroup2"]
+
+    ReportDetailArrayStrs := ["conditional access policy(s) found that meet(s) all requirements:"]
+    TestResultContains("MS.AAD.3.9v1", Output, ReportDetailArrayStrs, true) == true
+}
+
+test_Entra_3_9_User_Exclusions_Incorrect_V1 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "replace", "path": "Conditions/AuthenticationFlows/TransferMethods", "value": "deviceCodeFlow"},
+                {"op": "add", "path": "Conditions/Users/ExcludeUsers", "value": ["SpecialPerson1", "SpecialPerson2"]}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+                        with input.scuba_config.Aad["MS.AAD.3.9v1"] as ScubaConfig
+                        with input.scuba_config.Aad["MS.AAD.3.9v1"].CapExclusions.Users as ["SpecialPerson1", "SomeOtherPerson"]
+
+    ReportDetailStr :=
+        "0 conditional access policy(s) found that meet(s) all requirements. <a href='#caps'>View all CA policies</a>."
+    TestResult("MS.AAD.3.9v1", Output, ReportDetailStr, false) == true
+}
+
+test_Entra_3_9_Group_Exclusions_Incorrect_V1 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "replace", "path": "Conditions/AuthenticationFlows/TransferMethods", "value": "deviceCodeFlow"},
+                {"op": "add", "path": "Conditions/Users/ExcludeGroups", "value": ["SpecialGroup1", "SpecialGroup2"]}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+                        with input.scuba_config.Aad["MS.AAD.3.9v1"] as ScubaConfig
+                        with input.scuba_config.Aad["MS.AAD.3.9v1"].CapExclusions.Users as ["SomeOtherGroup", "SpecialGroup2"]
+
+    ReportDetailStr :=
+        "0 conditional access policy(s) found that meet(s) all requirements. <a href='#caps'>View all CA policies</a>."
+    TestResult("MS.AAD.3.9v1", Output, ReportDetailStr, false) == true
+}
+
+test_Entra_3_9_Report_Only_Incorrect_V1 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "replace", "path": "Conditions/AuthenticationFlows/TransferMethods", "value": "deviceCodeFlow"},
+                {"op": "replace", "path": "State", "value": "enabledForReportingButNotEnforced"}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+
+    ReportDetailStr :=
+        "0 conditional access policy(s) found that meet(s) all requirements. <a href='#caps'>View all CA policies</a>."
+    TestResult("MS.AAD.3.9v1", Output, ReportDetailStr, false) == true
+}
+
+test_Entra_3_9_Policy_Missing_Incorrect_V1 if {
+    Output := aad.tests with input.conditional_access_policies as []
+
+    ReportDetailStr :=
+        "0 conditional access policy(s) found that meet(s) all requirements. <a href='#caps'>View all CA policies</a>."
+    TestResult("MS.AAD.3.9v1", Output, ReportDetailStr, false) == true
+}
+
+test_Entra_3_9_Role_Exclusion_Incorrect_V1 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "Conditions/Users/ExcludeRoles", "value": ["SomeRole"]}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+
+    ReportDetailStr :=
+        "0 conditional access policy(s) found that meet(s) all requirements. <a href='#caps'>View all CA policies</a>."
+    TestResult("MS.AAD.3.9v1", Output, ReportDetailStr, false) == true
+}
+
+test_Entra_3_9_Application_Exclusion_Incorrect_V1 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "Conditions/Applications/ExcludeApplications", "value": ["SomeApp1","SomeApp2"]}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+
+    ReportDetailStr :=
+        "0 conditional access policy(s) found that meet(s) all requirements. <a href='#caps'>View all CA policies</a>."
+    TestResult("MS.AAD.3.9v1", Output, ReportDetailStr, false) == true
+}
+#--

--- a/PowerShell/ScubaGear/baselines/aad.md
+++ b/PowerShell/ScubaGear/baselines/aad.md
@@ -302,7 +302,7 @@ Managed Devices SHOULD be required to register MFA.
 Device code authentication SHOULD be blocked.
 
 <!--Policy: MS.AAD.3.9v1; Criticality: SHOULD -->
-- _Rationale:_ The device code authentication protocol has been abused to compromise user accounts via phishing. Since most organizations using M365 don't need device code authentication, blocking it mitigates the risk.
+- _Rationale:_ The device code authentication flow has been abused by threat actors to compromise user accounts via phishing. Since most organizations using M365 don't need device code authentication, blocking it mitigates the risk of this attack vector.
 - _Last modified:_ February 2025
 - _MITRE ATT&CK TTP Mapping:_
   - [T1528: Steal Application Access Token](https://attack.mitre.org/techniques/T1528/)
@@ -326,6 +326,10 @@ Device code authentication SHOULD be blocked.
 - [Enable passkeys (FIDO2) for your organization](https://learn.microsoft.com/en-us/entra/identity/authentication/how-to-enable-passkey-fido2)
 
 - [Storm-2372 conducts device code phishing campaign](https://www.microsoft.com/en-us/security/blog/2025/02/13/storm-2372-conducts-device-code-phishing-campaign/)
+
+- [Microsoft 365 Device Code Phishing Cyber Attack – Demonstration, Analysis and Mitigation](https://github.com/cisagov/ScubaGear/issues/1599)
+
+- [Block device code flow](https://learn.microsoft.com/en-us/entra/identity/conditional-access/managed-policies#block-device-code-flow)
 
 ### License Requirements
 

--- a/PowerShell/ScubaGear/baselines/aad.md
+++ b/PowerShell/ScubaGear/baselines/aad.md
@@ -298,6 +298,17 @@ Managed Devices SHOULD be required to register MFA.
   - [T1098: Account Manipulation](https://attack.mitre.org/techniques/T1098/)
     - [T1098.005: Device Registration](https://attack.mitre.org/techniques/T1098/005/)
 
+#### MS.AAD.3.9v1
+Device code authentication SHOULD be blocked.
+
+<!--Policy: MS.AAD.3.9v1; Criticality: SHOULD -->
+- _Rationale:_ The device code authentication protocol has been abused to compromise user accounts via phishing. Since most organizations using M365 don't need device code authentication, blocking it mitigates the risk.
+- _Last modified:_ February 2025
+- _MITRE ATT&CK TTP Mapping:_
+  - [T1528: Steal Application Access Token](https://attack.mitre.org/techniques/T1528/)
+  - [T1078: Valid Accounts](https://attack.mitre.org/techniques/T1078/)
+    - [T1078.004: Cloud Accounts](https://attack.mitre.org/techniques/T1078/004/)
+
 ### Resources
 
 - [What authentication and verification methods are available in Microsoft Entra ID?](https://learn.microsoft.com/en-us/entra/identity/authentication/concept-authentication-methods)
@@ -313,6 +324,8 @@ Managed Devices SHOULD be required to register MFA.
 - [Set up automatic enrollment for Windows devices (for Intune)](https://learn.microsoft.com/en-us/mem/intune/enrollment/windows-enroll)
 
 - [Enable passkeys (FIDO2) for your organization](https://learn.microsoft.com/en-us/entra/identity/authentication/how-to-enable-passkey-fido2)
+
+- [Storm-2372 conducts device code phishing campaign](https://www.microsoft.com/en-us/security/blog/2025/02/13/storm-2372-conducts-device-code-phishing-campaign/)
 
 ### License Requirements
 
@@ -397,6 +410,20 @@ If phishing-resistant MFA has not been deployed yet and Microsoft Authenticator 
   Target resources > User actions > <b>Register security information</b>
 
   Access controls > Grant > Grant Access > <b>Require device to be marked as compliant</b> and <b>Require Microsoft Entra ID hybrid joined device</b> > For multiple controls > <b>Require one of the selected controls</b>
+</pre>
+
+#### MS.AAD.3.9v1 Instructions
+
+1. Create a Conditional Access policy to block device code flow
+
+<pre>
+  Users > Include > <b>All users</b>
+
+  Target resources > Cloud apps >  Include > <b>All cloud apps</b>
+
+  Conditions > Authentication Flows > Configure > <b>Yes</b> > Select <b>Device code flow</b>
+
+  Access controls > Grant > <b>Block Access</b>
 </pre>
 
 ## 4. Centralized Log Collection

--- a/Testing/Functional/Products/TestPlans/aad.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/aad.testplan.yaml
@@ -1186,3 +1186,57 @@ TestPlan:
         Postconditions: []
         IsNotChecked: true
         ExpectedResult: false
+
+  - PolicyId: MS.AAD.3.9v1
+    TestDriver: ScubaCached
+    Tests:
+      - TestDescription: MS.AAD.3.9v1 Non-Compliant case - Device code block disabled
+        Preconditions:
+          - Command: UpdateCachedConditionalAccessPolicyByName
+            Splat:
+              displayName: Automated Test 1 - DO NOT MODIFY
+              updates:
+                state: disabled
+                Conditions:
+                  Applications:
+                    IncludeApplications: ["All"]
+                    ExcludeApplications: []
+                  Users:
+                    IncludeUsers: ["All"]
+                    ExcludeUsers: []
+                    IncludeGroups: []
+                    ExcludeGroups: []
+                    IncludeRoles: []
+                    ExcludeRoles: []
+                  AuthenticationFlows:
+                    TransferMethods: "deviceCodeFlow"
+                GrantControls:
+                  BuiltInControls:
+                    - block
+        Postconditions: []
+        ExpectedResult: false
+      - TestDescription: MS.AAD.3.9v1 Compliant case - Device code block enabled
+        Preconditions:
+          - Command: UpdateCachedConditionalAccessPolicyByName
+            Splat:
+              displayName: Automated Test 1 - DO NOT MODIFY
+              updates:
+                state: enabled
+                Conditions:
+                  Applications:
+                    IncludeApplications: ["All"]
+                    ExcludeApplications: []
+                  Users:
+                    IncludeUsers: ["All"]
+                    ExcludeUsers: []
+                    IncludeGroups: []
+                    ExcludeGroups: []
+                    IncludeRoles: []
+                    ExcludeRoles: []
+                  AuthenticationFlows:
+                    TransferMethods: "deviceCodeFlow"
+                GrantControls:
+                  BuiltInControls:
+                    - block
+        Postconditions: []
+        ExpectedResult: true


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##
This pull request creates a new Entra Id baseline policy 3.9 which checks for a conditional access policy that blocks device code authentication. It includes changes to the baseline document and the code.

*Ancillary changes: Upon working on the Rego unit tests I identified an issue with one of the Rego helper functions related to unit tests so I corrected it since it was a minor tweak. The Rego ruleset TestResultContains in /Rego/Utils/KeyFunctions.rego was modified to fix the fact that the print message for the Checking RequirementMet section was printing the values backwards so I re-arranged the order.

Closes #1600 

## 🧪 PR Testing Instructions ##

### Compliant test case steps

1. Setup a conditional access policy that blocks device code authentication as per the instructions section in the baseline document for 3.9
2. Run ScubaGear and ensure that policy 3.9 produces a Pass in the report

### Non-Compliant test case steps

1. Disable the conditional access policy created in the compliant test case
2. Run ScubaGear and ensure that policy 3.9 produces a Fail in the report

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [x] Resolved all merge conflicts on branch
- [x] Notified merge coordinator that PR is ready for merge via comment mention
- [x] Demonstrate changes to the team for questions and comments. 
    (Note: Only required for issues of size `Medium` or larger)

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [x] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
