### PR TITLE
Add capability to annotate controls

### DIFF
--- a/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
+++ b/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
@@ -100,7 +100,7 @@ function Add-Annotation {
         if ([string]::IsNullOrEmpty($UserComment)) {
             # Result marked incorrect, comment not provided
             Write-Warning "Config file marks the result for $($ControlId) as incorrect, but no justification provided."
-            $Details = "Test result marked incorrect by user. <span clafss='comment-heading'>User justification not provided</span>"
+            $Details = "Test result marked incorrect by user. <span class='comment-heading'>User justification not provided</span>"
         }
         else {
             # Result marked incorrect, comment provided

--- a/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
+++ b/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
@@ -260,7 +260,7 @@ function New-Report {
 
                 # If the user commented on a failed control, save the comment to the failed control to comment mapping
                 if ($Result.DisplayString -eq "Fail") {
-                    $UserComment = $Config.AnnotatePolicy.$ControlId.Comment
+                    $UserComment = $Config.AnnotatePolicy.$($Control.Id).Comment
                     $ReportSummary["AnnotatedFailedPolicies"][$Control.Id] = @{}
                     $ReportSummary["AnnotatedFailedPolicies"][$Control.Id].FalsePositive = $FalsePositive
                     $ReportSummary["AnnotatedFailedPolicies"][$Control.Id].Comment = $UserComment

--- a/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
+++ b/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
@@ -288,7 +288,7 @@ function New-Report {
                 }
 
                 # Handle incorrect result
-                if ($IncorrectResult -and ($Result.DisplayString -eq "Fail" -or $Result.DisplayString -eq "Warning")) {
+                if ($IncorrectResult -and ($Result.DisplayString -eq "Fail" -or $Result.DisplayString -eq "Warning" -or $Result.DisplayString -eq "Pass")) {
                     $ReportSummary.IncorrectResults += 1
                     $Fragment += [pscustomobject]@{
                         "Control ID"=$Control.Id

--- a/PowerShell/ScubaGear/Modules/CreateReport/scripts/main.js
+++ b/PowerShell/ScubaGear/Modules/CreateReport/scripts/main.js
@@ -28,8 +28,17 @@ const colorRows = () => {
             else if (rows[i].children[statusCol].innerHTML === "Omitted") {
                 rows[i].style.background = "var(--test-other)";
             }
-            else if (rows[i].children[statusCol].innerHTML === "False positive") {
-                rows[i].style.background = "var(--test-pass)";
+            else if (rows[i].children[statusCol].innerHTML === "Incorrect result") {
+                if (rows[i].children[criticalityCol].innerHTML === "Shall") {
+                    rows[i].style.background = "linear-gradient(to right, var(--test-fail), var(--test-pass))";
+                }
+                else if (rows[i].children[criticalityCol].innerHTML === "Should") {
+                    rows[i].style.background = "linear-gradient(to right, var(--test-warning), var(--test-pass))";
+                }
+                else {
+                    // This should never happen
+                    console.log(`Unexpected criticality for incorrect result, ${rows[i].children[criticalityCol].innerHTML}.`);
+                }
             }
             else if (rows[i].children[criticalityCol].innerHTML.includes("Not-Implemented")) {
                 rows[i].style.background = "var(--test-other)";

--- a/PowerShell/ScubaGear/Modules/CreateReport/scripts/main.js
+++ b/PowerShell/ScubaGear/Modules/CreateReport/scripts/main.js
@@ -28,6 +28,9 @@ const colorRows = () => {
             else if (rows[i].children[statusCol].innerHTML === "Omitted") {
                 rows[i].style.background = "var(--test-other)";
             }
+            else if (rows[i].children[statusCol].innerHTML === "False positive") {
+                rows[i].style.background = "var(--test-pass)";
+            }
             else if (rows[i].children[criticalityCol].innerHTML.includes("Not-Implemented")) {
                 rows[i].style.background = "var(--test-other)";
             }

--- a/PowerShell/ScubaGear/Modules/CreateReport/styles/ParentReportStyle.css
+++ b/PowerShell/ScubaGear/Modules/CreateReport/styles/ParentReportStyle.css
@@ -56,6 +56,7 @@ table.tenantdata tr:first-child {
 .failure { background-color: var(--test-fail); }
 .warning { background-color: var(--test-warning); }
 .pass { background-color: var(--test-pass); }
+.incorrect { background: linear-gradient(to right, var(--test-fail), var(--test-pass)) }
 .manual { background-color: var(--test-other); }
 .error {
     background-color: var(--test-fail);

--- a/PowerShell/ScubaGear/Modules/CreateReport/styles/main.css
+++ b/PowerShell/ScubaGear/Modules/CreateReport/styles/main.css
@@ -190,6 +190,12 @@ img {
     margin-top: 3.125em;
 }
 
+.comment-heading {
+    display: block;
+    font-style: italic;
+    margin-top: 10px;
+}
+
 #caps tr:nth-child(even), .alternating tr:nth-child(even) {
     background-color: var(--cap-even);
 }

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -361,8 +361,8 @@ function Invoke-SCuBA {
             }
         }
 
-        if (-not $SilenceBODWarnings -and $null -eq $ScubaConfig.OrgUnit) {
-            $Warning = "Config file option OrgUnit not provided. This option is required for BOD "
+        if (-not $SilenceBODWarnings -and $null -eq $ScubaConfig.OrgName) {
+            $Warning = "Config file option OrgName not provided. This option is required for BOD "
             $Warning += "submissions. See https://github.com/cisagov/ScubaGear/blob/main/docs/configuration/configuration.md#scuba-compliance-use for more details. "
             $Warning += "This warning can be silenced with the -SilenceBODWarnings parameter"
             Write-Warning $Warning

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -1323,7 +1323,7 @@ function Invoke-ReportCreation {
                 $BaselineURL = "<a href= `"https://github.com/cisagov/ScubaGear/blob/v$($ModuleVersion)/baselines`" target=`"_blank`"><h3 style=`"width: 100px;`">Baseline Documents</h3></a>"
                 $ManualSummary = "<div class='summary'></div>"
                 $OmitSummary = "<div class='summary'></div>"
-                $FalsePositiveSummary = "<div class='summary'></div>"
+                $IncorrectResultSummary = "<div class='summary'></div>"
                 $ErrorSummary = ""
 
                 if ($Report.Passes -gt 0) {
@@ -1350,9 +1350,9 @@ function Invoke-ReportCreation {
                     $OmitSummary = "<div class='summary manual'>$($Report.Omits) omitted</div>"
                 }
 
-                if ($Report.FalsePositives -gt 0) {
-                    $Noun = Pluralize -SingularNoun "false positive" -PluralNoun "false positives" -Count $Report.FalsePositives
-                    $FalsePositiveSummary = "<div class='summary pass'>$($Report.FalsePositives) $Noun</div>"
+                if ($Report.IncorrectResults -gt 0) {
+                    $Noun = Pluralize -SingularNoun "incorrect result" -PluralNoun "incorrect results" -Count $Report.IncorrectResults
+                    $IncorrectResultSummary = "<div class='summary incorrect'>$($Report.IncorrectResults) $Noun</div>"
                 }
 
                 if ($Report.Errors -gt 0) {
@@ -1362,7 +1362,7 @@ function Invoke-ReportCreation {
 
                 $Fragment += [pscustomobject]@{
                 "Baseline Conformance Reports" = $Link;
-                "Details" = "$PassesSummary $WarningsSummary $FailuresSummary $ManualSummary $OmitSummary $FalsePositiveSummary $ErrorSummary"
+                "Details" = "$PassesSummary $WarningsSummary $FailuresSummary $ManualSummary $OmitSummary $IncorrectResultSummary $ErrorSummary"
                 }
             }
             $TenantMetaData += [pscustomobject]@{

--- a/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfig.psm1
+++ b/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfig.psm1
@@ -92,6 +92,31 @@ class ScubaConfig {
             }
         }
 
+        # If FailedPolicies was included in the config file, validate the policy IDs included there.
+        if ($this.Configuration.ContainsKey("FailedPolicies")) {
+            foreach ($Policy in $this.Configuration.OmitPolicy.Keys) {
+                if (-not ($Policy -match "^ms\.[a-z]+\.[0-9]+\.[0-9]+v[0-9]+$")) {
+                    # Note that -match is a case insensitive match
+                    # Note that the regex does not validate the product name, this will be done later
+                    $Warning = "Config file documents failure rationale for $Policy, "
+                    $Warning += "but $Policy is not a valid control ID. "
+                    $Warning += "Expected format is 'MS.[PRODUCT].[GROUP].[NUMBER]v[VERSION]', "
+                    $Warning += "e.g., 'MS.DEFENDER.1.1v1'."
+                    Write-Warning $Warning
+                    Continue
+                }
+                $Product = ($Policy -Split "\.")[1]
+                # Here's where the product name is validated
+                if (-not ($this.Configuration.ProductNames -Contains $Product)) {
+                    $Warning = "Config file documents failure rationale for $Policy, "
+                    $Warning += "but $Product is not one of the products "
+                    $Warning += "specified in the ProductNames parameter."
+                    Write-Warning $Warning
+                    Continue
+                }
+            }
+        }
+
         return [ScubaConfig]::_IsLoaded
     }
 

--- a/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfig.psm1
+++ b/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfig.psm1
@@ -92,13 +92,13 @@ class ScubaConfig {
             }
         }
 
-        # If FailedPolicies was included in the config file, validate the policy IDs included there.
-        if ($this.Configuration.ContainsKey("FailedPolicies")) {
-            foreach ($Policy in $this.Configuration.OmitPolicy.Keys) {
+        # If AnnotatePolicy was included in the config file, validate the policy IDs included there.
+        if ($this.Configuration.ContainsKey("AnnotatePolicy")) {
+            foreach ($Policy in $this.Configuration.AnnotatePolicy.Keys) {
                 if (-not ($Policy -match "^ms\.[a-z]+\.[0-9]+\.[0-9]+v[0-9]+$")) {
                     # Note that -match is a case insensitive match
                     # Note that the regex does not validate the product name, this will be done later
-                    $Warning = "Config file documents failure rationale for $Policy, "
+                    $Warning = "Config file adds annotation for $Policy, "
                     $Warning += "but $Policy is not a valid control ID. "
                     $Warning += "Expected format is 'MS.[PRODUCT].[GROUP].[NUMBER]v[VERSION]', "
                     $Warning += "e.g., 'MS.DEFENDER.1.1v1'."
@@ -108,7 +108,7 @@ class ScubaConfig {
                 $Product = ($Policy -Split "\.")[1]
                 # Here's where the product name is validated
                 if (-not ($this.Configuration.ProductNames -Contains $Product)) {
-                    $Warning = "Config file documents failure rationale for $Policy, "
+                    $Warning = "Config file adds annotation for $Policy, "
                     $Warning += "but $Product is not one of the products "
                     $Warning += "specified in the ProductNames parameter."
                     Write-Warning $Warning

--- a/PowerShell/ScubaGear/Sample-Config-Files/annotate_policies.yaml
+++ b/PowerShell/ScubaGear/Sample-Config-Files/annotate_policies.yaml
@@ -16,8 +16,8 @@ OutRegoFileName: TestResults
 OutReportName: BaselineReports
 AnnotatePolicy:
   MS.EXO.2.2v1:
-    FalsePositive: true
-    Comment: "Known false positive; our SPF policy currently cannot to be retrieved via ScubaGear due to a split
+    IncorrectResult: true
+    Comment: "Known incorrect result; our SPF policy currently cannot to be retrieved via ScubaGear due to a split
       horizon setup but is available publicly."
   MS.AAD.3.1v1:
     Comment: Implementation in progress.

--- a/PowerShell/ScubaGear/Sample-Config-Files/annotate_policies.yaml
+++ b/PowerShell/ScubaGear/Sample-Config-Files/annotate_policies.yaml
@@ -20,4 +20,5 @@ AnnotatePolicy:
     Comment: "Known false positive; our SPF policy currently cannot to be retrieved via ScubaGear due to a split
       horizon setup but is available publicly."
   MS.AAD.3.1v1:
-    Comment: Implementation in progress, anticipated completion date 8/1/2025.
+    Comment: Implementation in progress.
+    RemediationDate: 8/1/2025

--- a/PowerShell/ScubaGear/Sample-Config-Files/annotate_policies.yaml
+++ b/PowerShell/ScubaGear/Sample-Config-Files/annotate_policies.yaml
@@ -1,0 +1,23 @@
+Description: |
+  SCuBAGear YAML Configuration file with custom variables
+  This configuration shows a standard SCuBAGear set of parameters to run
+  but also includes examples of annotating specific policies to identify a false
+  positive and document a plan of action for a failed control.
+ProductNames:
+  - exo
+  - aad
+M365Environment: commercial
+LogIn: true
+DisconnectOnExit: false
+OutPath: .
+OutFolderName: M365BaselineConformance
+OutProviderFileName: ProviderSettingsExport
+OutRegoFileName: TestResults
+OutReportName: BaselineReports
+AnnotatePolicy:
+  MS.EXO.2.2v1:
+    FalsePositive: true
+    Comment: "Known false positive; our SPF policy currently cannot to be retrieved via ScubaGear due to a split
+      horizon setup but is available publicly."
+  MS.AAD.3.1v1:
+    Comment: Implementation in progress, anticipated completion date 8/1/2025.

--- a/PowerShell/ScubaGear/Sample-Config-Files/annotate_policies.yaml
+++ b/PowerShell/ScubaGear/Sample-Config-Files/annotate_policies.yaml
@@ -15,7 +15,8 @@ OutProviderFileName: ProviderSettingsExport
 OutRegoFileName: TestResults
 OutReportName: BaselineReports
 AnnotatePolicy:
-  MS.EXO.2.2v1:
+  MS.EXO.2.2v2:
+
     IncorrectResult: true
     Comment: "Known incorrect result; our SPF policy currently cannot to be retrieved via ScubaGear due to a split
       horizon setup but is available publicly."

--- a/PowerShell/ScubaGear/Sample-Config-Files/omit_policies.yaml
+++ b/PowerShell/ScubaGear/Sample-Config-Files/omit_policies.yaml
@@ -6,7 +6,7 @@ Description: |
   and documented as part of an organization's cybersecurity risk management
   program process and practices.
 ProductNames:
-  - exo
+  - aad
   - teams
 M365Environment: commercial
 LogIn: true
@@ -17,9 +17,8 @@ OutProviderFileName: ProviderSettingsExport
 OutRegoFileName: TestResults
 OutReportName: BaselineReports
 OmitPolicy:
-  MS.EXO.2.2v1:
-    Rationale: "Known false positive; our SPF policy currently cannot to be retrieved via ScubaGear due to a split
-      horizon setup but is available publicly."
+  MS.AAD.2.1v1:
+    Rationale: "Our tenant does not have the P2 licenses required for this feature; accepting risk."
     Expiration: "2023-12-31"
   MS.TEAMS.6.1v1:
     Rationale: &DLPRationale "The DLP capability required for Teams is implemented by third party product, [x],

--- a/PowerShell/ScubaGear/Sample-Config-Files/scuba_compliance.yaml
+++ b/PowerShell/ScubaGear/Sample-Config-Files/scuba_compliance.yaml
@@ -24,10 +24,16 @@ OrgName: Department of Example
 OrgUnitName: Subdepartment of Example
 
 # The OmitPolicy field can be used to exclude policies from the SCuBA assessment
-# results (e.g., for controls that are met using a third party tool).
+# results (e.g., for controls that are met using a third party tool or acceptance of risk).
 # See https://github.com/cisagov/ScubaGear/blob/main/docs/configuration/configuration.md#omit-policies
-# for in depth details
+# for in-depth details
 OmitPolicy: {}
+
+# Policies can be annotated to mark false positives and document plans of action.
+# The annotation is appended in the Details column of the HTML report for the applicable
+# controls. See https://github.com/cisagov/ScubaGear/blob/main/docs/configuration/configuration.md#annotate-policies
+# for in-depth details.
+AnnotatePolicy: {}
 
 # For product specific details on filling out the fields below, see:
 # https://github.com/cisagov/ScubaGear/blob/main/docs/configuration/configuration.md#product-specific-configuration

--- a/PowerShell/ScubaGear/Sample-Config-Files/scuba_compliance.yaml
+++ b/PowerShell/ScubaGear/Sample-Config-Files/scuba_compliance.yaml
@@ -29,7 +29,7 @@ OrgUnitName: Subdepartment of Example
 # for in-depth details
 OmitPolicy: {}
 
-# Policies can be annotated to mark false positives and document plans of action.
+# Policies can be annotated to mark incorrect results and document plans of action.
 # The annotation is appended in the Details column of the HTML report for the applicable
 # controls. See https://github.com/cisagov/ScubaGear/blob/main/docs/configuration/configuration.md#annotate-policies
 # for in-depth details.

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/CreateReport/Add-Annotation.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/CreateReport/Add-Annotation.Tests.ps1
@@ -1,0 +1,186 @@
+Import-Module (Join-Path -Path $PSScriptRoot -ChildPath '../../../../Modules/CreateReport') `
+    -Function 'Add-Annotation' -Force
+
+InModuleScope CreateReport {
+    Describe -Tag CreateReport -Name 'Add-Annotation' {
+        BeforeAll {
+            Mock -CommandName Write-Warning {}
+        }
+
+        Context "When marked false positive" {
+            It 'Handles failing controls' {
+                $Result = @{
+                    "DisplayString" = "Fail";
+                    "Details" = "Details"
+                }
+                $Config = [PSCustomObject]@{
+                    "AnnotatePolicy" = [PSCustomObject]@{
+                        "MS.DEFENDER.1.1v1" = [PSCustomObject]@{
+                            "Comment" = "Example comment";
+                            "FalsePositive" = $true;
+                        }
+                    }
+                }
+                $Result = Add-Annotation $Result $Config "MS.DEFENDER.1.1v1"
+                $Result | Should -Be "Test marked as false positive by user. <span class='comment-heading'>User justification</span>`"Example comment`""
+                Should -Invoke -CommandName Write-Warning -Exactly -Times 0
+            }
+            It 'Warns if no justification provided' {
+                $Result = @{
+                    "DisplayString" = "Fail";
+                    "Details" = "Details"
+                }
+                $Config = [PSCustomObject]@{
+                    "AnnotatePolicy" = [PSCustomObject]@{
+                        "MS.DEFENDER.1.1v1" = [PSCustomObject]@{
+                            "FalsePositive" = $true;
+                        }
+                    }
+                }
+                $Result = Add-Annotation $Result $Config "MS.DEFENDER.1.1v1"
+                $Result | Should -Be "Test marked as false positive by user. <span class='comment-heading'>User justification not provided</span>"
+                Should -Invoke -CommandName Write-Warning -Exactly -Times 1
+            }
+            It 'Does not overwrite details if control already passing' {
+                $Result = @{
+                    "DisplayString" = "Pass";
+                    "Details" = "Details"
+                }
+                $Config = [PSCustomObject]@{
+                    "AnnotatePolicy" = [PSCustomObject]@{
+                        "MS.DEFENDER.1.1v1" = [PSCustomObject]@{
+                            "FalsePositive" = $true;
+                            "Comment" = "Example comment";
+                        }
+                    }
+                }
+                $Result = Add-Annotation $Result $Config "MS.DEFENDER.1.1v1"
+                $Result | Should -Be "Details<span class='comment-heading'>User comment</span>`"Example comment`""
+                Should -Invoke -CommandName Write-Warning -Exactly -Times 0
+            }
+        }
+
+        Context "When not false positive" {
+            It 'Handles failing controls' {
+                $Result = @{
+                    "DisplayString" = "Fail";
+                    "Details" = "Details"
+                }
+                $Config = [PSCustomObject]@{
+                    "AnnotatePolicy" = [PSCustomObject]@{
+                        "MS.DEFENDER.1.1v1" = [PSCustomObject]@{
+                            "Comment" = "Example comment";
+                        }
+                    }
+                }
+                $Result = Add-Annotation $Result $Config "MS.DEFENDER.1.1v1"
+                $Result | Should -Be "Details<span class='comment-heading'>User comment</span>`"Example comment`""
+                Should -Invoke -CommandName Write-Warning -Exactly -Times 0
+            }
+            It 'Handles passing controls' {
+                $Result = @{
+                    "DisplayString" = "Pass";
+                    "Details" = "Details"
+                }
+                $Config = [PSCustomObject]@{
+                    "AnnotatePolicy" = [PSCustomObject]@{
+                        "MS.DEFENDER.1.1v1" = [PSCustomObject]@{
+                            "Comment" = "Example comment";
+                        }
+                    }
+                }
+                $Result = Add-Annotation $Result $Config "MS.DEFENDER.1.1v1"
+                $Result | Should -Be "Details<span class='comment-heading'>User comment</span>`"Example comment`""
+                Should -Invoke -CommandName Write-Warning -Exactly -Times 0
+            }
+        }
+
+        Context "When a remediation date is provided" {
+            BeforeAll {
+                Mock -CommandName Get-Date {
+                    # Modify the Get-Date function so that it returns a fixed date when
+                    # no date is provided, instead of the current time.
+                    if ($null -eq $Date) {
+                        Get-Date -Date "2025-01-01"
+                    }
+                    else {
+                        # If a specific date is requested, operate as normal
+                        $Date
+                    }
+                }
+            }
+            It 'Adds date to details' {
+                $Result = @{
+                    "DisplayString" = "Fail";
+                    "Details" = "Details"
+                }
+                $Config = [PSCustomObject]@{
+                    "AnnotatePolicy" = [PSCustomObject]@{
+                        "MS.DEFENDER.1.1v1" = [PSCustomObject]@{
+                            "Comment" = "Example comment";
+                            "RemediationDate" = "2025-01-02"
+                        }
+                    }
+                }
+                $Result = Add-Annotation $Result $Config "MS.DEFENDER.1.1v1"
+                $Result | Should -Be "Details<span class='comment-heading'>User comment</span>`"Example comment`"<span class='comment-heading'>Anticipated remediation date</span>`"2025-01-02`""
+                Should -Invoke -CommandName Write-Warning -Exactly -Times 0
+            }
+            It 'Warns if date in past and still failing' {
+                $Result = @{
+                    "DisplayString" = "Fail";
+                    "Details" = "Details"
+                }
+                $Config = [PSCustomObject]@{
+                    "AnnotatePolicy" = [PSCustomObject]@{
+                        "MS.DEFENDER.1.1v1" = [PSCustomObject]@{
+                            "Comment" = "Example comment";
+                            "RemediationDate" = "2024-01-02"
+                        }
+                    }
+                }
+                $Result = Add-Annotation $Result $Config "MS.DEFENDER.1.1v1"
+                $Result | Should -Be "Details<span class='comment-heading'>User comment</span>`"Example comment`"<span class='comment-heading'>Anticipated remediation date</span>`"2024-01-02`""
+                Should -Invoke -CommandName Write-Warning -Exactly -Times 1
+            }
+            It 'Does not warn if date in past but passing' {
+                $Result = @{
+                    "DisplayString" = "Pass";
+                    "Details" = "Details"
+                }
+                $Config = [PSCustomObject]@{
+                    "AnnotatePolicy" = [PSCustomObject]@{
+                        "MS.DEFENDER.1.1v1" = [PSCustomObject]@{
+                            "Comment" = "Example comment";
+                            "RemediationDate" = "2024-01-02"
+                        }
+                    }
+                }
+                $Result = Add-Annotation $Result $Config "MS.DEFENDER.1.1v1"
+                $Result | Should -Be "Details<span class='comment-heading'>User comment</span>`"Example comment`"<span class='comment-heading'>Anticipated remediation date</span>`"2024-01-02`""
+                Should -Invoke -CommandName Write-Warning -Exactly -Times 0
+            }
+            It 'Warns if date is malformed' {
+                $Result = @{
+                    "DisplayString" = "Fail";
+                    "Details" = "Details"
+                }
+                $Config = [PSCustomObject]@{
+                    "AnnotatePolicy" = [PSCustomObject]@{
+                        "MS.DEFENDER.1.1v1" = [PSCustomObject]@{
+                            "Comment" = "Example comment";
+                            "RemediationDate" = "2025-99-02"
+                        }
+                    }
+                }
+                $Result = Add-Annotation $Result $Config "MS.DEFENDER.1.1v1"
+                $Result | Should -Be "Details<span class='comment-heading'>User comment</span>`"Example comment`"<span class='comment-heading'>Anticipated remediation date</span>`"2025-99-02`""
+                Should -Invoke -CommandName Write-Warning -Exactly -Times 1
+            }
+        }
+    }
+
+    AfterAll {
+        Remove-Module CreateReport -ErrorAction SilentlyContinue
+    }
+}

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/CreateReport/Add-Annotation.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/CreateReport/Add-Annotation.Tests.ps1
@@ -7,7 +7,7 @@ InModuleScope CreateReport {
             Mock -CommandName Write-Warning {}
         }
 
-        Context "When marked false positive" {
+        Context "When marked incorrect" {
             It 'Handles failing controls' {
                 $Result = @{
                     "DisplayString" = "Fail";
@@ -17,12 +17,12 @@ InModuleScope CreateReport {
                     "AnnotatePolicy" = [PSCustomObject]@{
                         "MS.DEFENDER.1.1v1" = [PSCustomObject]@{
                             "Comment" = "Example comment";
-                            "FalsePositive" = $true;
+                            "IncorrectResult" = $true;
                         }
                     }
                 }
                 $Result = Add-Annotation $Result $Config "MS.DEFENDER.1.1v1"
-                $Result | Should -Be "Test marked as false positive by user. <span class='comment-heading'>User justification</span>`"Example comment`""
+                $Result | Should -Be "Test result marked incorrect by user. <span class='comment-heading'>User justification</span>`"Example comment`""
                 Should -Invoke -CommandName Write-Warning -Exactly -Times 0
             }
             It 'Warns if no justification provided' {
@@ -33,12 +33,12 @@ InModuleScope CreateReport {
                 $Config = [PSCustomObject]@{
                     "AnnotatePolicy" = [PSCustomObject]@{
                         "MS.DEFENDER.1.1v1" = [PSCustomObject]@{
-                            "FalsePositive" = $true;
+                            "IncorrectResult" = $true;
                         }
                     }
                 }
                 $Result = Add-Annotation $Result $Config "MS.DEFENDER.1.1v1"
-                $Result | Should -Be "Test marked as false positive by user. <span class='comment-heading'>User justification not provided</span>"
+                $Result | Should -Be "Test result marked incorrect by user. <span class='comment-heading'>User justification not provided</span>"
                 Should -Invoke -CommandName Write-Warning -Exactly -Times 1
             }
             It 'Does not overwrite details if control already passing' {
@@ -49,7 +49,7 @@ InModuleScope CreateReport {
                 $Config = [PSCustomObject]@{
                     "AnnotatePolicy" = [PSCustomObject]@{
                         "MS.DEFENDER.1.1v1" = [PSCustomObject]@{
-                            "FalsePositive" = $true;
+                            "IncorrectResult" = $true;
                             "Comment" = "Example comment";
                         }
                     }
@@ -60,7 +60,7 @@ InModuleScope CreateReport {
             }
         }
 
-        Context "When not false positive" {
+        Context "When not marked incorrect" {
             It 'Handles failing controls' {
                 $Result = @{
                     "DisplayString" = "Fail";

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/CreateReport/Add-Annotation.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/CreateReport/Add-Annotation.Tests.ps1
@@ -41,23 +41,6 @@ InModuleScope CreateReport {
                 $Result | Should -Be "Test result marked incorrect by user. <span class='comment-heading'>User justification not provided</span>"
                 Should -Invoke -CommandName Write-Warning -Exactly -Times 1
             }
-            It 'Does not overwrite details if control already passing' {
-                $Result = @{
-                    "DisplayString" = "Pass";
-                    "Details" = "Details"
-                }
-                $Config = [PSCustomObject]@{
-                    "AnnotatePolicy" = [PSCustomObject]@{
-                        "MS.DEFENDER.1.1v1" = [PSCustomObject]@{
-                            "IncorrectResult" = $true;
-                            "Comment" = "Example comment";
-                        }
-                    }
-                }
-                $Result = Add-Annotation $Result $Config "MS.DEFENDER.1.1v1"
-                $Result | Should -Be "Details<span class='comment-heading'>User comment</span>`"Example comment`""
-                Should -Invoke -CommandName Write-Warning -Exactly -Times 0
-            }
         }
 
         Context "When not marked incorrect" {

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/CreateReport/Get-OmissionState.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/CreateReport/Get-OmissionState.Tests.ps1
@@ -1,4 +1,5 @@
-Import-Module (Join-Path -Path $PSScriptRoot -ChildPath '../../../../Modules/CreateReport')
+Import-Module (Join-Path -Path $PSScriptRoot -ChildPath '../../../../Modules/CreateReport') `
+    -Function 'Get-OmissionState' -Force
 
 InModuleScope CreateReport {
     Describe -Tag CreateReport -Name 'Get-OmissionState' {

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -125,6 +125,23 @@ For each omitted policy, the config file allows you to indicate the following:
 - `Rationale`: The reason the policy should be omitted from the report. This value will be displayed in the "Details" column of the report. ScubaGear will output a warning if no rationale is provided.
 - `Expiration`: Optional. A date after which the policy should no longer be omitted from the report. The expected format is yyyy-mm-dd.
 
+## Annotate Policies
+
+ScubaGear supports annotating results for individual policies. Annotated policies will be shown in the HTML with the
+annotation appended to the details column. Annotated policies are intended to:
+- Document action plans for any failed controls. ScubaGear will output a warning for any failing controls that are not
+documented in the config file, though this warning can be silenced with the `-SilenceBODWarnings` flag.
+- Allow users to identify false positives
+- Help contextualize results
+
+The `AnnotatePolicy` top-level key, shown in this [example ScubaGear configuration file](../../PowerShell/ScubaGear/Sample-Config-Files/annotate_policies.yaml), allows the user to specify the policies that should be annotated.
+
+For each annotated policy, the config file allows you to indicate the following:
+- `FalsePositive`: Boolean, whether or not the result is a false positive. Optional, defaults to false.
+- `Comment`: The annotation to add to the report. A warning will be printed if control is marked false positive with no comment provided as justification.
+
+**Exercise care when marking false positives because this can inadvertently introduce blind spots when assessing your system.**
+
 ## Product-specific Configuration
 
 Config files can include a top-level level key for a given product whose values are related to that specific product. For example, look for the value of `Defender` in this [Defender config file](../../PowerShell/ScubaGear/Sample-Config-Files/defender_config.yaml). Currently, only Entra ID, Defender, and Exchange Online use this extra configuration.

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -139,6 +139,7 @@ The `AnnotatePolicy` top-level key, shown in this [example ScubaGear configurati
 For each annotated policy, the config file allows you to indicate the following:
 - `FalsePositive`: Boolean, whether or not the result is a false positive. Optional, defaults to false.
 - `Comment`: The annotation to add to the report. A warning will be printed if control is marked false positive with no comment provided as justification.
+- `RemediationDate`: Optional. The date a failing control is anticipated to be implemented. The expected format is yyy-mm-dd.
 
 **Exercise care when marking false positives because this can inadvertently introduce blind spots when assessing your system.**
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -131,17 +131,17 @@ ScubaGear supports annotating results for individual policies. Annotated policie
 annotation appended to the details column. Annotated policies are intended to:
 - Document action plans for any failed controls. ScubaGear will output a warning for any failing controls that are not
 documented in the config file, though this warning can be silenced with the `-SilenceBODWarnings` flag.
-- Allow users to identify false positives
+- Allow users to identify incorrect results
 - Help contextualize results
 
 The `AnnotatePolicy` top-level key, shown in this [example ScubaGear configuration file](../../PowerShell/ScubaGear/Sample-Config-Files/annotate_policies.yaml), allows the user to specify the policies that should be annotated.
 
 For each annotated policy, the config file allows you to indicate the following:
-- `FalsePositive`: Boolean, whether or not the result is a false positive. Optional, defaults to false.
-- `Comment`: The annotation to add to the report. A warning will be printed if control is marked false positive with no comment provided as justification.
+- `IncorrectResult`: Boolean, whether or not to mark the result incorrect. Optional, defaults to false.
+- `Comment`: The annotation to add to the report. A warning will be printed if control is marked incorrect with no comment provided as justification.
 - `RemediationDate`: Optional. The date a failing control is anticipated to be implemented. The expected format is yyy-mm-dd.
 
-**Exercise care when marking false positives because this can inadvertently introduce blind spots when assessing your system.**
+**Exercise care when marking incorrect results because this can inadvertently introduce blind spots when assessing your system.**
 
 ## Product-specific Configuration
 

--- a/docs/configuration/parameters.md
+++ b/docs/configuration/parameters.md
@@ -443,6 +443,23 @@ Invoke-SCuBA -ProductNames teams `
   -Quiet
 ```
 
+## SilenceBODWarnings
+
+**SilenceBODWarnings** silences warnings relating to BOD submissions requirements, e.g., the requirement to document `OrgUnit` in the config file.
+
+| Parameter   | Value  |
+|-------------|--------|
+| Optional    | Yes    |
+| Datatype    | Switch |
+| Default     | n/a    |
+| Config File | No     |
+
+```powershell
+# Silence warning related to BOD submission requirements
+Invoke-SCuBA -SilenceBODWarnings
+```
+
+
 ## Version
 
 **Version** writes the current ScubaGear version to the console.  ScubaGear will not be run.  When the `Version` parameter is used, no other parameters should be included.

--- a/docs/configuration/parameters.md
+++ b/docs/configuration/parameters.md
@@ -445,7 +445,7 @@ Invoke-SCuBA -ProductNames teams `
 
 ## SilenceBODWarnings
 
-**SilenceBODWarnings** silences warnings relating to BOD submissions requirements, e.g., the requirement to document `OrgUnit` in the config file.
+**SilenceBODWarnings** silences warnings relating to BOD submissions requirements, e.g., the requirement to document `OrgName` in the config file.
 
 | Parameter   | Value  |
 |-------------|--------|


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##
- Add capability to mark failed controls false positives
- Add capability to annotate control results
- Add warnings for BOD submission requirements (i.e., document failing policies and `OrgUnit`)

## 💭 Motivation and context ##
Closes #1733.

## 🧪 Testing ##
- Comment on passing control
- Comment on failing control
- Comment on a warning control (SHOULD)
- Don't comment on warning controls
- Comment on failing control and mark it a false positive
- Don't comment on all failing controls
- Don't comment on all failing controls and use `-SilenceBODWarnings`
- Omit a control
- Comment on an omitted
- Omit a control without providing a justification control
- Don't comment on a failing control you marked a false positive
- Mark a passing control a false positive
- Don't specify `OrgUnit` or `-SilenceBODWarnings`
- Don't specify `OrgUnit` but use `-SilenceBODWarnings`
- Specify `OrgUnit` and don't use `-SilenceBODWarnings`

## 📷 Screenshots ##
What happens when you mark something a false positive:
![image](https://github.com/user-attachments/assets/c093d408-63c2-47df-80e4-0a2629d5c55c)
![image](https://github.com/user-attachments/assets/df304421-2bc9-4e02-a18d-dc929a2da5b1)

What happens if you mark something a false positive without justifying it:
![image](https://github.com/user-attachments/assets/b223fd48-eb39-46e4-8649-c3be439b0776)
![image](https://github.com/user-attachments/assets/8e67dc87-e763-4690-8e9b-1fdceff8a78d)
![image](https://github.com/user-attachments/assets/89a361e0-23fc-43b0-b0a8-5d02794b85b8)

When you mark a SHOULD incorrect:
![image](https://github.com/user-attachments/assets/63390568-7252-4104-b425-b8e4e03e4d80)
![image](https://github.com/user-attachments/assets/37df442e-36e9-497a-a346-71da89aafef6)

What annotations to failed controls (not false positives) look like:
![image](https://github.com/user-attachments/assets/e521c13d-ffb1-4f8f-a67d-eb87d7f227d6)
![image](https://github.com/user-attachments/assets/bcd0e934-3e56-4249-bed4-feaf4af0a4fb)

You can also annotate non-failing controls:
![image](https://github.com/user-attachments/assets/46c02db0-2f78-44de-b8c2-a9c60b2efe9a)

I also tweaked the way omits are displayed, they now look like this:
![image](https://github.com/user-attachments/assets/4930d0ed-757e-4717-974c-8299d335c555)

In addition to being output in the HTML as shown above, the annotations (for failed controls only) are aggregated in a new top-level key in the JSON results:
![image](https://github.com/user-attachments/assets/0c077ad5-d227-4e05-8e47-52b55907458d)

What happens when the user doesn't annotate all failed controls? (unless run with `SilenceBODWarnings`)
![image](https://github.com/user-attachments/assets/7a80407d-5bf9-4e1b-8775-839d1c86ca7d)

Users can add anticipated remediation dates:
![image](https://github.com/user-attachments/assets/ba822f5d-2840-4861-9491-805a9aef0474)

Warning printed to terminal if the remediation date is passes (if still not passing) or if it is malformed:
![image](https://github.com/user-attachments/assets/32aacde0-9c72-468a-997b-e2a1b8b14188)
![image](https://github.com/user-attachments/assets/9ca75e6b-fe51-44ca-97e7-23c51d233c65)

Warning printed to the terminal if `OrgUnit` not provided in the config file, unless run with `SilenceBODWarnings`:
![image](https://github.com/user-attachments/assets/b206da98-3aad-4d2a-86fe-c212b29014fe)

Summary page:
![image](https://github.com/user-attachments/assets/128df4cd-b607-4c55-a3da-96d3a2236b27)
![image](https://github.com/user-attachments/assets/a634e522-4fa3-4c01-bd5d-47c42d8fc92e)


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] Changes are sized such that they do not touch excessive number of files.
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [ ] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] All relevant type-of-change labels added.
- [ ] All relevant project fields are set.
- [ ] All relevant repo and/or project documentation updated to reflect these changes.
- [ ] Unit tests added/updated to cover PowerShell and Rego changes.
- [ ] Functional tests added/updated to cover PowerShell and Rego changes.
- [ ] All relevant functional tests passed.
- [ ] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] PR passed smoke test check.
- [ ] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [ ] Resolved all merge conflicts on branch
- [ ] Notified merge coordinator that PR is ready for merge via comment mention
- [ ] Demonstrate changes to the team for questions and comments. 
    (Note: Only required for issues of size `Medium` or larger)

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
