### PR TITLE
Bump OPA version from v1.1.0 to v1.2.0

### DIFF
--- a/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfig.psm1
+++ b/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfig.psm1
@@ -41,7 +41,7 @@ class ScubaConfig {
             "Hybrid Identity Administrator",
             "Application Administrator",
             "Cloud Application Administrator")
-        DefaultOPAVersion = '1.1.0'
+        DefaultOPAVersion = '1.2.0'
     }
 
     static [object]ScubaDefault ([string]$Name){

--- a/PowerShell/ScubaGear/Modules/Support/Support.psm1
+++ b/PowerShell/ScubaGear/Modules/Support/Support.psm1
@@ -273,7 +273,7 @@ function Install-OPAforSCuBA {
     )
 
     # Constants
-    $ACCEPTABLEVERSIONS = '0.69.0', '0.70.0', '1.0.1', [ScubaConfig]::ScubaDefault('DefaultOPAVersion') # End Versions
+    $ACCEPTABLEVERSIONS = '0.69.0', '0.70.0', '1.0.1', '1.1.0', [ScubaConfig]::ScubaDefault('DefaultOPAVersion') # End Versions
     $FILENAME = @{ Windows = "opa_windows_amd64.exe"; MacOS = "opa_darwin_amd64"; Linux = "opa_linux_amd64_static"}
 
     # Set preferences for writing messages


### PR DESCRIPTION
   <!-- Remember this title will end up as the merge commit subject -->
 
 ## 🗣 Description ##
 
 This update bumps ScubaGear's Open Policy Agent (OPA) executable version dependency so that:
   - OPA v1.2.0 is the new default version
   - OPA v1.1.0 is retained as an acceptable version

Smoke test results [here](https://github.com/cisagov/ScubaGear/actions/runs/14228121494).

 <!-- To avoid scope creep, limit changes to a single goal. -->
 
 ## 💭 Motivation and context ##
 
 - Bump to the latest OPA version v1.2.0 
 <!-- What problem does this change solve? How did you solve it? -->
 <!-- Mention any related issue(s) here using appropriate keywords such -->
 <!-- as "closes" or "resolves" to auto-close them on merge. -->
 
 ## 🧪 Testing ##
 
 <!-- How did you test your changes? How could someone else test this PR? -->
 <!-- Include details of your testing environment, and the tests you ran to -->
 - Currently a human should still check if bumping the OPA version affects ScubaGear.
Recommend running `Invoke-SCuBA` with previous OPA version first and save results.
Then running `Initialize-SCuBA` on your system to confirm that the upgrade process installs OPA v1.2.0 on your machine and succeeds at SHA256 check.  Then running ScubaGear on test tenant with new OPA installed.  Compare results from previous run to validate there are no unexpected result changes and inspect for any runtime errors.
 
 <!--
 ## 📷 Screenshots (if appropriate) ##
 
 Uncomment this section if a screenshot is needed.
 
 -->
 
 ## ✅ Pre-approval checklist ##
 
 <!-- Remove any of the following that do not apply. -->
 <!-- Draft PRs may have one or more unchecked boxes. -->
 <!-- If you're unsure about any of these, don't hesitate to ask. -->
 <!-- We're here to help! -->
 
 - [x] This PR has an informative and human-readable title.
 - [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
 - [x] Changes are limited to a single goal - *eschew scope creep!*
 - [x] Changes are sized such that they do not touch excessive number of files.
 - [x] *All* future TODOs are captured in issues, which are referenced in code comments.
 - [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
 - [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
 - [x] All relevant type-of-change labels added.
 - [x] All relevant project fields are set.
 - [x] All relevant repo and/or project documentation updated to reflect these changes.
 - [x] Unit tests added/updated to cover PowerShell and Rego changes.
 - [x] Functional tests added/updated to cover PowerShell and Rego changes.
 - [x] All relevant functional tests passed.
 - [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.
 
 ## ✅ Pre-merge checklist ##
 
 <!-- Remove any of the following that do not apply. -->
 <!-- These boxes should remain unchecked until the pull request has been -->
 <!-- approved. -->
 
 - [x] PR passed smoke test check.
 - [x] Feature branch has been rebased against changes from parent branch, as needed
 
   Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
 - [x] Resolved all merge conflicts on branch
 - [x] Notified merge coordinator that PR is ready for merge via comment mention
 - [x] Demonstrate changes to the team for questions and comments. 
     (Note: Only required for issues of size `Medium` or larger)
 
 ## ✅ Post-merge checklist ##
 
 <!-- Remove any of the following that do not apply. -->
 <!-- These boxes should remain unchecked until the pull request has been -->
 <!-- approved. This section is for the merge coordinator to complete. -->
 - [x] Feature branch deleted after merge to clean up repository.
 - [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
