### PR TITLE
Fix Defender functional test errors

### DIFF
--- a/Testing/Functional/Products/TestPlans/defender.g5.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/defender.g5.testplan.yaml
@@ -363,12 +363,10 @@ TestPlan:
         Preconditions:
           # Pull first tenant user that is part of the default tenant domain and add that user to the preset policies
           - Command: |
-                      $Domain = (@(Get-MgBetaDomain | Where-Object {$_.IsDefault -eq $true})[0]).Id
-                      $Domain = '@' + $Domain
-                      $User = (Get-MgBetaUser -ConsistencyLevel eventual -Count userCount -Filter "endsWith(UserPrincipalName, '$Domain')")[0]
+                      $User = (Get-MailUser)[0].UserPrincipalName
                       $Group = (Get-UnifiedGroup)[0].alias
-                      Set-ATPProtectionPolicyRule -Identity "Standard Preset Security Policy" -SentTo $User.UserPrincipalName -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
-                      Set-ATPProtectionPolicyRule -Identity "Strict Preset Security Policy" -SentTo $User.UserPrincipalName -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
+                      Set-ATPProtectionPolicyRule -Identity "Standard Preset Security Policy" -SentTo "$User" -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
+                      Set-ATPProtectionPolicyRule -Identity "Strict Preset Security Policy" -SentTo "$User" -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
         Postconditions: []
         ExpectedResult: false
       - TestDescription: MS.DEFENDER.1.3v1 Compliant -- std&strict SentTo Null, SentToMemberOf Null, RecipientDomainIs Null
@@ -411,11 +409,9 @@ TestPlan:
               ErrorAction: Continue
           # Pull first tenant user that is part of the default tenant domain and add that user to the preset policies
           - Command: |
-                      $Domain = (@(Get-MgBetaDomain | Where-Object {$_.IsDefault -eq $true})[0]).Id
-                      $Domain = '@' + $Domain
-                      $User = (Get-MgBetaUser -ConsistencyLevel eventual -Count userCount -Filter "endsWith(UserPrincipalName, '$Domain')")[0]
+                      $User = (Get-MailUser)[0].UserPrincipalName
                       $Group = (Get-UnifiedGroup)[0].alias
-                      Set-ATPProtectionPolicyRule -Identity "Strict Preset Security Policy" -SentTo $User.UserPrincipalName -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
+                      Set-ATPProtectionPolicyRule -Identity "Strict Preset Security Policy" -SentTo "$User" -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
         Postconditions: []
         ExpectedResult: false
       - TestDescription: MS.DEFENDER.1.5v1 Compliant Matched Recipient Domains

--- a/Testing/Functional/Products/TestPlans/defender.g5.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/defender.g5.testplan.yaml
@@ -363,7 +363,7 @@ TestPlan:
         Preconditions:
           # Pull first tenant user that is part of the default tenant domain and add that user to the preset policies
           - Command: |
-                      $User = (Get-MailUser)[0].UserPrincipalName
+                      $User = (Get-EXOMailbox)[0].UserPrincipalName
                       $Group = (Get-UnifiedGroup)[0].alias
                       Set-ATPProtectionPolicyRule -Identity "Standard Preset Security Policy" -SentTo "$User" -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
                       Set-ATPProtectionPolicyRule -Identity "Strict Preset Security Policy" -SentTo "$User" -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
@@ -409,7 +409,7 @@ TestPlan:
               ErrorAction: Continue
           # Pull first tenant user that is part of the default tenant domain and add that user to the preset policies
           - Command: |
-                      $User = (Get-MailUser)[0].UserPrincipalName
+                      $User = (Get-EXOMailbox)[0].UserPrincipalName
                       $Group = (Get-UnifiedGroup)[0].alias
                       Set-ATPProtectionPolicyRule -Identity "Strict Preset Security Policy" -SentTo "$User" -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
         Postconditions: []

