### PR TITLE
Rehaul DNS Error Handling

### DIFF
--- a/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
+++ b/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
@@ -384,6 +384,8 @@ function New-Report {
                 }
             }
             $LogTable = $DnsLogs | ConvertTo-Html -As Table -Fragment
+            # Add CSS class to get alternating row colors
+            $LogTable = $LogTable.Replace("<table>", "<table class='alternating'>")
             $LogHtml += $LogTable
         }
         $ReportHTML = $ReportHTML.Replace("{DNS_LOGS}", $LogHTML)

--- a/PowerShell/ScubaGear/Modules/CreateReport/IndividualReport/IndividualReport.html
+++ b/PowerShell/ScubaGear/Modules/CreateReport/IndividualReport/IndividualReport.html
@@ -26,7 +26,8 @@
             <h4>{AADWARNING}</h4>
             {TABLES}
             {LICENSING_INFO}
-            {SERVICE_PRINCIPAL}            
+            {SERVICE_PRINCIPAL}
+            {DNS_LOGS}
         </main>
     </body>
 </html>

--- a/PowerShell/ScubaGear/Modules/CreateReport/styles/main.css
+++ b/PowerShell/ScubaGear/Modules/CreateReport/styles/main.css
@@ -175,7 +175,7 @@ img {
     margin-top: 3.125em;
 }
 
-#caps tr:nth-child(even){
+#caps tr:nth-child(even), .alternating tr:nth-child(even) {
     background-color: var(--cap-even);
 }
 

