### PR TITLE
Add Authentication Strength Capability for AAD 3.2v1 

### DIFF
--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -15,6 +15,7 @@ import data.utils.aad.UserExclusionsFullyExempt
 import data.utils.aad.GroupExclusionsFullyExempt
 import data.utils.aad.Aad2P2Licenses
 import data.utils.aad.IsPhishingResistantMFA
+import data.utils.aad.IsGeneralMFA
 import data.utils.aad.CAPLINK
 import data.utils.aad.DomainReportDetails
 import data.utils.aad.INT_MAX
@@ -255,7 +256,7 @@ NonSpecificMFAPolicies contains CAPolicy.DisplayName if {
     ###
 
     ### Conditional access checks specific to this policy
-    "mfa" in CAPolicy.GrantControls.BuiltInControls
+    IsGeneralMFA(CAPolicy) == true
     ###
 
     # Only match policies with user and group exclusions per the confile file

--- a/PowerShell/ScubaGear/Rego/Utils/AAD.rego
+++ b/PowerShell/ScubaGear/Rego/Utils/AAD.rego
@@ -154,6 +154,38 @@ IsPhishingResistantMFA(Policy) := true if {
     Count(Strengths) > 0
 } else := false
 
+# Returns true if the policy enforces general MFA (either through built-in controls
+# or authentication strength that includes MFA methods)
+IsGeneralMFA(Policy) := true if {
+    # Check for traditional MFA built-in control
+    "mfa" in Policy.GrantControls.BuiltInControls
+} else := true if {
+    # Check for authentication strength that includes MFA methods
+    Strengths := ConvertToSet(Policy.GrantControls.AuthenticationStrength.AllowedCombinations)
+    # Check if any of the allowed combinations contain MFA methods
+    # This includes combinations like "password, microsoftAuthenticatorPush", "password, softwareOath", etc.
+    MFACombinations := {
+        "windowsHelloForBusiness",
+        "fido2", 
+        "x509CertificateMultiFactor",
+        "deviceBasedPush",
+        "temporaryAccessPassOneTime",
+        "temporaryAccessPassMultiUse",
+        "password, microsoftAuthenticatorPush",
+        "password, softwareOath",
+        "password, hardwareOath", 
+        "password, sms",
+        "password, voice",
+        "federatedMultiFactor",
+        "microsoftAuthenticatorPush, federatedSingleFactor",
+        "softwareOath, federatedSingleFactor",
+        "hardwareOath, federatedSingleFactor",
+        "sms, federatedSingleFactor",
+        "voice, federatedSingleFactor"
+    }
+    Count(Strengths & MFACombinations) > 0
+} else := false
+
 
 ############################################################################
 # Report formatting functions for MS.AAD.6.1v1                             #

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_03_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_03_test.rego
@@ -173,8 +173,8 @@ test_3_1_Fails_3_2_Passes_Correct if {
     Output := aad.tests with input.conditional_access_policies as [CAP, CAP2]
 
     ReportDetailStr := concat("", [
-        "1 conditional access policy(s) found that meet(s) all requirements:",
-        "<br/>Test Policy. <a href='#caps'>View all CA policies</a>."
+        "2 conditional access policy(s) found that meet(s) all requirements:",
+        "<br/>Bad Policy, Test Policy. <a href='#caps'>View all CA policies</a>."
     ])
 
     TestResult("MS.AAD.3.2v1", Output, ReportDetailStr, true) == true
@@ -1836,4 +1836,152 @@ test_Entra_3_9_Application_Exclusion_Incorrect_V1 if {
         "0 conditional access policy(s) found that meet(s) all requirements. <a href='#caps'>View all CA policies</a>."
     TestResult("MS.AAD.3.9v1", Output, ReportDetailStr, false) == true
 }
-#--
+
+# Test for Windows Hello for Business
+test_IsGeneralMFA_WindowsHelloForBusiness_Correct if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "DisplayName", "value": "Windows Hello for Business Policy"},
+                {"op": "remove", "path": "GrantControls/BuiltInControls"},
+                {"op": "add", "path": "GrantControls/AuthenticationStrength/AllowedCombinations", "value": ["windowsHelloForBusiness"]}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+
+    ReportDetailStr := concat("", [
+        "1 conditional access policy(s) found that meet(s) all requirements:",
+        "<br/>Windows Hello for Business Policy. <a href='#caps'>View all CA policies</a>."
+    ])
+
+    TestResult("MS.AAD.3.2v1", Output, ReportDetailStr, true) == true
+}
+
+# Test for FIDO2
+test_IsGeneralMFA_Fido2_Correct if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "DisplayName", "value": "FIDO2 Policy"},
+                {"op": "remove", "path": "GrantControls/BuiltInControls"},
+                {"op": "add", "path": "GrantControls/AuthenticationStrength/AllowedCombinations", "value": ["fido2"]}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+
+    ReportDetailStr := concat("", [
+        "1 conditional access policy(s) found that meet(s) all requirements:",
+        "<br/>FIDO2 Policy. <a href='#caps'>View all CA policies</a>."
+    ])
+
+    TestResult("MS.AAD.3.2v1", Output, ReportDetailStr, true) == true
+}
+
+# Test for X509 Certificate Multi-Factor
+test_IsGeneralMFA_X509CertificateMultiFactor_Correct if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "DisplayName", "value": "X509 Certificate Multi-Factor Policy"},
+                {"op": "remove", "path": "GrantControls/BuiltInControls"},
+                {"op": "add", "path": "GrantControls/AuthenticationStrength/AllowedCombinations", "value": ["x509CertificateMultiFactor"]}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+
+    ReportDetailStr := concat("", [
+        "1 conditional access policy(s) found that meet(s) all requirements:",
+        "<br/>X509 Certificate Multi-Factor Policy. <a href='#caps'>View all CA policies</a>."
+    ])
+
+    TestResult("MS.AAD.3.2v1", Output, ReportDetailStr, true) == true
+}
+
+# Test for Device Based Push
+test_IsGeneralMFA_DeviceBasedPush_Correct if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "DisplayName", "value": "Device Based Push Policy"},
+                {"op": "remove", "path": "GrantControls/BuiltInControls"},
+                {"op": "add", "path": "GrantControls/AuthenticationStrength/AllowedCombinations", "value": ["deviceBasedPush"]}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+
+    ReportDetailStr := concat("", [
+        "1 conditional access policy(s) found that meet(s) all requirements:",
+        "<br/>Device Based Push Policy. <a href='#caps'>View all CA policies</a>."
+    ])
+
+    TestResult("MS.AAD.3.2v1", Output, ReportDetailStr, true) == true
+}
+
+# Test for Temporary Access Pass One Time
+test_IsGeneralMFA_TemporaryAccessPassOneTime_Correct if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "DisplayName", "value": "Temporary Access Pass One Time Policy"},
+                {"op": "remove", "path": "GrantControls/BuiltInControls"},
+                {"op": "add", "path": "GrantControls/AuthenticationStrength/AllowedCombinations", "value": ["temporaryAccessPassOneTime"]}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+
+    ReportDetailStr := concat("", [
+        "1 conditional access policy(s) found that meet(s) all requirements:",
+        "<br/>Temporary Access Pass One Time Policy. <a href='#caps'>View all CA policies</a>."
+    ])
+
+    TestResult("MS.AAD.3.2v1", Output, ReportDetailStr, true) == true
+}
+
+# Test for Temporary Access Pass Multi Use
+test_IsGeneralMFA_TemporaryAccessPassMultiUse_Correct if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "DisplayName", "value": "Temporary Access Pass Multi Use Policy"},
+                {"op": "remove", "path": "GrantControls/BuiltInControls"},
+                {"op": "add", "path": "GrantControls/AuthenticationStrength/AllowedCombinations", "value": ["temporaryAccessPassMultiUse"]}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+
+    ReportDetailStr := concat("", [
+        "1 conditional access policy(s) found that meet(s) all requirements:",
+        "<br/>Temporary Access Pass Multi Use Policy. <a href='#caps'>View all CA policies</a>."
+    ])
+
+    TestResult("MS.AAD.3.2v1", Output, ReportDetailStr, true) == true
+}
+
+# Test for multiple authentication combinations
+test_IsGeneralMFA_MultipleCombinations_Correct if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "DisplayName", "value": "Multiple Authentication Combinations Policy"},
+                {"op": "remove", "path": "GrantControls/BuiltInControls"},
+                {"op": "add", "path": "GrantControls/AuthenticationStrength/AllowedCombinations", 
+                "value": ["windowsHelloForBusiness", "password, microsoftAuthenticatorPush", "federatedMultiFactor"]}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+
+    ReportDetailStr := concat("", [
+        "1 conditional access policy(s) found that meet(s) all requirements:",
+        "<br/>Multiple Authentication Combinations Policy. <a href='#caps'>View all CA policies</a>."
+    ])
+
+    TestResult("MS.AAD.3.2v1", Output, ReportDetailStr, true) == true
+}
+
+# Test for non-MFA authentication strength (should fail)
+test_IsGeneralMFA_NonMFAStrength_Incorrect if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "DisplayName", "value": "Non-MFA Authentication Strength Policy"},
+                {"op": "remove", "path": "GrantControls/BuiltInControls"},
+                {"op": "add", "path": "GrantControls/AuthenticationStrength/AllowedCombinations", "value": ["password"]}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+
+    ReportDetailStr :=
+        "0 conditional access policy(s) found that meet(s) all requirements. <a href='#caps'>View all CA policies</a>."
+    TestResult("MS.AAD.3.2v1", Output, ReportDetailStr, false) == true
+}
+
+# Test for empty authentication strength (should fail)
+test_IsGeneralMFA_EmptyAuthenticationStrength_Incorrect if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "DisplayName", "value": "Empty Authentication Strength Policy"},
+                {"op": "remove", "path": "GrantControls/BuiltInControls"},
+                {"op": "add", "path": "GrantControls/AuthenticationStrength/AllowedCombinations", "value": []}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+
+    ReportDetailStr :=
+        "0 conditional access policy(s) found that meet(s) all requirements. <a href='#caps'>View all CA policies</a>."
+    TestResult("MS.AAD.3.2v1", Output, ReportDetailStr, false) == true
+}
+

