### PR TITLE
Update Invoke-CheckScubaGearVersion function

### DIFF
--- a/PowerShell/ScubaGear/CheckVersion.ps1
+++ b/PowerShell/ScubaGear/CheckVersion.ps1
@@ -2,16 +2,22 @@
 function Invoke-CheckScubaGearVersion {
     <#
     .SYNOPSIS
-    Complain if a newer version of ScubaGear is available from the Github release page.
+    Complain if a newer version of ScubaGear is available from PSGallery.
 
     .DESCRIPTION
-    Checks latest version available on the Github release page and compares it to the current running version.
+    Checks latest version available on PSGallery and compares it to the current running version.
     #>
-    $ScubaManifest = Import-PowerShellDataFile (Join-Path -Path $PSScriptRoot -ChildPath 'ScubaGear.psd1' -Resolve  -ErrorAction 'Stop' ) -ErrorAction 'Stop'
-    $CurrentVersion = [System.Version]$ScubaManifest.ModuleVersion
-    $LatestVersion = [System.Version]$(Invoke-RestMethod -Uri "https://api.github.com/repos/cisagov/ScubaGear/releases/latest" -ErrorAction 'Stop').tag_name.TrimStart("v")
-    if ($CurrentVersion -lt $LatestVersion) {
-        Write-Warning "A newer version of ScubaGear ($latestVersion) is available. Please consider updating at: https://github.com/cisagov/ScubaGear/releases. This notification can be disabled by setting `$env:SCUBAGEAR_SKIP_VERSION_CHECK = `$true before running ScubaGear."
+    try{
+        $ScubaManifest = Import-PowerShellDataFile (Join-Path -Path $PSScriptRoot -ChildPath 'ScubaGear.psd1' -Resolve  -ErrorAction 'Stop' ) -ErrorAction 'Stop'
+        $CurrentVersion = [System.Version]$ScubaManifest.ModuleVersion
+        $LatestVersion = [System.Version](Find-Module -Name ScubaGear -Repository PSGallery -ErrorAction SilentlyContinue).Version
+
+        if ($null -ne $LatestVersion -and $CurrentVersion -lt $LatestVersion) {
+            Write-Warning "A newer version of ScubaGear ($LatestVersion) is available. Please consider running: Update-ScubaGear, this notification can be disabled by setting `$env:SCUBAGEAR_SKIP_VERSION_CHECK = `$true before running ScubaGear."
+        }
+    }
+    catch{
+        Write-Warning "The ScubaGear version check failed: $($_.Exception.Message)"
     }
 }
 


### PR DESCRIPTION

# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##
Updated the `Invoke-CheckScubaGearVersion` function to use `Find-Module` directly instead of checking GitHub releases. The function now:

- Uses `Find-Module -Name ScubaGear -Repository PSGallery` instead of GitHub API calls
- Eliminates dependency on GitHub API (`https://api.github.com/repos/cisagov/ScubaGear/releases/latest`)
- Updated warning message to suggest running `Update-ScubaGear` instead of directing users to GitHub releases page
- Added null check for `$LatestVersion` to prevent errors when PSGallery is unavailable

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
The previous implementation used `Invoke-RestMethod` to call the GitHub API directly, which could fail in environments with restricted GitHub access. This change:

- Updated message to suggest `Update-ScubaGear` command instead of manual GitHub download
- Added null check to prevent errors when `Find-Module` returns null due to connectivity issues

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
- [x] Verified that when newer version is available, appropriate warning with `Update-ScubaGear` suggestion is displayed
- [x] Tested that when current version is up-to-date, no warning is shown

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [ ] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] All relevant type-of-change labels added.
- [ ] All relevant project fields are set.
- [ ] All relevant repo and/or project documentation updated to reflect these changes.
- [ ] Unit tests added/updated to cover PowerShell and Rego changes.
- [ ] Functional tests added/updated to cover PowerShell and Rego changes.
- [ ] All relevant functional tests passed.
- [ ] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] PR passed smoke test check.
- [ ] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [ ] Resolved all merge conflicts on branch
- [ ] Notified merge coordinator that PR is ready for merge via comment mention
- [ ] Demonstrate changes to the team for questions and comments. 
    (Note: Only required for issues of size `Medium` or larger)

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