--- a/Testing/Functional/Products/TestPlans/defender.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/defender.testplan.yaml
@@ -7,12 +7,10 @@ TestPlan:
         Preconditions:
           # Pull first tenant user that is part of the default tenant domain and first group, then add that user/group to the preset policies
           - Command: |
-                      $Domain = (@(Get-MgBetaDomain | Where-Object {$_.IsDefault -eq $true})[0]).Id
-                      $Domain = '@' + $Domain
-                      $User = (Get-MgBetaUser -ConsistencyLevel eventual -Count userCount -Filter "endsWith(UserPrincipalName, '$Domain')")[0]
+                      $User = (Get-MailUser)[0].UserPrincipalName
                       $Group = (Get-UnifiedGroup)[0].alias
-                      Set-EOPProtectionPolicyRule -Identity "Standard Preset Security Policy" -SentTo $User.UserPrincipalName -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
-                      Set-EOPProtectionPolicyRule -Identity "Strict Preset Security Policy" -SentTo $User.UserPrincipalName -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
+                      Set-EOPProtectionPolicyRule -Identity "Standard Preset Security Policy" -SentTo "$User" -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
+                      Set-EOPProtectionPolicyRule -Identity "Strict Preset Security Policy" -SentTo "$User" -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
         Postconditions: []
         ExpectedResult: false
       - TestDescription: MS.DEFENDER.1.2v1 Compliant - Std Non-null Strict Null
@@ -20,11 +18,9 @@ TestPlan:
           # Pull first tenant user that is part of the default tenant domain and first group, then add that user/group to the preset policies
           # yamllint disable-line rule:line-length
           - Command: |
-                      $Domain = (@(Get-MgBetaDomain | Where-Object {$_.IsDefault -eq $true})[0]).Id
-                      $Domain = '@' + $Domain
-                      $User = (Get-MgBetaUser -ConsistencyLevel eventual -Count userCount -Filter "endsWith(UserPrincipalName, '$Domain')")[0]
+                      $User = (Get-MailUser)[0].UserPrincipalName
                       $Group = (Get-UnifiedGroup)[0].alias
-                      Set-EOPProtectionPolicyRule -Identity "Standard Preset Security Policy" -SentTo $User.UserPrincipalName -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
+                      Set-EOPProtectionPolicyRule -Identity "Standard Preset Security Policy" -SentTo "$User" -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
           - Command: Set-EOPProtectionPolicyRule
             Splat:
               Identity: Strict Preset Security Policy
@@ -46,11 +42,9 @@ TestPlan:
           # Pull first tenant user that is part of the default tenant domain and first group, then add that user/group to the preset policies
           # yamllint disable-line rule:line-length
           - Command: |
-                      $Domain = (@(Get-MgBetaDomain | Where-Object {$_.IsDefault -eq $true})[0]).Id
-                      $Domain = '@' + $Domain
-                      $User = (Get-MgBetaUser -ConsistencyLevel eventual -Count userCount -Filter "endsWith(UserPrincipalName, '$Domain')")[0]
+                      $User = (Get-MailUser)[0].UserPrincipalName
                       $Group = (Get-UnifiedGroup)[0].alias
-                      Set-EOPProtectionPolicyRule -Identity "Strict Preset Security Policy" -SentTo $User.UserPrincipalName -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
+                      Set-EOPProtectionPolicyRule -Identity "Strict Preset Security Policy" -SentTo "$User" -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
         Postconditions: []
         ExpectedResult: true
       - TestDescription: MS.DEFENDER.1.2v1 Compliant - std&strict SentTo Null, SentToMemberOf Null, RecipientDomainIs Null
@@ -94,11 +88,9 @@ TestPlan:
           # Pull first tenant user that is part of the default tenant domain and first group, then add that user/group to the preset policies
           # yamllint disable-line rule:line-length
           - Command: |