--- a/Testing/Functional/Products/TestPlans/aad.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/aad.testplan.yaml
@@ -207,7 +207,7 @@ TestPlan:
         Preconditions:
           - Command: UpdateCachedConditionalAccessPolicyByName
             Splat:
-              displayName: Automated Test 2 - DO NOT MODIFY
+              displayName: Automated Test 1 - DO NOT MODIFY
               updates:
                 State: enabled
                 Conditions:

--- a/Testing/Functional/Products/TestPlans/aad.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/aad.testplan.yaml
@@ -202,6 +202,47 @@ TestPlan:
                 State: enabledForReportingButNotEnforced
         Postconditions: []
         ExpectedResult: true
+      - TestDescription: MS.AAD.3.2v1 Compliant case - Authentication Strength with Multifactor Authentication is enforced
+        ### This test enables the standard non-specific MFA policy with authentication strength set to "Multifactor Authentication"
+        Preconditions:
+          - Command: UpdateCachedConditionalAccessPolicyByName
+            Splat:
+              displayName: Automated Test 2 - DO NOT MODIFY
+              updates:
+                State: enabled
+                Conditions:
+                  Users:
+                    IncludeUsers: ["All"]
+                    ExcludeUsers: []
+                    IncludeGroups: []
+                    ExcludeGroups: []
+                    IncludeRoles: []
+                    ExcludeRoles: []
+                  Applications:
+                    IncludeApplications: ["All"]
+                    ExcludeApplications: []
+                GrantControls:
+                  AuthenticationStrength:
+                    AllowedCombinations:
+                      - "windowsHelloForBusiness"
+                      - "fido2"
+                      - "x509CertificateMultiFactor"
+                      - "deviceBasedPush"
+                      - "temporaryAccessPassOneTime"
+                      - "temporaryAccessPassMultiUse"
+                      - "password, microsoftAuthenticatorPush"
+                      - "password, softwareOath"
+                      - "password, hardwareOath"
+                      - "password, sms"
+                      - "password, voice"
+                      - "federatedMultiFactor"
+                      - "microsoftAuthenticatorPush, federatedSingleFactor"
+                      - "softwareOath, federatedSingleFactor"
+                      - "hardwareOath, federatedSingleFactor"
+                      - "sms, federatedSingleFactor"
+                      - "voice, federatedSingleFactor"
+        Postconditions: []
+        ExpectedResult: true
 
   - PolicyId: MS.AAD.3.3v2
     TestDriver: ScubaCached


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##
This PR checks authentication strength capability for AAD 3.2v1 which wasn't previously done by ScubaGear 
Closes #1683
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
This was a public reported bug and was a capability that ScubaGear needed to add, since it was causing false negatives in the compliance of policy 3.2v1
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
I tested it by changing settings via cached scuba runs and it can be tested by directly changing the CAPs themselves or by updating the json and running it via that. I also ran against the different tenants and ran the unit tests.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [x] Resolved all merge conflicts on branch
- [x] Notified merge coordinator that PR is ready for merge via comment mention
- [ ] Demonstrate changes to the team for questions and comments. 
    (Note: Only required for issues of size `Medium` or larger)

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