--- a/PowerShell/ScubaGear/Modules/CreateReport/styles/main.css
+++ b/PowerShell/ScubaGear/Modules/CreateReport/styles/main.css
@@ -63,6 +63,21 @@ h3 {
     text-align: center;
     font-family: Arial, Helvetica, sans-serif;
     color: var(--header-color);
+    font-size: 0.9em;
+}
+
+header h3 {
+    font-size: 1.17em;
+}
+
+p {
+    max-width: 700px;
+    text-align: center;
+}
+
+hr {
+    /* border-bottom: 0.063em solid var(--header-bottom); */
+    width: 1000px;
 }
 
 h4 {

--- a/PowerShell/ScubaGear/Modules/Providers/ExportEXOProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportEXOProvider.psm1
@@ -215,7 +215,7 @@ function Invoke-RobustDnsTxt {
         "Errors" = @()
     }
 
-    $TradResult = Invoke-TraditionalDns -Qname Qname -MaxTries MaxTries
+    $TradResult = Invoke-TraditionalDns -Qname $Qname -MaxTries $MaxTries
     $Results['Answers'] += $TradResult['Answers']
     $Results['NXDomain'] = $TradResult['NXDomain']
     $Results['LogEntries'] += $TradResult['LogEntries']
@@ -223,7 +223,7 @@ function Invoke-RobustDnsTxt {
 
     if ($Results.Answers.Length -eq 0 -and -not $Results.NXDomain) {
         # The traditional DNS query(ies) failed. Retry with DoH
-        $DoHResult = Invoke-DoH -Qname Qname -MaxTries MaxTries
+        $DoHResult = Invoke-DoH -Qname $Qname -MaxTries $MaxTries
         $Results['Answers'] += $DoHResult['Answers']
         $Results['NXDomain'] = $DoHResult['NXDomain']
         $Results['LogEntries'] += $DoHResult['LogEntries']
@@ -244,6 +244,19 @@ function Invoke-TraditionalDns {
     .Functionality
     Internal
     #>
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param (
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Qname,
+
+        [Parameter(Mandatory=$false)]
+        [ValidateRange(1, [int]::MaxValue)]
+        [int]
+        $MaxTries = 2
+    )
 
     $Answers = @()
     $NXDomain = $false
@@ -331,6 +344,19 @@ function Invoke-DoH {
     .Functionality
     Internal
     #>
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param (
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Qname,
+
+        [Parameter(Mandatory=$false)]
+        [ValidateRange(1, [int]::MaxValue)]
+        [int]
+        $MaxTries = 2
+    )
 
     $Answers = @()
     $NXDomain = $false

--- a/PowerShell/ScubaGear/Rego/EXOConfig.rego
+++ b/PowerShell/ScubaGear/Rego/EXOConfig.rego
@@ -160,7 +160,7 @@ DomainsWithoutSpf contains Details if {
 }
 
 # Link used for SPF, DKIM, and DMARC related logs
-DNSLink = "<a href=\"#dns-logs\">View DNS logs</a> for more details."
+DNSLink := "<a href=\"#dns-logs\">View DNS logs</a> for more details."
 
 SpfStatusMessage := Message if {
     count(DomainsWithoutSpf) == 0

--- a/PowerShell/ScubaGear/Rego/EXOConfig.rego
+++ b/PowerShell/ScubaGear/Rego/EXOConfig.rego
@@ -159,6 +159,9 @@ DomainsWithoutSpf contains Details if {
     ])
 }
 
+# Link used for SPF, DKIM, and DMARC related logs
+DNSLink = "<a href=\"#dns-logs\">View DNS logs</a> for more details."
+
 SpfStatusMessage := Message if {
     count(DomainsWithoutSpf) == 0
     Message := "Requirement met."
@@ -175,7 +178,7 @@ tests contains {
     "Criticality": "Shall",
     "Commandlet": ["Get-ScubaSpfRecord", "Get-AcceptedDomain"],
     "ActualValue": DomainsWithoutSpf,
-    "ReportDetails": SpfStatusMessage,
+    "ReportDetails": concat(". ", [SpfStatusMessage, DNSLink]),
     "RequirementMet": Status
 } if {
     Status := count(DomainsWithoutSpf) == 0
@@ -214,7 +217,10 @@ tests contains {
         "Get-AcceptedDomain"
     ],
     "ActualValue": [input.dkim_records, input.dkim_config],
-    "ReportDetails": ReportDetailsArray(Status, DomainsWithoutDkim, "agency domain(s) found in violation:"),
+    "ReportDetails": concat(". ", [
+        ReportDetailsArray(Status, DomainsWithoutDkim, "agency domain(s) found in violation:"),
+        DNSLink
+    ]),
     "RequirementMet": Status
 } if {
     # Get domains that are not in DomainsWithDkim array
@@ -249,7 +255,10 @@ tests contains {
         "Get-AcceptedDomain"
     ],
     "ActualValue": input.dmarc_records,
-    "ReportDetails": ReportDetailsArray(Status, Domains, "agency domain(s) found in violation:"),
+    "ReportDetails": concat(". ", [
+        ReportDetailsArray(Status, Domains, "agency domain(s) found in violation:"),
+        DNSLink
+    ]),
     "RequirementMet": Status
 } if {
     Domains := DomainsWithoutDmarc
@@ -278,7 +287,10 @@ tests contains {
         "Get-AcceptedDomain"
     ],
     "ActualValue": input.dmarc_records,
-    "ReportDetails": ReportDetailsArray(Status, Domains, "agency domain(s) found in violation:"),
+    "ReportDetails": concat(". ", [
+        ReportDetailsArray(Status, Domains, "agency domain(s) found in violation:"),
+        DNSLink
+    ]),
     "RequirementMet": Status
 } if {
     Domains := DomainsWithoutPreject
@@ -318,8 +330,10 @@ tests contains {
         "Get-AcceptedDomain"
     ],
     "ActualValue": input.dmarc_records,
-    "ReportDetails": ReportDetailsArray(Status, Domains, "agency domain(s) found in violation:"),
-    "RequirementMet": Status
+    "ReportDetails": concat(". ", [
+        ReportDetailsArray(Status, Domains, "agency domain(s) found in violation:"),
+        DNSLink
+    ]),    "RequirementMet": Status
 } if {
     Domains := DomainsWithoutDHSContact
     Status := count(Domains) == 0
@@ -374,8 +388,10 @@ tests contains {
         "Get-AcceptedDomain"
     ],
     "ActualValue": input.dmarc_records,
-    "ReportDetails": ReportDetailsArray(Status, Domains, "agency domain(s) found in violation:"),
-    "RequirementMet": Status
+    "ReportDetails": concat(". ", [
+        ReportDetailsArray(Status, Domains, "agency domain(s) found in violation:"),
+        DNSLink
+    ]),    "RequirementMet": Status
 } if {
     Domains := DomainsWithoutAgencyContact
     Status := count(Domains) == 0

--- a/PowerShell/ScubaGear/Rego/EXOConfig.rego
+++ b/PowerShell/ScubaGear/Rego/EXOConfig.rego
@@ -164,7 +164,7 @@ DNSLink = "<a href=\"#dns-logs\">View DNS logs</a> for more details."
 
 SpfStatusMessage := Message if {
     count(DomainsWithoutSpf) == 0
-    Message := "Requirement met."
+    Message := "Requirement met"
 } else := concat("", [
         format_int(count(DomainsWithoutSpf), 10),
         " failing domain(s):",

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/EXOProvider/Get-ScubaSpfRecord.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/EXOProvider/Get-ScubaSpfRecord.Tests.ps1
@@ -4,52 +4,116 @@ Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "$($ProviderPath)/Export
 
 InModuleScope 'ExportEXOProvider' {
     Describe -Tag 'ExportEXOProvider' -Name "Get-ScubaSpfRecord" {
-        Context "When high-confidence answers are available" {
-            BeforeAll {
-                Mock -CommandName Write-Warning {}
+        Context "When a txt record is found" {
+            It "Handles correct SPF records" {
                 Mock -CommandName Invoke-RobustDnsTxt {
                     @{
-                        "Answers" = @("v=spf1...");
-                        "HighConfidence" = $true;
-                        "LogEntries" = @("some text")
+                        "Answers" = @("v=spf1 include:spf.protection.outlook.com -all");
+                        "Errors" = @();
+                        "NXDomain" = $false
+                        "LogEntries" = @()
                     }
                 }
-            }
-            It "Resolves 1 domain name" {
-                # Test basic functionality
                 $Response = Get-ScubaSpfRecord -Domains @(@{"DomainName" = "example.com"})
                 Should -Invoke -CommandName Invoke-RobustDnsTxt -Exactly -Times 1
-                Should -Invoke -CommandName Write-Warning -Exactly -Times 0
-                $Response.rdata -Contains "v=spf1..." | Should -Be $true
+                $Response.Compliant | Should -Be $true
+                $Response.Message | Should -Be "SPF record found."
             }
 
-            It "Resolves multiple domain names" {
-                # Test to ensure function will loop over the domain names provided in the -Domains argument.
-                $Response = Get-ScubaSpfRecord -Domains @(@{"DomainName" = "example.com"},
-                    @{"DomainName" = "example.com"})
-                Should -Invoke -CommandName Invoke-RobustDnsTxt -Exactly -Times 2
-                Should -Invoke -CommandName Write-Warning -Exactly -Times 0
-                $Response.rdata -Contains "v=spf1..." | Should -Be $true
-            }
-        }
-        Context "When high-confidence answers are not available" {
-            BeforeAll {
-                Mock -CommandName Write-Warning {}
+            It "Handles soft fail" {
                 Mock -CommandName Invoke-RobustDnsTxt {
                     @{
-                        "Answers" = @("v=spf1...");
-                        "HighConfidence" = $false;
-                        "LogEntries" = @("some text")
+                        "Answers" = @("v=spf1 include:spf.protection.outlook.com ~all");
+                        "Errors" = @();
+                        "NXDomain" = $false
+                        "LogEntries" = @()
                     }
                 }
-            }
-            It "Prints a warning" {
-                # If Invoke-RobustDnsTxt returns a low confidence answer, Get-ScubaSpfRecord should print a
-                # warning.
                 $Response = Get-ScubaSpfRecord -Domains @(@{"DomainName" = "example.com"})
                 Should -Invoke -CommandName Invoke-RobustDnsTxt -Exactly -Times 1
-                Should -Invoke -CommandName Write-Warning -Exactly -Times 1
-                $Response.rdata -Contains "v=spf1..." | Should -Be $true
+                $Response.Compliant | Should -Be $false
+                $Response.Message |
+                    Should -Be "SPF record found, but it does not hardfail (`"-all`") or redirect to one that does."
+            }
+
+            It "Handles no SPF record" {
+                Mock -CommandName Invoke-RobustDnsTxt {
+                    @{
+                        "Answers" = @("something else, like a domain verification record");
+                        "Errors" = @();
+                        "NXDomain" = $false
+                        "LogEntries" = @()
+                    }
+                }
+                $Response = Get-ScubaSpfRecord -Domains @(@{"DomainName" = "example.com"})
+                Should -Invoke -CommandName Invoke-RobustDnsTxt -Exactly -Times 1
+                $Response.Compliant | Should -Be $false
+                $Response.Message |
+                    Should -Be "Domain name exists but no SPF records returned."
+            }
+
+            It "Handles some errors but answer still found" {
+                # There can be errors but still have a valid answer. For example, if the traditional DNS query failed
+                # but DoH worked
+                Mock -CommandName Invoke-RobustDnsTxt {
+                    @{
+                        "Answers" = @("v=spf1 include:spf.protection.outlook.com -all");
+                        "Errors" = @("something went wrong");
+                        "NXDomain" = $false
+                        "LogEntries" = @()
+                    }
+                }
+                $Response = Get-ScubaSpfRecord -Domains @(@{"DomainName" = "example.com"})
+                Should -Invoke -CommandName Invoke-RobustDnsTxt -Exactly -Times 1
+                $Response.Compliant | Should -Be $true
+                $Response.Message | Should -Be "SPF record found."
+            }
+        }
+
+        Context "When no txt record is found" {
+            It "Handles NXDomain" {
+                Mock -CommandName Invoke-RobustDnsTxt {
+                    @{
+                        "Answers" = @();
+                        "Errors" = @();
+                        "NXDomain" = $true
+                        "LogEntries" = @()
+                    }
+                }
+                $Response = Get-ScubaSpfRecord -Domains @(@{"DomainName" = "example.com"})
+                Should -Invoke -CommandName Invoke-RobustDnsTxt -Exactly -Times 1
+                $Response.Compliant | Should -Be $false
+                $Response.Message | Should -Be "Domain does not exist."
+            }
+
+            It "Handles empty answer" {
+                Mock -CommandName Invoke-RobustDnsTxt {
+                    @{
+                        "Answers" = @();
+                        "Errors" = @();
+                        "NXDomain" = $false
+                        "LogEntries" = @()
+                    }
+                }
+                $Response = Get-ScubaSpfRecord -Domains @(@{"DomainName" = "example.com"})
+                Should -Invoke -CommandName Invoke-RobustDnsTxt -Exactly -Times 1
+                $Response.Compliant | Should -Be $false
+                $Response.Message | Should -Be "Domain name exists but no answers returned."
+            }
+
+            It "Handles errors" {
+                Mock -CommandName Invoke-RobustDnsTxt {
+                    @{
+                        "Answers" = @();
+                        "Errors" = @("something went wrong");
+                        "NXDomain" = $false
+                        "LogEntries" = @()
+                    }
+                }
+                $Response = Get-ScubaSpfRecord -Domains @(@{"DomainName" = "example.com"})
+                Should -Invoke -CommandName Invoke-RobustDnsTxt -Exactly -Times 1
+                $Response.Compliant | Should -Be $false
+                $Response.Message | Should -Be "Exceptions other than NXDOMAIN returned."
             }
         }
     }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/EXOProvider/Invoke-DoH.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/EXOProvider/Invoke-DoH.Tests.ps1
@@ -1,0 +1,88 @@
+$ProviderPath = "../../../../../Modules/Providers"
+Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "$($ProviderPath)/ExportEXOProvider.psm1") `
+    -Function 'Invoke-DoH' -Force
+
+InModuleScope 'ExportEXOProvider' {
+    Describe -Tag 'ExportEXOProvider' -Name "Invoke-DoH" {
+        BeforeAll {
+            Mock -CommandName Select-DohServer { "cloudflare-dns.com" }
+        }
+        Context 'When resolving a domain name' {
+            It "Returns correct response when DoH works" {
+                $DohResponseHeaders = @(
+                    "HTTP/1.1 200 OK",
+                    "Connection: keep-alive",
+                    "Access-Control-Allow-Origin: *",
+                    "CF-RAY: some value",
+                    "Content-Length: 123",
+                    "Content-Type: application/dns-json",
+                    "Date: some date",
+                    "Server: cloudflare"
+                )
+                Mock -CommandName ConvertFrom-Json {
+                    @{
+                        "Status" = 0;
+                        "Answer" = @(@{
+                            "name" = "example.com";
+                            "type" = 16;
+                            "data" = "`"v=spf1 include:spf.protection.outlook.com -all`"";
+                        })
+                    }
+                }
+                Mock -CommandName Invoke-WebRequest {
+                    @{
+                        "RawContent" = ($DohResponseHeaders -Join "`r`n") + "`r`n" + "json encoded answer"
+                    }
+                }
+                $Response = Invoke-DoH -Qname "example.com" -MaxTries 2
+                Should -Invoke -CommandName Invoke-WebRequest -Exactly -Times 1
+                $Response.Answers -Contains "v=spf1 include:spf.protection.outlook.com -all" | Should -Be $true
+                $Response.Errors.Length | Should -Be 0
+                $Response.NXDomain | Should -Be $false
+            }
+
+            It "Reports error when DoH unavailable" {
+                Mock -CommandName ConvertFrom-Json {}
+                Mock -CommandName Invoke-WebRequest { throw "some error" }
+                $Response = Invoke-DoH -Qname "example.com" -MaxTries 2
+                Should -Invoke -CommandName Invoke-WebRequest -Exactly -Times 2
+                $Response.Answers.Length | Should -Be 0
+                $Response.Errors.Length | Should -Be 2
+                $Response.NXDomain | Should -Be $false
+            }
+
+            It "Does not error with no answer" {
+                $DohResponseHeaders = @(
+                    "HTTP/1.1 200 OK",
+                    "Connection: keep-alive",
+                    "Access-Control-Allow-Origin: *",
+                    "CF-RAY: some value",
+                    "Content-Length: 123",
+                    "Content-Type: application/dns-json",
+                    "Date: some date",
+                    "Server: cloudflare"
+                )
+                # If there is no answer (e.g., the domain name exists but there are no txt records), the answer section
+                # will just be gone
+                Mock -CommandName ConvertFrom-Json {
+                    @{
+                        "Status" = 0;
+                    }
+                }
+                Mock -CommandName Invoke-WebRequest {
+                    @{
+                        "RawContent" = ($DohResponseHeaders -Join "`r`n") + "`r`n" + "json encoded answer"
+                    }
+                }
+                $Response = Invoke-DoH -Qname "example.com" -MaxTries 2
+                Should -Invoke -CommandName Invoke-WebRequest -Exactly -Times 1
+                $Response.Answers.Length | Should -Be 0
+                $Response.Errors.Length | Should -Be 0
+                $Response.NXDomain | Should -Be $false
+            }
+        }
+    }
+}
+AfterAll {
+    Remove-Module ExportEXOProvider -Force -ErrorAction SilentlyContinue
+}

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/EXOProvider/Invoke-RobustDnsTxt.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/EXOProvider/Invoke-RobustDnsTxt.Tests.ps1
@@ -4,143 +4,193 @@ Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "$($ProviderPath)/Export
 
 InModuleScope 'ExportEXOProvider' {
     Describe -Tag 'ExportEXOProvider' -Name "Invoke-RobustDnsTxt" {
-        BeforeAll {
-            Mock -CommandName Select-DohServer { "cloudflare-dns.com" }
-        }
-        Context 'When resolving a domain name' {
+        Context 'When a txt record exists' {
             It "Returns correct response when traditional DNS works" {
-                # Test where Resolve-DnsName works first try
-                Mock -CommandName Resolve-DnsName {
-                    @(
-                        @{
-                            "Strings" = @("v=spf1 include:spf.protection.outlook.com -all");
-                            "Section" = "Answer"
-                        }
-                        )
+                Mock -CommandName Invoke-TraditionalDns {
+                    @{
+                        "Answers" = @("v=spf1 include:spf.protection.outlook.com -all");
+                        "NXDomain" = $false;
+                        "LogEntries" = @();
+                        "Errors" = @();
                     }
-                Mock -CommandName Invoke-WebRequest {}
-                Mock -CommandName ConvertFrom-Json {}
+                }
+                Mock -CommandName Invoke-DoH {}
                 $Response = Invoke-RobustDnsTxt -Qname "example.com"
-                Should -Invoke -CommandName Resolve-DnsName -Exactly -Times 1
-                Should -Invoke -CommandName Invoke-WebRequest -Exactly -Times 0
+                Should -Invoke -CommandName Invoke-TraditionalDns -Exactly -Times 1
+                Should -Invoke -CommandName Invoke-DoH -Exactly -Times 0
                 $Response.Answers -Contains "v=spf1 include:spf.protection.outlook.com -all" | Should -Be $true
-                $Response.HighConfidence | Should -Be $true
+                $Response.Errors.Length | Should -Be 0
+                $Response.NXDomain | Should -Be $false
             }
 
-            It "Handles NXDOMAIN" {
-                # Test where Resolve-DnsName returns NXDOMAIN
-                Mock -CommandName Resolve-DnsName {
-                    throw "DNS_ERROR_RCODE_NAME_ERROR,Microsoft.DnsClient.Commands.ResolveDnsName"
+            It "Handles when traditional DNS doesn't return an answer but DoH does" {
+                Mock -CommandName Invoke-TraditionalDns {
+                    @{
+                        "Answers" = @();
+                        "NXDomain" = $false;
+                        "LogEntries" = @();
+                        "Errors" = @();
+                    }
                 }
-                Mock -CommandName Invoke-WebRequest {}
-                Mock -CommandName ConvertFrom-Json {}
+                Mock -CommandName Invoke-DoH {
+                    @{
+                        "Answers" = @("v=spf1 include:spf.protection.outlook.com -all");
+                        "NXDomain" = $false;
+                        "LogEntries" = @();
+                        "Errors" = @();
+                    }
+                }
                 $Response = Invoke-RobustDnsTxt -Qname "example.com"
-                Should -Invoke -CommandName Resolve-DnsName -Exactly -Times 1
-                Should -Invoke -CommandName Invoke-WebRequest -Exactly -Times 0
-                $Response.Answers.Length | Should -Be 0
-                $Response.HighConfidence | Should -Be $true
-            }
-
-            It "Tries over DoH if traditional DNS is unavailable" {
-                # Test where Resolve-DnsName throws an exception. In this case, Invoke-RobustDnsTxt should try
-                # again over DoH
-                Mock -CommandName Resolve-DnsName { throw "Some error" }
-                $DohResponseHeaders = @(
-                    "HTTP/1.1 200 OK",
-                    "Connection: keep-alive",
-                    "Access-Control-Allow-Origin: *",
-                    "CF-RAY: some value",
-                    "Content-Length: 123",
-                    "Content-Type: application/dns-json",
-                    "Date: some date",
-                    "Server: cloudflare"
-                )
-                Mock -CommandName ConvertFrom-Json {
-                    @{
-                        "Status" = 0;
-                        "Answer" = @(@{
-                            "name" = "example.com";
-                            "type" = 16;
-                            "data" = "`"v=spf1 include:spf.protection.outlook.com -all`"";
-                        })
-                    }
-                }
-                Mock -CommandName Invoke-WebRequest {
-                    @{
-                        "RawContent" = ($DohResponseHeaders -Join "`r`n") + "`r`n" + "json encoded answer"
-                    }
-                }
-                $Response = Invoke-RobustDnsTxt -Qname "example.com" -MaxTries 2
-                Should -Invoke -CommandName Resolve-DnsName -Exactly -Times 2
-                Should -Invoke -CommandName Invoke-WebRequest -Exactly -Times 1
+                Should -Invoke -CommandName Invoke-TraditionalDns -Exactly -Times 1
+                Should -Invoke -CommandName Invoke-DoH -Exactly -Times 1
                 $Response.Answers -Contains "v=spf1 include:spf.protection.outlook.com -all" | Should -Be $true
-                $Response.HighConfidence | Should -Be $true
+                $Response.Errors.Length | Should -Be 0
+                $Response.NXDomain | Should -Be $false
             }
 
-            It "Tries over DoH if traditional DNS gives an empty answer" {
-                # Test where Resolve-DnsName doesn't throw an exception but also doesn't return an answer.
-                # Invoke-RobustDnsTxt should try again over DoH in that this. For context, there are some
-                # cases where Resolve-DnsName won't throw an exception but won't actually return an answer.
-                # For example, in some cases where the answer can't be using the local resolver but trying
-                # over a public resolve will reveal the answer.
-                Mock -CommandName Resolve-DnsName { @(
+            It "Handles when traditional DNS has errors but DoH works" {
+                Mock -CommandName Invoke-TraditionalDns {
                     @{
-                        "Strings" = @("");
-                        "Section" = "Authority"
-                    }
-                    )
-                }
-                $DohResponseHeaders = @(
-                    "HTTP/1.1 200 OK",
-                    "Connection: keep-alive",
-                    "Access-Control-Allow-Origin: *",
-                    "CF-RAY: some value",
-                    "Content-Length: 123",
-                    "Content-Type: application/dns-json",
-                    "Date: some date",
-                    "Server: cloudflare"
-                )
-                Mock -CommandName ConvertFrom-Json {
-                    @{
-                        "Status" = 0;
-                        "Answer" = @(@{
-                            "name" = "example.com";
-                            "type" = 16;
-                            "data" = "`"v=spf1 include:spf.protection.outlook.com -all`"";
-                        })
+                        "Answers" = @();
+                        "NXDomain" = $false;
+                        "LogEntries" = @();
+                        "Errors" = @("something went wrong");
                     }
                 }
-                Mock -CommandName Invoke-WebRequest {
+                Mock -CommandName Invoke-DoH {
                     @{
-                        "RawContent" = ($DohResponseHeaders -Join "`r`n") + "`r`n" + "json encoded answer"
+                        "Answers" = @("v=spf1 include:spf.protection.outlook.com -all");
+                        "NXDomain" = $false;
+                        "LogEntries" = @();
+                        "Errors" = @();
                     }
                 }
-                $Response = Invoke-RobustDnsTxt -Qname "example.com" -MaxTries 2
-                Should -Invoke -CommandName Resolve-DnsName -Exactly -Times 1
-                Should -Invoke -CommandName Invoke-WebRequest -Exactly -Times 1
+                $Response = Invoke-RobustDnsTxt -Qname "example.com"
+                Should -Invoke -CommandName Invoke-TraditionalDns -Exactly -Times 1
+                Should -Invoke -CommandName Invoke-DoH -Exactly -Times 1
                 $Response.Answers -Contains "v=spf1 include:spf.protection.outlook.com -all" | Should -Be $true
-                $Response.HighConfidence | Should -Be $true
+                $Response.Errors.Length | Should -Be 1
+                $Response.NXDomain | Should -Be $false
+            }
+        }
+
+        Context 'When a txt record does not exist' {
+            It "Handles NXDomain when traditional DNS works" {
+                Mock -CommandName Invoke-TraditionalDns {
+                    @{
+                        "Answers" = @();
+                        "NXDomain" = $true;
+                        "LogEntries" = @();
+                        "Errors" = @();
+                    }
+                }
+                Mock -CommandName Invoke-DoH {}
+                $Response = Invoke-RobustDnsTxt -Qname "example.com"
+                Should -Invoke -CommandName Invoke-TraditionalDns -Exactly -Times 1
+                Should -Invoke -CommandName Invoke-DoH -Exactly -Times 0
+                $Response.Answers.Length| Should -Be 0
+                $Response.Errors.Length | Should -Be 0
+                $Response.NXDomain | Should -Be $true
             }
 
-            It "Indicates low confidence if traditional DNS gives an empty answer and DoH unavailable" {
-                # There are some cases where Resolve-DnsName won't throw an exception but won't actually
-                # return an answer, but where trying over a public DNS resolver reveals the answer
-                # However, many systems block DoH. If Resolve-DnsName returns an empty answer and DoH
-                # fails, Invoke-RobustDnsTxt should indicate that the answer is not high-confidence.
-                Mock -CommandName Resolve-DnsName { @(
+            It "Handles NXDomain when traditional DNS does not work" {
+                Mock -CommandName Invoke-TraditionalDns {
                     @{
-                        "Strings" = @("");
-                        "Section" = "Authority"
+                        "Answers" = @();
+                        "NXDomain" = $false;
+                        "LogEntries" = @();
+                        "Errors" = @("something went wrong");
                     }
-                    )
                 }
-                Mock -CommandName ConvertFrom-Json {}
-                Mock -CommandName Invoke-WebRequest { throw "some error" }
-                $Response = Invoke-RobustDnsTxt -Qname "example.com" -MaxTries 2
-                Should -Invoke -CommandName Resolve-DnsName -Exactly -Times 1
-                Should -Invoke -CommandName Invoke-WebRequest -Exactly -Times 2
-                $Response.Answers.Length | Should -Be 0
-                $Response.HighConfidence | Should -Be $false
+                Mock -CommandName Invoke-DoH {
+                    @{
+                        "Answers" = @();
+                        "NXDomain" = $true;
+                        "LogEntries" = @();
+                        "Errors" = @();
+                    }
+                }
+                $Response = Invoke-RobustDnsTxt -Qname "example.com"
+                Should -Invoke -CommandName Invoke-TraditionalDns -Exactly -Times 1
+                Should -Invoke -CommandName Invoke-DoH -Exactly -Times 1
+                $Response.Answers.Length| Should -Be 0
+                $Response.Errors.Length | Should -Be 1
+                $Response.NXDomain | Should -Be $true
+            }
+
+            It "Handles NXDomain from DoH when traditional DNS gives empty answer" {
+                Mock -CommandName Invoke-TraditionalDns {
+                    @{
+                        "Answers" = @();
+                        "NXDomain" = $false;
+                        "LogEntries" = @();
+                        "Errors" = @();
+                    }
+                }
+                Mock -CommandName Invoke-DoH {
+                    @{
+                        "Answers" = @();
+                        "NXDomain" = $true;
+                        "LogEntries" = @();
+                        "Errors" = @();
+                    }
+                }
+                $Response = Invoke-RobustDnsTxt -Qname "example.com"
+                Should -Invoke -CommandName Invoke-TraditionalDns -Exactly -Times 1
+                Should -Invoke -CommandName Invoke-DoH -Exactly -Times 1
+                $Response.Answers.Length| Should -Be 0
+                $Response.Errors.Length | Should -Be 0
+                $Response.NXDomain | Should -Be $true
+            }
+
+            It "Handles empty answer from both traditional and DoH" {
+                Mock -CommandName Invoke-TraditionalDns {
+                    @{
+                        "Answers" = @();
+                        "NXDomain" = $false;
+                        "LogEntries" = @();
+                        "Errors" = @();
+                    }
+                }
+                Mock -CommandName Invoke-DoH {
+                    @{
+                        "Answers" = @();
+                        "NXDomain" = $false;
+                        "LogEntries" = @();
+                        "Errors" = @();
+                    }
+                }
+                $Response = Invoke-RobustDnsTxt -Qname "example.com"
+                Should -Invoke -CommandName Invoke-TraditionalDns -Exactly -Times 1
+                Should -Invoke -CommandName Invoke-DoH -Exactly -Times 1
+                $Response.Answers.Length| Should -Be 0
+                $Response.Errors.Length | Should -Be 0
+                $Response.NXDomain | Should -Be $false
+            }
+
+            It "Handles errors from both traditional and DoH" {
+                Mock -CommandName Invoke-TraditionalDns {
+                    @{
+                        "Answers" = @();
+                        "NXDomain" = $false;
+                        "LogEntries" = @();
+                        "Errors" = @("something went wrong");
+                    }
+                }
+                Mock -CommandName Invoke-DoH {
+                    @{
+                        "Answers" = @();
+                        "NXDomain" = $false;
+                        "LogEntries" = @();
+                        "Errors" = @("something went wrong");
+                    }
+                }
+                $Response = Invoke-RobustDnsTxt -Qname "example.com"
+                Should -Invoke -CommandName Invoke-TraditionalDns -Exactly -Times 1
+                Should -Invoke -CommandName Invoke-DoH -Exactly -Times 1
+                $Response.Answers.Length| Should -Be 0
+                $Response.Errors.Length | Should -Be 2
+                $Response.NXDomain | Should -Be $false
             }
         }
     }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/EXOProvider/Invoke-TraditionalDns.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/EXOProvider/Invoke-TraditionalDns.Tests.ps1
@@ -1,0 +1,69 @@
+$ProviderPath = "../../../../../Modules/Providers"
+Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "$($ProviderPath)/ExportEXOProvider.psm1") `
+    -Function 'Invoke-TraditionalDns' -Force
+
+InModuleScope 'ExportEXOProvider' {
+    Describe -Tag 'ExportEXOProvider' -Name "Invoke-TraditionalDns" {
+        Context 'When resolving a domain name' {
+            It "Returns correct response when traditional DNS works" {
+                # Test where Resolve-DnsName works first try
+                Mock -CommandName Resolve-DnsName {
+                    @(
+                        @{
+                            "Strings" = @("v=spf1 include:spf.protection.outlook.com -all");
+                            "Section" = "Answer"
+                        }
+                        )
+                    }
+                $Response = Invoke-TraditionalDns -Qname "example.com"
+                Should -Invoke -CommandName Resolve-DnsName -Exactly -Times 1
+                $Response.Answers -Contains "v=spf1 include:spf.protection.outlook.com -all" | Should -Be $true
+                $Response.Errors.Length | Should -Be 0
+                $Response.NXDomain | Should -Be $false
+            }
+
+            It "Handles NXDOMAIN" {
+                # Test where Resolve-DnsName returns NXDOMAIN
+                Mock -CommandName Resolve-DnsName {
+                    throw "DNS_ERROR_RCODE_NAME_ERROR,Microsoft.DnsClient.Commands.ResolveDnsName"
+                }
+                $Response = Invoke-TraditionalDns -Qname "example.com"
+                Should -Invoke -CommandName Resolve-DnsName -Exactly -Times 1
+                $Response.Answers.Length | Should -Be 0
+                $Response.Errors.Length | Should -Be 0
+                $Response.NXDomain | Should -Be $true
+            }
+
+            It "Reports errors correctly" {
+                # Test where Resolve-DnsName throws an exception. Should try twice then report the error
+                Mock -CommandName Resolve-DnsName { throw "Some error" }
+                $Response = Invoke-TraditionalDns -Qname "example.com" -MaxTries 2
+                Should -Invoke -CommandName Resolve-DnsName -Exactly -Times 2
+                $Response.Answers.Length | Should -Be 0
+                $Response.Errors.Length | Should -Be 2
+                $Response.NXDomain | Should -Be $false
+            }
+
+            It "Handles empty answer correctly" {
+                # Test where Resolve-DnsName doesn't throw an exception but also doesn't return an answer.
+                # For example, in some cases where the answer can't be using the local resolver but trying
+                # over a public resolve will reveal the answer.
+                Mock -CommandName Resolve-DnsName { @(
+                    @{
+                        "Strings" = @("");
+                        "Section" = "Authority"
+                    }
+                    )
+                }
+                $Response = Invoke-TraditionalDns -Qname "example.com" -MaxTries 2
+                Should -Invoke -CommandName Resolve-DnsName -Exactly -Times 1
+                $Response.Answers.Length | Should -Be 0
+                $Response.Errors.Length | Should -Be 0
+                $Response.NXDomain | Should -Be $false
+            }
+        }
+    }
+}
+AfterAll {
+    Remove-Module ExportEXOProvider -Force -ErrorAction SilentlyContinue
+}

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/EXO/EXOBaseConfig.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/EXO/EXOBaseConfig.rego
@@ -6,10 +6,9 @@ RemoteDomains := {
     "DomainName": "example.com"
 }
 SpfRecords := {
-    "rdata": [
-        "v=spf1 -all"
-    ],
-    "domain": "Test name"
+    "domain": "test.name",
+    "compliant": true,
+    "message": "SPF record found."
 }
 DkimConfig := {
     "Enabled": true,

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/EXO/EXOConfig_02_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/EXO/EXOConfig_02_test.rego
@@ -32,7 +32,7 @@ test_Spf_Incorrect_V1 if {
         "</li>",
         "</ul>"
     ])
-    TestResult("MS.EXO.2.2v2", Output, concat(". ", [ReportDetailString, DNSLink]), false) == true
+    TestResult("MS.EXO.2.2v2", RuleOutput, concat(". ", [ReportDetailString, DNSLink]), false) == true
 }
 
 test_Spf_Incorrect_V2 if {
@@ -56,7 +56,7 @@ test_Spf_Incorrect_V2 if {
     ])
 
     Output := exo.tests with input.spf_records as [Record1, Record2, Record3]
-
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == "MS.EXO.2.2v2"]
     ReportDetailString := concat("", [
         "2 failing domain(s):<ul>",
         "<li>bad1.com: ",
@@ -67,6 +67,6 @@ test_Spf_Incorrect_V2 if {
         "</li>",
         "</ul>"
     ])
-    TestResult("MS.EXO.2.2v2", Output, concat(". ", [ReportDetailString, DNSLink]), false) == true
+    TestResult("MS.EXO.2.2v2", RuleOutput, concat(". ", [ReportDetailString, DNSLink]), false) == true
 }
 #--

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/EXO/EXOConfig_02_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/EXO/EXOConfig_02_test.rego
@@ -2,7 +2,6 @@ package exo_test
 import rego.v1
 import data.exo
 import data.utils.key.TestResult
-import data.utils.key.TestResultContains
 import data.utils.key.PASS
 import data.exo.DNSLink
 

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/EXO/EXOConfig_03_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/EXO/EXOConfig_03_test.rego
@@ -3,7 +3,7 @@ import rego.v1
 import data.exo
 import data.utils.key.TestResult
 import data.utils.key.PASS
-
+import data.exo.DNSLink
 
 #
 # Policy MS.EXO.3.1v1
@@ -15,12 +15,12 @@ test_Enabled_Correct_V1 if {
                         with input.dkim_config as [DkimConfig]
                         with input.dkim_records as [DkimRecords]
 
-    TestResult("MS.EXO.3.1v1", Output, PASS, true) == true
+    TestResult("MS.EXO.3.1v1", Output, concat(". ", [PASS, DNSLink]), true) == true
 }
 
 # Test with correct default domain
 test_Enabled_Correct_V2 if {
-    
+
     DkimConfig1 := json.patch(DkimConfig, [{"op": "add", "path": "Domain", "value": "example.onmicrosoft.com"}])
     DkimRecord1 := json.patch(DkimRecords, [{"op": "add", "path": "domain", "value": "example.onmicrosoft.com"}])
     SPFRecord := json.patch(SpfRecords, [{"op": "add", "path": "rdata", "value": ["spf1 "]},
@@ -32,14 +32,14 @@ test_Enabled_Correct_V2 if {
                         with input.dkim_config as [DkimConfig, DkimConfig1]
                         with input.dkim_records as [DkimRecords, DkimRecord1]
 
-    TestResult("MS.EXO.3.1v1", Output, PASS, true) == true
+    TestResult("MS.EXO.3.1v1", Output, concat(". ", [PASS, DNSLink]), true) == true
 }
 
 # Test for multiple custom domains
 test_Enabled_Correct_V3 if {
     DkimConfig1 := json.patch(DkimConfig, [{"op": "add", "path": "Domain", "value": "test2.name"}])
     DkimRecord1 := json.patch(DkimRecords, [{"op": "add", "path": "domain", "value": "test2.name"}])
-    
+
     SPFRecord := json.patch(SpfRecords, [{"op": "add", "path": "rdata", "value": ["spf1 "]},
                                         {"op": "add", "path": "domain", "value": "test.name"}])
     SPFRecord1 := json.patch(SpfRecords, [{"op": "add", "path": "rdata", "value": ["spf1 "]},
@@ -49,7 +49,7 @@ test_Enabled_Correct_V3 if {
                         with input.dkim_records as [DkimRecords, DkimRecord1]
 
 
-    TestResult("MS.EXO.3.1v1", Output, PASS, true) == true
+    TestResult("MS.EXO.3.1v1", Output, concat(". ", [PASS, DNSLink]), true) == true
 }
 
 # Test for no custom domains, just the default domain
@@ -64,7 +64,7 @@ test_Enabled_Correct_V4 if {
                         with input.dkim_records as [DkimRecord1]
 
 
-    TestResult("MS.EXO.3.1v1", Output, PASS, true) == true
+    TestResult("MS.EXO.3.1v1", Output, concat(". ", [PASS, DNSLink]), true) == true
 }
 
 test_Enabled_Incorrect if {
@@ -78,7 +78,7 @@ test_Enabled_Incorrect if {
 
 
     ReportDetailString := "1 agency domain(s) found in violation: test.name"
-    TestResult("MS.EXO.3.1v1", Output, ReportDetailString, false) == true
+    TestResult("MS.EXO.3.1v1", Output, concat(". ", [ReportDetailString, DNSLink]), false) == true
 }
 
 test_Rdata_Incorrect_V1 if {
@@ -91,7 +91,7 @@ test_Rdata_Incorrect_V1 if {
                         with input.dkim_records as [DkimRecord1]
 
     ReportDetailString := "1 agency domain(s) found in violation: test.name"
-    TestResult("MS.EXO.3.1v1", Output, ReportDetailString, false) == true
+    TestResult("MS.EXO.3.1v1", Output, concat(". ", [ReportDetailString, DNSLink]), false) == true
 }
 
 test_Rdata_Incorrect_V2 if {
@@ -104,7 +104,7 @@ test_Rdata_Incorrect_V2 if {
                         with input.dkim_records as [DkimRecord1]
 
     ReportDetailString := "1 agency domain(s) found in violation: test.name"
-    TestResult("MS.EXO.3.1v1", Output, ReportDetailString, false) == true
+    TestResult("MS.EXO.3.1v1", Output, concat(". ", [ReportDetailString, DNSLink]), false) == true
 }
 
 test_Enabled_Incorrect_V3 if {
@@ -122,7 +122,7 @@ test_Enabled_Incorrect_V3 if {
 
 
     ReportDetailString := "1 agency domain(s) found in violation: test2.name"
-    TestResult("MS.EXO.3.1v1", Output, ReportDetailString, false) == true
+    TestResult("MS.EXO.3.1v1", Output, concat(". ", [ReportDetailString, DNSLink]), false) == true
 }
 
 # Test with incorrect default domain
@@ -141,6 +141,6 @@ test_Enabled_Incorrect_V4 if {
                         with input.dkim_records as [DkimRecords, DkimRecord1]
 
     ReportDetailString := "1 agency domain(s) found in violation: example.onmicrosoft.com"
-    TestResult("MS.EXO.3.1v1", Output, ReportDetailString, false) == true
+    TestResult("MS.EXO.3.1v1", Output, concat(". ", [ReportDetailString, DNSLink]), false) == true
 }
 #--

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/EXO/EXOConfig_04_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/EXO/EXOConfig_04_test.rego
@@ -3,7 +3,7 @@ import rego.v1
 import data.exo
 import data.utils.key.TestResult
 import data.utils.key.PASS
-
+import data.exo.DNSLink
 
 #
 # Policy MS.EXO.4.1v1
@@ -15,7 +15,7 @@ test_Rdata_Correct if {
     Output := exo.tests with input.spf_records as [SPFRecord]
                         with input.dmarc_records as [DmarcRecords]
 
-    TestResult("MS.EXO.4.1v1", Output, PASS, true) == true
+    TestResult("MS.EXO.4.1v1", Output, concat(". ", [PASS, DNSLink]), true) == true
 }
 
 test_Rdata_Incorrect_V1 if {
@@ -27,7 +27,7 @@ test_Rdata_Incorrect_V1 if {
                         with input.dmarc_records as [DmarcRecord1]
 
     ReportDetailStr := "1 agency domain(s) found in violation: test.name"
-    TestResult("MS.EXO.4.1v1", Output, ReportDetailStr, false) == true
+    TestResult("MS.EXO.4.1v1", Output, concat(". ", [ReportDetailStr, DNSLink]), false) == true
 }
 
 test_Rdata_Incorrect_V2 if {
@@ -39,7 +39,7 @@ test_Rdata_Incorrect_V2 if {
                         with input.dmarc_records as [DmarcRecord1]
 
     ReportDetailStr := "1 agency domain(s) found in violation: test.name"
-    TestResult("MS.EXO.4.1v1", Output, ReportDetailStr, false) == true
+    TestResult("MS.EXO.4.1v1", Output, concat(". ", [ReportDetailStr, DNSLink]), false) == true
 }
 
 test_Rdata_Incorrect_V3 if {
@@ -47,16 +47,16 @@ test_Rdata_Incorrect_V3 if {
                                         {"op": "add", "path": "domain", "value": "test.name"}])
     SPFRecord1 := json.patch(SpfRecords, [{"op": "add", "path": "rdata", "value": ["spf1 "]},
                                         {"op": "add", "path": "domain", "value": "bad.name"}])
- 
+
     DmarcRecord1 := json.patch(DmarcRecords, [{"op": "add", "path": "rdata", "value": ["v=DMARC1"]},
                                                 {"op": "add", "path": "domain", "value": "bad.name"}])
-    
+
     Output := exo.tests with input.spf_records as [SPFRecord, SPFRecord1]
                         with input.dmarc_records as [DmarcRecords, DmarcRecord1]
 
 
     ReportDetailStr := "1 agency domain(s) found in violation: bad.name"
-    TestResult("MS.EXO.4.1v1", Output, ReportDetailStr, false) == true
+    TestResult("MS.EXO.4.1v1", Output, concat(". ", [ReportDetailStr, DNSLink]), false) == true
 }
 #--
 
@@ -70,7 +70,7 @@ test_Rdata_Correct_V2 if {
     Output := exo.tests with input.spf_records as [SPFRecord]
                         with input.dmarc_records as [DmarcRecords]
 
-    TestResult("MS.EXO.4.2v1", Output, PASS, true) == true
+    TestResult("MS.EXO.4.2v1", Output, concat(". ", [PASS, DNSLink]), true) == true
 }
 
 test_Rdata_Incorrect_V4 if {
@@ -89,7 +89,7 @@ test_Rdata_Incorrect_V4 if {
                         with input.dmarc_records as [DmarcRecord1]
 
     ReportDetailStr := "1 agency domain(s) found in violation: test.name"
-    TestResult("MS.EXO.4.2v1", Output, ReportDetailStr, false) == true
+    TestResult("MS.EXO.4.2v1", Output, concat(". ", [ReportDetailStr, DNSLink]), false) == true
 }
 
 test_Rdata_Incorrect_V5 if {
@@ -103,7 +103,7 @@ test_Rdata_Incorrect_V5 if {
                         with input.dmarc_records as [DmarcRecord1]
 
     ReportDetailStr := "1 agency domain(s) found in violation: test.name"
-    TestResult("MS.EXO.4.2v1", Output, ReportDetailStr, false) == true
+    TestResult("MS.EXO.4.2v1", Output, concat(". ", [ReportDetailStr, DNSLink]), false) == true
 }
 #--
 
@@ -118,7 +118,7 @@ test_DMARCReport_Correct_V1 if {
                         with input.dmarc_records as [DmarcRecords]
 
 
-    TestResult("MS.EXO.4.3v1", Output, PASS, true) == true
+    TestResult("MS.EXO.4.3v1", Output, concat(". ", [PASS, DNSLink]), true) == true
 }
 
 test_DMARCReport_Incorrect_V1 if {
@@ -132,7 +132,7 @@ test_DMARCReport_Incorrect_V1 if {
                         with input.dmarc_records as [DmarcRecord1]
 
     ReportDetailStr := "1 agency domain(s) found in violation: test.name"
-    TestResult("MS.EXO.4.3v1", Output, ReportDetailStr, false) == true
+    TestResult("MS.EXO.4.3v1", Output, concat(". ", [ReportDetailStr, DNSLink]), false) == true
 }
 
 test_DMARCReport_Incorrect_V2 if {
@@ -146,7 +146,7 @@ test_DMARCReport_Incorrect_V2 if {
                         with input.dmarc_records as [DmarcRecord1]
 
     ReportDetailStr := "1 agency domain(s) found in violation: test.name"
-    TestResult("MS.EXO.4.3v1", Output, ReportDetailStr, false) == true
+    TestResult("MS.EXO.4.3v1", Output, concat(". ", [ReportDetailStr, DNSLink]), false) == true
 }
 
 # empty rdata
@@ -159,7 +159,7 @@ test_DMARCReport_Incorrect_V3 if {
                         with input.dmarc_records as [DmarcRecord1]
 
     ReportDetailStr := "1 agency domain(s) found in violation: test.name"
-    TestResult("MS.EXO.4.3v1", Output, ReportDetailStr, false) == true
+    TestResult("MS.EXO.4.3v1", Output, concat(". ", [ReportDetailStr, DNSLink]), false) == true
 }
 #--
 
@@ -172,14 +172,14 @@ test_POC_Correct_V1 if {
     SPFRecord := json.patch(SpfRecords, [{"op": "add", "path": "rdata", "value": ["spf1 "]},
                                         {"op": "add", "path": "domain", "value": "test.name"}])
     DmarcRecord1 := json.patch(DmarcRecords, [{
-        "op": "add", "path": "rdata", 
-        "value": [`v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, 
+        "op": "add", "path": "rdata",
+        "value": [`v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov,
         mailto:reports@dmarc.cyber.dhs.gov; ruf=agencyemail@hq.dhs.gov`]}])
 
     Output := exo.tests with input.spf_records as [SPFRecord]
                         with input.dmarc_records as [DmarcRecord1]
 
-    TestResult("MS.EXO.4.4v1", Output, PASS, true) == true
+    TestResult("MS.EXO.4.4v1", Output, concat(". ", [PASS, DNSLink]), true) == true
 }
 
 # 2+ emails in rua= and 1+ in ruf
@@ -187,15 +187,15 @@ test_POC_Correct_V2 if {
     SPFRecord := json.patch(SpfRecords, [{"op": "add", "path": "rdata", "value": ["spf1 "]},
                                         {"op": "add", "path": "domain", "value": "test.name"}])
     DmarcRecord1 := json.patch(DmarcRecords, [
-        {"op": "add", "path": "rdata", 
-        "value": [`v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, 
-        mailto:reports@dmarc.cyber.dhs.gov, 
+        {"op": "add", "path": "rdata",
+        "value": [`v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov,
+        mailto:reports@dmarc.cyber.dhs.gov,
         mailto:test@example.com; ruf=agencyemail@hq.dhs.gov, test@test.com`]}])
 
     Output := exo.tests with input.spf_records as [SPFRecord]
                         with input.dmarc_records as [DmarcRecord1]
 
-    TestResult("MS.EXO.4.4v1", Output, PASS, true) == true
+    TestResult("MS.EXO.4.4v1", Output, concat(". ", [PASS, DNSLink]), true) == true
 }
 
 # Only 1 rua
@@ -203,14 +203,14 @@ test_POC_Incorrect_V1 if {
     SPFRecord := json.patch(SpfRecords, [{"op": "add", "path": "rdata", "value": ["spf1 "]},
                                         {"op": "add", "path": "domain", "value": "test.name"}])
     DmarcRecord1 := json.patch(DmarcRecords, [
-        {"op": "add", "path": "rdata", 
+        {"op": "add", "path": "rdata",
         "value": ["v=DMARC1; p=reject; pct=100; rua=mailto:reports@dmarc.cyber.dhs.gov"]}])
 
     Output := exo.tests with input.spf_records as [SPFRecord]
-                        with input.dmarc_records as [DmarcRecord1] 
+                        with input.dmarc_records as [DmarcRecord1]
 
     ReportDetailStr := "1 agency domain(s) found in violation: test.name"
-    TestResult("MS.EXO.4.4v1", Output, ReportDetailStr, false) == true
+    TestResult("MS.EXO.4.4v1", Output, concat(". ", [ReportDetailStr, DNSLink]), false) == true
 }
 
 # Only 2 emails in rua no ruf
@@ -218,29 +218,29 @@ test_POC_Incorrect_V2 if {
     SPFRecord := json.patch(SpfRecords, [{"op": "add", "path": "rdata", "value": ["spf1 "]},
                                         {"op": "add", "path": "domain", "value": "test.name"}])
     DmarcRecord1 := json.patch(DmarcRecords, [
-        {"op": "add", "path": "rdata", 
-        "value": [`v=DMARC1; p=reject; pct=100; 
+        {"op": "add", "path": "rdata",
+        "value": [`v=DMARC1; p=reject; pct=100;
         rua=mailto:reports@dmarc.cyber.dhs.gov, test@exo.com`]}])
 
     Output := exo.tests with input.spf_records as [SPFRecord]
-                        with input.dmarc_records as [DmarcRecord1] 
+                        with input.dmarc_records as [DmarcRecord1]
 
     ReportDetailStr := "1 agency domain(s) found in violation: test.name"
-    TestResult("MS.EXO.4.4v1", Output, ReportDetailStr, false) == true
+    TestResult("MS.EXO.4.4v1", Output, concat(". ", [ReportDetailStr, DNSLink]), false) == true
 }
 
 # Only 1 ruf no rua
 test_POC_Incorrect_V3 if {
     SPFRecord := json.patch(SpfRecords, [{"op": "add", "path": "rdata", "value": ["spf1 "]},
                                         {"op": "add", "path": "domain", "value": "test.name"}])
-    DmarcRecord1 := json.patch(DmarcRecords, [{"op": "add", "path": "rdata", "value": 
+    DmarcRecord1 := json.patch(DmarcRecords, [{"op": "add", "path": "rdata", "value":
                                                 ["v=DMARC1; p=reject; pct=100; rua=test@exo.com"]}])
 
     Output := exo.tests with input.spf_records as [SPFRecord]
                         with input.dmarc_records as [DmarcRecord1]
 
     ReportDetailStr := "1 agency domain(s) found in violation: test.name"
-    TestResult("MS.EXO.4.4v1", Output, ReportDetailStr, false) == true
+    TestResult("MS.EXO.4.4v1", Output, concat(". ", [ReportDetailStr, DNSLink]), false) == true
 }
 
 # 2 domains 1 fails rua/ruf number
@@ -249,12 +249,12 @@ test_POC_Incorrect_V4 if {
                                         {"op": "add", "path": "domain", "value": "test.name"}])
     SPFRecord1 := json.patch(SpfRecords, [{"op": "add", "path": "rdata", "value": ["spf1 "]},
                                         {"op": "add", "path": "domain", "value": "example.com"}])
-    DmarcRecord1 := json.patch(DmarcRecords, [{"op": "add", "path": "rdata", "value": 
-                                                [`v=DMARC1; p=reject; pct=100; 
-                                                rua=mailto:reports@dmarc.cyber.dhs.gov, 
+    DmarcRecord1 := json.patch(DmarcRecords, [{"op": "add", "path": "rdata", "value":
+                                                [`v=DMARC1; p=reject; pct=100;
+                                                rua=mailto:reports@dmarc.cyber.dhs.gov,
                                                 test@test.name ruf=test2@test.name`]}])
-    DmarcRecord2 := json.patch(DmarcRecords, [{"op": "add", "path": "rdata", "value": 
-                                                [`v=DMARC1; p=reject; pct=100; 
+    DmarcRecord2 := json.patch(DmarcRecords, [{"op": "add", "path": "rdata", "value":
+                                                [`v=DMARC1; p=reject; pct=100;
                                                 rua=mailto:reports@dmarc.cyber.dhs.gov`]},
                                             {"op": "add", "path": "domain", "value": "example.com"}])
 
@@ -262,7 +262,7 @@ test_POC_Incorrect_V4 if {
                         with input.dmarc_records as [DmarcRecord1, DmarcRecord2]
 
     ReportDetailStr := "1 agency domain(s) found in violation: example.com"
-    TestResult("MS.EXO.4.4v1", Output, ReportDetailStr, false) == true
+    TestResult("MS.EXO.4.4v1", Output, concat(". ", [ReportDetailStr, DNSLink]), false) == true
 }
 
 # 2 domains 1 fails rua # of email policy requirement
@@ -271,12 +271,12 @@ test_POC_Incorrect_V5 if {
                                         {"op": "add", "path": "domain", "value": "test.name"}])
     SPFRecord1 := json.patch(SpfRecords, [{"op": "add", "path": "rdata", "value": ["spf1 "]},
                                         {"op": "add", "path": "domain", "value": "example.com"}])
-    DmarcRecord1 := json.patch(DmarcRecords, [{"op": "add", "path": "rdata", "value": 
-                                                [`v=DMARC1; p=reject; pct=100; 
-                                                rua=mailto:reports@dmarc.cyber.dhs.gov, 
+    DmarcRecord1 := json.patch(DmarcRecords, [{"op": "add", "path": "rdata", "value":
+                                                [`v=DMARC1; p=reject; pct=100;
+                                                rua=mailto:reports@dmarc.cyber.dhs.gov,
                                                 test@test.name ruf=test2@test.name`]}])
-    DmarcRecord2 := json.patch(DmarcRecords, [{"op": "add", "path": "rdata", "value": 
-                                                [`v=DMARC1; p=reject; pct=100; 
+    DmarcRecord2 := json.patch(DmarcRecords, [{"op": "add", "path": "rdata", "value":
+                                                [`v=DMARC1; p=reject; pct=100;
                                                 rua=mailto:reports@dmarc.cyber.dhs.gov; ruf=test@exo.com`]},
                                             {"op": "add", "path": "domain", "value": "example.com"}])
 
@@ -284,7 +284,7 @@ test_POC_Incorrect_V5 if {
                         with input.dmarc_records as [DmarcRecord1, DmarcRecord2]
 
     ReportDetailStr := "1 agency domain(s) found in violation: example.com"
-    TestResult("MS.EXO.4.4v1", Output, ReportDetailStr, false) == true
+    TestResult("MS.EXO.4.4v1", Output, concat(". ", [ReportDetailStr, DNSLink]), false) == true
 }
 
 # 2 domains 1 domain failed DNS query. Empty rdata
@@ -293,17 +293,17 @@ test_POC_Incorrect_V6 if {
                                         {"op": "add", "path": "domain", "value": "test.name"}])
     SPFRecord1 := json.patch(SpfRecords, [{"op": "add", "path": "rdata", "value": ["spf1 "]},
                                         {"op": "add", "path": "domain", "value": "example.com"}])
-    DmarcRecord1 := json.patch(DmarcRecords, [{"op": "add", "path": "rdata", "value": 
-                                                [`v=DMARC1; p=reject; pct=100; 
-                                                rua=mailto:reports@dmarc.cyber.dhs.gov, 
+    DmarcRecord1 := json.patch(DmarcRecords, [{"op": "add", "path": "rdata", "value":
+                                                [`v=DMARC1; p=reject; pct=100;
+                                                rua=mailto:reports@dmarc.cyber.dhs.gov,
                                                 test@test.name ruf=test2@test.name`]}])
     DmarcRecord2 := json.patch(DmarcRecords, [{"op": "add", "path": "rdata", "value": []},
                                         {"op": "add", "path": "domain", "value": "example.com"}])
-    
+
     Output := exo.tests with input.spf_records as [SPFRecord, SPFRecord1]
                         with input.dmarc_records as [DmarcRecord1, DmarcRecord2]
 
     ReportDetailStr := "1 agency domain(s) found in violation: example.com"
-    TestResult("MS.EXO.4.4v1", Output, ReportDetailStr, false) == true
+    TestResult("MS.EXO.4.4v1", Output, concat(". ", [ReportDetailStr, DNSLink]), false) == true
 }
 #--


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##
- Corrected various DNS-related bugs
- Abandoned old error complicated handling method that involved tracking if an answer was "high confidence"
- Split up old unwieldy `Invoke-RobustDnsTxt` function into 3 functions. 
- Don't print warning on empty answer. Warning was confusing and not very helpful. Instead, added table with all DNS logs at the end of EXO report. That way users can see exactly how ScubaGear reached it's conclusions and identify any unexpected results themselves (e.g., due to split horizon).

The DNS log table may be a good place to point users to the DNS configuration options (#1533) once we implement that.

## 💭 Motivation and context ##
Closes #1479.
Closes #1510.
Closes #1357.
Closes #1148.
Closes #994.
Closes #1534.

## 🧪 Testing ##
- Updated and added new unit tests
- Manually tested against both E5 and G5
- Temporarily modified the `Get-ScubaSpfRecord` function to add some edge cases
![image](https://github.com/user-attachments/assets/3c4f9b02-4640-407e-8929-93a81cb51a9b)


## 📷 Screenshots ##
![image](https://github.com/user-attachments/assets/212f1aca-f8fe-4aa5-9a06-24bcceb76504)

![image](https://github.com/user-attachments/assets/7f7f96de-8af4-436f-9ec6-529665962c49)




## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] PR passed smoke test check.
- [ ] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [ ] Resolved all merge conflicts on branch
- [ ] Notified merge coordinator that PR is ready for merge via comment mention
- [ ] Demonstrate changes to the team for questions and comments. 
    (Note: Only required for issues of size `Medium` or larger)

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