-                      $Domain = (@(Get-MgBetaDomain | Where-Object {$_.IsDefault -eq $true})[0]).Id
-                      $Domain = '@' + $Domain
-                      $User = (Get-MgBetaUser -ConsistencyLevel eventual -Count userCount -Filter "endsWith(UserPrincipalName, '$Domain')")[0]
+                      $User = (Get-MailUser)[0].UserPrincipalName
                       $Group = (Get-UnifiedGroup)[0].alias
-                      Set-EOPProtectionPolicyRule -Identity "Strict Preset Security Policy" -SentTo $User.UserPrincipalName -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
+                      Set-EOPProtectionPolicyRule -Identity "Strict Preset Security Policy" -SentTo "$User" -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
         Postconditions: []
         ExpectedResult: false
       - TestDescription: MS.DEFENDER.1.4v1 Non-compliant Mismatched User
@@ -112,11 +104,9 @@ TestPlan:
           # Pull first tenant user that is part of the default tenant domain and first group, then add that user/group to the preset policies
           # yamllint disable-line rule:line-length
           - Command: |
-                      $Domain = (@(Get-MgBetaDomain | Where-Object {$_.IsDefault -eq $true})[0]).Id
-                      $Domain = '@' + $Domain
-                      $User = (Get-MgBetaUser -ConsistencyLevel eventual -Count userCount -Filter "endsWith(UserPrincipalName, '$Domain')")[0]
+                      $User = (Get-MailUser)[0].UserPrincipalName
                       $Group = (Get-UnifiedGroup)[0].alias
-                      Set-EOPProtectionPolicyRule -Identity "Strict Preset Security Policy" -SentTo $User.UserPrincipalName -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
+                      Set-EOPProtectionPolicyRule -Identity "Strict Preset Security Policy" -SentTo "$User" -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
         Postconditions: []
         ExpectedResult: false
       - TestDescription: MS.DEFENDER.1.4v1 Non-compliant Mismatched Group
@@ -130,11 +120,9 @@ TestPlan:
           # Pull first tenant user that is part of the default tenant domain and first group, then add that user/group to the preset policies
           # yamllint disable-line rule:line-length
           - Command: |
-                      $Domain = (@(Get-MgBetaDomain | Where-Object {$_.IsDefault -eq $true})[0]).Id
-                      $Domain = '@' + $Domain
-                      $User = (Get-MgBetaUser -ConsistencyLevel eventual -Count userCount -Filter "endsWith(UserPrincipalName, '$Domain')")[0]
+                      $User = (Get-MailUser)[0].UserPrincipalName
                       $Group = (Get-UnifiedGroup)[0].alias
-                      Set-EOPProtectionPolicyRule -Identity "Strict Preset Security Policy" -SentTo $User.UserPrincipalName -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
+                      Set-EOPProtectionPolicyRule -Identity "Strict Preset Security Policy" -SentTo "$User" -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
         Postconditions: []
         ExpectedResult: false
       - TestDescription: MS.DEFENDER.1.4v1 Compliant Matched Recipient Domains

--- a/Testing/Functional/Products/TestPlans/defender.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/defender.testplan.yaml
@@ -7,7 +7,7 @@ TestPlan:
         Preconditions:
           # Pull first tenant user that is part of the default tenant domain and first group, then add that user/group to the preset policies
           - Command: |
-                      $User = (Get-MailUser)[0].UserPrincipalName
+                      $User = (Get-EXOMailbox)[0].UserPrincipalName
                       $Group = (Get-UnifiedGroup)[0].alias
                       Set-EOPProtectionPolicyRule -Identity "Standard Preset Security Policy" -SentTo "$User" -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
                       Set-EOPProtectionPolicyRule -Identity "Strict Preset Security Policy" -SentTo "$User" -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
@@ -18,7 +18,7 @@ TestPlan:
           # Pull first tenant user that is part of the default tenant domain and first group, then add that user/group to the preset policies
           # yamllint disable-line rule:line-length
           - Command: |
