### PR TITLE
Remove Get-TenantDetailsFromGraph commandlet due to Azure AD Graph deprecation

### DIFF
--- a/PowerShell/ScubaGear/Modules/Connection/Connection.psm1
+++ b/PowerShell/ScubaGear/Modules/Connection/Connection.psm1
@@ -106,6 +106,18 @@ function Connect-Tenant {
                        }
                    }
                    Add-PowerAppsAccount @AddPowerAppsParams | Out-Null
+
+                   if ($AADAuthRequired) {
+                        $LimitedGraphParams = @{
+                            'M365Environment' = $M365Environment;
+                            'ErrorAction' = 'Stop';
+                        }
+                        if ($ServicePrincipalParams) {
+                            $LimitedGraphParams += @{ServicePrincipalParams = $ServicePrincipalParams }
+                        }
+                        Connect-GraphHelper @LimitedGraphParams
+                        $AADAuthRequired = $false
+                    }
                }
                "sharepoint" {
                    if ($AADAuthRequired) {

--- a/PowerShell/ScubaGear/Modules/Providers/ExportPowerPlatformProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportPowerPlatformProvider.psm1
@@ -1,3 +1,5 @@
+Import-Module -Name $PSScriptRoot/../Utility/Utility.psm1 -Function Invoke-GraphDirectly, ConvertFrom-GraphHashtable
+
 function Export-PowerPlatformProvider {
     <#
     .Description
@@ -24,114 +26,11 @@ function Export-PowerPlatformProvider {
     # There are conflicting PowerShell Cmdlet names in EXO and Power Platform
     Import-Module Microsoft.PowerApps.Administration.PowerShell -DisableNameChecking
 
+    $TenantDetails = $Tracker.TryCommand("Get-MgBetaOrganization", @{"M365Environment"=$M365Environment; "GraphDirect"=$true})
+    $TenantId = if ($TenantDetails.Id) { $TenantDetails.Id } else { "" }
 
-    #$TenantDetails = $Tracker.TryCommand("Get-TenantDetailsFromGraph")
-    #$TenantDetails = Get-MgBetaOrganization -ErrorAction "Stop"
-    $TenantDetails = ConvertTo-Json @($Tracker.TryCommand("Get-MgBetaOrganization"), @{ "GraphDirect"=$true })
-    if ($TenantDetails.Id) {
-        $TenantID = $TenantDetails.Id
-    }
-    else {
-        $TenantID = ""
-    }
-
-    # Check if M365Enviromment is set correctly
-    $TenantIdConfig = ""
-    try {
-        $Domains = $TenantDetails.VerifiedDomains
-        $TenantDomain = "Unretrievable"
-        $TLD = ".com"
-        if (($M365Environment -eq "gcchigh") -or ($M365Environment -eq "dod")) {
-            $TLD = ".us"
-        }
-        foreach ($Domain in $Domains) {
-            $Name = $Domain.Name
-            $IsInitial = $Domain.IsInitial
-            $DomainChecker = $Name.EndsWith(".onmicrosoft$($TLD)") -and !$Name.EndsWith(".mail.onmicrosoft$($TLD)") -and $IsInitial
-            if ($DomainChecker){
-                $TenantDomain = $Name
-            }
-        }
-        $Uri = "https://login.microsoftonline$($TLD)/$($TenantDomain)/.well-known/openid-configuration"
-        $TenantIdConfig = (Invoke-WebRequest -Uri $Uri -UseBasicParsing -ErrorAction "Stop").Content
-    }
-    catch {
-        $EnvCheckWarning = @"
-    Power Platform Provider Warning: $($_). Unable to check if M365Environment is set correctly in the Power Platform Provider. This MAY impact the output of the Power Platform Baseline report.
-    See the 'Running the Script Behind Some Proxies' in the README.md for a possible solution to this warning.
-"@
-        Write-Warning $EnvCheckWarning
-    }
-
-    # Commercial: "tenant_region_scope":"NA"
-    # GCC: "tenant_region_scope":"NA","tenant_region_sub_scope":"GCC",
-    # GCCHigh: "tenant_region_scope":"USGov","tenant_region_sub_scope":"DODCON"
-    # DoD: "tenant_region_scope":"USGov","tenant_region_sub_scope":"DOD"
-    try {
-        if ($TenantIdConfig -ne "") {
-            $TenantIdConfigJson = ConvertFrom-Json $TenantIdConfig
-            $RegionScope = $TenantIdConfigJson.tenant_region_scope
-            $RegionSubScope = $TenantIdConfigJson.tenant_region_sub_scope
-            if (-not $RegionSubScope) {
-                $RegionSubScope = ""
-            }
-
-            $CheckRScope = $true
-            $CheckRSubScope = $true
-            if ($RegionScope -eq "NA" -or $RegionScope -eq "USGov" -or $RegionScope -eq "USG") {
-                switch ($M365Environment) {
-                    "commercial" {
-                        $CheckRScope = $RegionScope -eq "NA"
-                        $CheckRSubScope = $RegionSubScope -eq ""
-                    }
-                    "gcc" {
-                        $CheckRScope = $RegionScope -eq "NA"
-                        $CheckRSubScope = $RegionSubScope -eq "GCC"
-                    }
-                    "gcchigh" {
-                        $CheckRScope = $RegionScope -eq "USGov" -or $RegionScope -eq "USG"
-                        $CheckRSubScope = $RegionSubScope -eq "DODCON"
-                    }
-                    "dod" {
-                        $CheckRScope = $RegionScope -eq "USGov" -or $RegionScope -eq "USG"
-                        $CheckRSubScope = $RegionSubScope -eq "DOD"
-                    }
-                    default {
-                        throw "Unsupported or invalid M365Environment argument"
-                    }
-                }
-            }
-            # spacing is intentional
-            $EnvErrorMessage = @"
-"Power Platform Provider ERROR: The M365Environment parameter value is not set correctly which WILL cause the Power Platform report to display incorrect values.
-            ---------------------------------------
-            M365Environment Parameter value: $($M365Environment)
-            Your tenant's OpenId-Configuration: tenant_region_scope: $($RegionScope), tenant_region_sub_scope: $($RegionSubScope)
-"@
-            if (-not ($CheckRScope -and $CheckRSubScope)) {
-                throw $EnvErrorMessage
-            }
-        }
-    }
-    catch {
-
-        $FullEnvErrorMessage = @"
-$($_)
-        ---------------------------------------
-        Rerun ScubaGear with the correct M365Environment parameter value
-        by looking at your tenant's OpenId-Configuration displayed above and
-        contrast it with the mapped values in the table below
-        M365Enviroment => OpenId-Configuration
-        ---------------------------------------
-        commercial: tenant_region_scope:NA, tenant_region_sub_scope:
-        gcc: tenant_region_scope:NA, tenant_region_sub_scope: GCC
-        gcchigh : tenant_region_scope:USGov, tenant_region_sub_scope: DODCON
-        dod: tenant_region_scope:USGov, tenant_region_sub_scope: DOD
-        ---------------------------------------
-        Example Rerun for gcc tenants: Invoke-Scuba -M365Environment gcc
-"@
-        throw $FullEnvErrorMessage
-    }
+    $DomainInfo = Get-TenantDomainInfo -TenantDetails $TenantDetails -M365Environment $M365Environment
+    Test-M365EnvironmentConfiguration -TenantDomain $DomainInfo.TenantDomain -TLD $DomainInfo.TLD -M365Environment $M365Environment
 
     # MS.POWERPLATFORM.1.1v1, MS.POWERPLATFORM.1.2v1, MS.POWERPLATFORM.5.1v1
     $EnvironmentCreation = ConvertTo-Json @($Tracker.TryCommand("Get-TenantSettings"))
@@ -209,6 +108,141 @@ $($_)
     $json
 }
 
+function Get-TenantDomainInfo {
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [object]$TenantDetails,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $M365Environment
+    )
+
+    $TenantDomain = "Unretrievable"
+    $TLD = ".com"
+    if (($M365Environment -eq "gcchigh") -or ($M365Environment -eq "dod")) {
+        $TLD = ".us"
+    }
+
+    foreach ($Domain in $TenantDetails.VerifiedDomains) {
+        $Name = $Domain.Name
+        $IsInitial = $Domain.IsInitial
+        $DomainChecker = $Name.EndsWith(".onmicrosoft$($TLD)") -and !$Name.EndsWith(".mail.onmicrosoft$($TLD)") -and $IsInitial
+        if ($DomainChecker){
+            $TenantDomain = $Name
+        }
+    }
+
+    return @{
+        TenantDomain = $TenantDomain;
+        TLD = $TLD;
+    }
+}
+
+function Test-M365EnvironmentConfiguration {
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$TenantDomain,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$TLD,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $M365Environment
+    )
+
+    $TenantIdConfig = ""
+    try {
+        $Uri = "https://login.microsoftonline$($TLD)/$($TenantDomain)/.well-known/openid-configuration"
+        $TenantIdConfig = (Invoke-WebRequest -Uri $Uri -UseBasicParsing -ErrorAction "Stop").Content
+    }
+    catch {
+        $EnvCheckWarning = @"
+    Power Platform Provider Warning: $($_). Unable to check if M365Environment is set correctly in the Power Platform Provider. This MAY impact the output of the Power Platform Baseline report.
+    See the 'Running the Script Behind Some Proxies' in the README.md for a possible solution to this warning.
+"@
+        Write-Warning $EnvCheckWarning
+    }
+
+    # Commercial: "tenant_region_scope":"NA"
+    # GCC: "tenant_region_scope":"NA","tenant_region_sub_scope":"GCC",
+    # GCCHigh: "tenant_region_scope":"USGov","tenant_region_sub_scope":"DODCON"
+    # DoD: "tenant_region_scope":"USGov","tenant_region_sub_scope":"DOD"
+    try {
+        if ($TenantIdConfig -ne "") {
+            $TenantIdConfigJson = ConvertFrom-Json $TenantIdConfig
+            $RegionScope = $TenantIdConfigJson.tenant_region_scope
+            $RegionSubScope = $TenantIdConfigJson.tenant_region_sub_scope
+            if (-not $RegionSubScope) {
+                $RegionSubScope = ""
+            }
+
+            $CheckRScope = $true
+            $CheckRSubScope = $true
+            if ($RegionScope -eq "NA" -or $RegionScope -eq "USGov" -or $RegionScope -eq "USG") {
+                switch ($M365Environment) {
+                    "commercial" {
+                        $CheckRScope = $RegionScope -eq "NA"
+                        $CheckRSubScope = $RegionSubScope -eq ""
+                    }
+                    "gcc" {
+                        $CheckRScope = $RegionScope -eq "NA"
+                        $CheckRSubScope = $RegionSubScope -eq "GCC"
+                    }
+                    "gcchigh" {
+                        $CheckRScope = $RegionScope -eq "USGov" -or $RegionScope -eq "USG"
+                        $CheckRSubScope = $RegionSubScope -eq "DODCON"
+                    }
+                    "dod" {
+                        $CheckRScope = $RegionScope -eq "USGov" -or $RegionScope -eq "USG"
+                        $CheckRSubScope = $RegionSubScope -eq "DOD"
+                    }
+                    default {
+                        throw "Unsupported or invalid M365Environment argument"
+                    }
+                }
+            }
+
+            # spacing is intentional
+            $EnvErrorMessage = @"
+"Power Platform Provider ERROR: The M365Environment parameter value is not set correctly which WILL cause the Power Platform report to display incorrect values.
+            ---------------------------------------
+            M365Environment Parameter value: $($M365Environment)
+            Your tenant's OpenId-Configuration: tenant_region_scope: $($RegionScope), tenant_region_sub_scope: $($RegionSubScope)
+"@
+
+        if (-not ($CheckRScope -and $CheckRSubScope)) {
+                throw $EnvErrorMessage
+            }
+        }
+    }
+    catch {
+
+        $FullEnvErrorMessage = @"
+$($_)
+        ---------------------------------------
+        Rerun ScubaGear with the correct M365Environment parameter value
+        by looking at your tenant's OpenId-Configuration displayed above and
+        contrast it with the mapped values in the table below
+        M365Enviroment => OpenId-Configuration
+        ---------------------------------------
+        commercial: tenant_region_scope:NA, tenant_region_sub_scope:
+        gcc: tenant_region_scope:NA, tenant_region_sub_scope: GCC
+        gcchigh : tenant_region_scope:USGov, tenant_region_sub_scope: DODCON
+        dod: tenant_region_scope:USGov, tenant_region_sub_scope: DOD
+        ---------------------------------------
+        Example Rerun for gcc tenants: Invoke-Scuba -M365Environment gcc
+"@
+        throw $FullEnvErrorMessage
+    }
+}
+
 function Get-PowerPlatformTenantDetail {
     <#
     .Description
@@ -227,30 +261,14 @@ function Get-PowerPlatformTenantDetail {
     Import-Module Microsoft.PowerApps.Administration.PowerShell -DisableNameChecking
 
     try {
-        #$PowerTenantDetails = Get-TenantDetailsFromGraph -ErrorAction "Stop"
-        #$PowerTenantDetails = Get-MgBetaOrganization -ErrorAction "Stop"
-        $PowerTenantDetails = (Invoke-GraphDirectly -Commandlet "Get-MgBetaOrganization" -M365Environment $M365Environment).Value
-
-        $Domains = $PowerTenantDetails.VerifiedDomains
-        $TenantDomain = "PowerPlatform: Domain Unretrievable"
-        $TLD = ".com"
-        if (($M365Environment -eq "gcchigh") -or ($M365Environment -eq "dod")) {
-            $TLD = ".us"
-        }
-        foreach ($Domain in $Domains) {
-            $Name = $Domain.Name
-            $IsInitial = $Domain.IsInitial
-            $DomainChecker = $Name.EndsWith(".onmicrosoft$($TLD)") -and !$Name.EndsWith(".mail.onmicrosoft$($TLD)") -and $IsInitial
-            if ($DomainChecker){
-                $TenantDomain = $Name
-            }
-        }
+        $TenantDetails = (Invoke-GraphDirectly -Commandlet "Get-MgBetaOrganization" -M365Environment $M365Environment).Value
+        $DomainInfo = Get-TenantDomainInfo -TenantDetails $TenantDetails -M365Environment $M365Environment
 
         $PowerTenantInfo = @{
-            "DisplayName" = $PowerTenantDetails.DisplayName;
-            "DomainName" = $TenantDomain;
-            "TenantId" = $PowerTenantDetails.TenantId
-            "PowerPlatformAdditionalData" = $PowerTenantDetails;
+            "DisplayName" = $TenantDetails.DisplayName;
+            "DomainName" = $DomainInfo.TenantDomain;
+            "TenantId" = $TenantDetails.TenantId;
+            "PowerPlatformAdditionalData" = $TenantDetails;
         }
         $PowerTenantInfo = ConvertTo-Json @($PowerTenantInfo) -Depth 4
         $PowerTenantInfo

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/PowerPlatformProvider/Export-PowerPlatformProvider.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/PowerPlatformProvider/Export-PowerPlatformProvider.Tests.ps1
@@ -36,6 +36,25 @@ InModuleScope -ModuleName ExportPowerPlatformProvider {
                                     TenantId    = "TenantId";
                                 }
                             }
+                            "Get-MgBetaOrganization" {
+                                $this.SuccessfulCommands += $Command
+                                return [pscustomobject]@{
+                                    DisplayName = "Test tenant name";
+                                    Id          = "00000000-0000-0000-0000-000000000000";
+                                    VerifiedDomains = @(
+                                        @{
+                                            IsInitial = $true;
+                                            IsDefault = $true;
+                                            Name      = "root.onmicrosoft.com";
+                                        },
+                                        @{
+                                            IsInitial = $false;
+                                            IsDefault = $false;
+                                            Name      = "managed.onmicrosoft.com";
+                                        }
+                                    );
+                                }
+                            }
                             "Get-TenantSettings" {
                                 $this.SuccessfulCommands += $Command
                                 return [pscustomobject]@{}


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

This PR switches the Get-TenantDetailsFromGraph commandlet to MS Graph's Get-MgBetaOrganization commandlet in the PowerPlatform provider. 

Resolves #1686 

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

We've received a couple public reports of the PowerPlatform baseline failing due to a 403 forbidden status code from the Get-TenantDetailsFromGraph commandlet. The issue was pinpointed to the commandlet using Azure AD Graph endpoints, which will deprecated on June 30, 2025.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Ran ScubaGear interactively and noninteractively against multiple environments: G3/G5, E5, GCC High. 

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [ ] All relevant repo and/or project documentation updated to reflect these changes.
- [ ] Unit tests added/updated to cover PowerShell and Rego changes.
- [ ] Functional tests added/updated to cover PowerShell and Rego changes.
- [ ] All relevant functional tests passed.
- [ ] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] PR passed smoke test check.
- [ ] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [ ] Resolved all merge conflicts on branch
- [ ] Notified merge coordinator that PR is ready for merge via comment mention
- [ ] Demonstrate changes to the team for questions and comments. 
    (Note: Only required for issues of size `Medium` or larger)

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