-                      $User = (Get-MailUser)[0].UserPrincipalName
+                      $User = (Get-EXOMailbox)[0].UserPrincipalName
                       $Group = (Get-UnifiedGroup)[0].alias
                       Set-EOPProtectionPolicyRule -Identity "Standard Preset Security Policy" -SentTo "$User" -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
           - Command: Set-EOPProtectionPolicyRule
@@ -42,7 +42,7 @@ TestPlan:
           # Pull first tenant user that is part of the default tenant domain and first group, then add that user/group to the preset policies
           # yamllint disable-line rule:line-length
           - Command: |
-                      $User = (Get-MailUser)[0].UserPrincipalName
+                      $User = (Get-EXOMailbox)[0].UserPrincipalName
                       $Group = (Get-UnifiedGroup)[0].alias
                       Set-EOPProtectionPolicyRule -Identity "Strict Preset Security Policy" -SentTo "$User" -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
         Postconditions: []
@@ -88,7 +88,7 @@ TestPlan:
           # Pull first tenant user that is part of the default tenant domain and first group, then add that user/group to the preset policies
           # yamllint disable-line rule:line-length
           - Command: |
-                      $User = (Get-MailUser)[0].UserPrincipalName
+                      $User = (Get-EXOMailbox)[0].UserPrincipalName
                       $Group = (Get-UnifiedGroup)[0].alias
                       Set-EOPProtectionPolicyRule -Identity "Strict Preset Security Policy" -SentTo "$User" -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
         Postconditions: []
@@ -104,7 +104,7 @@ TestPlan:
           # Pull first tenant user that is part of the default tenant domain and first group, then add that user/group to the preset policies
           # yamllint disable-line rule:line-length
           - Command: |
-                      $User = (Get-MailUser)[0].UserPrincipalName
+                      $User = (Get-EXOMailbox)[0].UserPrincipalName
                       $Group = (Get-UnifiedGroup)[0].alias
                       Set-EOPProtectionPolicyRule -Identity "Strict Preset Security Policy" -SentTo "$User" -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
         Postconditions: []
@@ -120,7 +120,7 @@ TestPlan:
           # Pull first tenant user that is part of the default tenant domain and first group, then add that user/group to the preset policies
           # yamllint disable-line rule:line-length
           - Command: |
-                      $User = (Get-MailUser)[0].UserPrincipalName
+                      $User = (Get-EXOMailbox)[0].UserPrincipalName
                       $Group = (Get-UnifiedGroup)[0].alias
                       Set-EOPProtectionPolicyRule -Identity "Strict Preset Security Policy" -SentTo "$User" -SentToMemberOf $Group -RecipientDomainIs badpeople.r.us -Confirm:$false
         Postconditions: []


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->
This update changes Defender functional test plan preconditions so they no longer rely on a connection to the MSGraph API. Instead, user and group information is retrieved with equivalent Exchange API calls.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->
Changes fix failing defender functional tests so developers can get accurate test results.

Closes #1665

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Either run the functional tests workflow on this branch or manually run the Defender standard and G5 variant functional tests to validate that the tests run successfully.  No changes were made to G3 tests.
Run the tests against all test tenants.  You may filter testing down to the policies with changes tests by adding `-Filter "MS.DEFENDER.1.[24]*` for the standard test plan and `-Filter "MS.DEFENDER.1.[35]*` for the G5 variant.
If using ScubaGearCheck.ps1, for example, run the following:

`ScubaGearCheck.ps1 -Baseline defender -Tenant 1 -Filter "MS.DEFENDER.1.[24]*`
`ScubaGearCheck.ps1 -Baseline defender -Tenant 1 -Filter "MS.DEFENDER.1.[35]* -Variant g5`

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [x] Resolved all merge conflicts on branch
- [x] Notified merge coordinator that PR is ready for merge via comment mention
- [x] Demonstrate changes to the team for questions and comments. 
    (Note: Only required for issues of size `Medium` or larger)

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [x] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
