### PR TITLE
docs: GovCloud (US) deployment guide + requirements/testing notes

### DIFF
--- a/docs/govcloud-deployment.md
+++ b/docs/govcloud-deployment.md
@@ -11,6 +11,7 @@
 - Python 3.8 or later and Git installed on the workstation.
 - Network egress to AWS APIs from the execution environment.
 - Use **temporary roles** rather than permanent credentials.
+- Windows example shown; macOS/Linux follow the same steps with shell syntax adjustments.
 
 ---
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,56 @@
+# Requirements & Use-Cases — GovCloud Deployment Docs Contribution
+
+## 1) Goals
+
+- Provide a clear, minimal **AWS GovCloud (US)** deployment guide for ScubaGear.
+- Offer a **baseline least-privilege IAM** example that teams can harden.
+- Show an **optional Security Hub ingestion** pattern.
+- Clarify **FedRAMP-aligned operational practices** without making compliance claims.
+
+## 2) User Stories
+
+- **US-01** — _As a federal contractor engineer_, I want a concise GovCloud deployment guide, so I can run ScubaGear within our authorization boundary.
+- **US-02** — _As a security analyst_, I want a sample Security Hub ingestion, so I can centralize findings in our tooling.
+- **US-03** — _As a compliance lead_, I want FedRAMP-relevant practices called out, so I can map outputs into our SSP/POA&M.
+
+## 3) Use Case (UC-01: Run ScubaGear in GovCloud)
+
+**Primary Actor:** Engineer  
+**Preconditions:** Role-based access in `us-gov-west-1` or `us-gov-east-1`; Python + Git installed; network egress allowed.  
+**Main Flow:**
+
+1. Set GovCloud region environment variable.
+2. Create venv; install requirements; verify `python -m scubagear --version`.
+3. Run `scan` to produce JSON results.
+4. Generate HTML report from results.
+5. Archive outputs to controlled storage.
+   **Alternate Flows:**
+
+- **AF-01 AccessDenied:** Adjust IAM baseline (scope ARNs/Conditions) → re-run step 3.
+- **AF-02 No Output:** Fix path/permissions → re-run report generation.
+
+## 4) Information & Relationships (ER-style, textual)
+
+- **Run** produces **Output** _(JSON, HTML)_.
+- **Output** may be transformed into **SecurityHubFinding** entries.
+- **Role** grants **Permission** to perform AWS actions (governed by policy).
+- **Configuration** (env vars/flags) constrains **Run** behavior and storage paths.
+
+## 5) Non-Functional Requirements (NFRs)
+
+- **NFR-01 Clarity:** Commands are copy-pasteable for Windows; Linux/macOS notes referenced as needed.
+- **NFR-02 Security:** Examples avoid long-lived credentials; recommend roles and least privilege.
+- **NFR-03 Portability:** Guide uses GovCloud nomenclature; no commercial region assumptions.
+- **NFR-04 Compliance Tone:** Reference material only; not an authorization package.
+
+## 6) Acceptance Criteria
+
+- **AC-01:** A newcomer can install, run a scan, and generate a report in GovCloud following the guide.
+- **AC-02:** IAM baseline example is valid JSON policy and mentions scoping ARNs/Conditions.
+- **AC-03:** Security Hub sample includes required API call and region note.
+- **AC-04:** FedRAMP section lists control tie-ins and includes a non-claim disclaimer.
+- **AC-05:** README (or docs index) links to the guide; all links resolve.
+
+## 7) Out of Scope
+
+- Authorization packages, SSP/POA&M authoring, or environment-specific accreditation content.

--- a/docs/testing-notes.md
+++ b/docs/testing-notes.md
@@ -1,0 +1,70 @@
+# Testing & Pre-Checkin Notes — GovCloud Deployment Docs Contribution
+
+## 1) Pre-Checkin Checklist
+
+- [ ] Markdown format passes (`mdformat`) on Windows.
+- [ ] All external links resolve (GovCloud guide, Security Hub, FedRAMP baselines).
+- [ ] No secrets/credentials in commands or screenshots.
+- [ ] File added under `docs/` and linked from README (or docs index).
+- [ ] Commit uses sign-off (`-s`) and conventional style: `docs: ...`.
+
+### Run locally (Windows PowerShell)
+
+```powershell
+pip install mdformat
+mdformat docs/govcloud-deployment.md docs/requirements.md
+```
+
+## 2) Manual Test Cases (Workstation Smoke Tests)
+
+**Environment:** Windows 11, Python 3.11, PowerShell 5.1, GovCloud account.
+
+**TC-01 Version Check**
+
+- Steps: Create venv, install, run `python -m scubagear --version`.
+- Expected: Version string prints (e.g., `ScubaGear x.y.z`).
+
+**TC-02 GovCloud Scan**
+
+- Steps:
+  ```powershell
+  $Env:AWS_DEFAULT_REGION="us-gov-west-1"
+  python -m scubagear scan --output .\results\scan_$(Get-Date -Format "yyyyMMdd_HHmm").json
+  ```
+- Expected: A JSON results file appears under `.\results\`.
+
+**TC-03 Report Generation**
+
+- Steps:
+  ```powershell
+  python -m scubagear report --input .\results\scan_*.json --format html --out .\results\report.html
+  ```
+- Expected: `report.html` generated; opens in browser.
+
+**TC-04 (Optional) Security Hub Ingestion**
+
+- Pre: IAM allows `securityhub:BatchImportFindings`.
+- Steps: Run `example_securityhub.py` from the guide with a small subset.
+- Expected: API call succeeds (HTTP 200 in CloudTrail/SecurityHub metrics or no exception).
+
+## 3) Troubleshooting Log (fill during testing)
+
+- [ ] Auth issues → confirm role session + region env var.
+- [ ] AccessDenied → scope policy to required services/resources; retry TC-02.
+- [ ] Missing output → verify `results/` write permissions; retry TC-03.
+
+## 4) Evidence for Assignment Submission
+
+Attach or link the following screenshots:
+
+- A. `git remote -v` (origin + upstream).
+- B. Issue you opened (“GovCloud/FedRAMP deployment documentation”).
+- C. Branch name in terminal: `docs/issue-1845-govcloud-docs`.
+- D. `git status` showing changed docs.
+- E. PR page (Conversation tab) + Files changed diff.
+- F. Terminal outputs for TC-01..TC-03.
+- G. (Optional) Security Hub ingestion success or no-error run.
+
+## 5) Deployment Note
+
+- This is a docs-only contribution. “Deployment” consists of PR approval and merge to `main`, after which the documentation is available in the repository.


### PR DESCRIPTION
Summary
Adds AWS GovCloud (US) deployment documentation for ScubaGear. Provides least-privilege IAM baseline (to be scoped by implementers), optional Security Hub ingestion example, and FedRAMP-relevant operational practices (non-authoritative). Includes contributor artifacts for clarity and grading: requirements and testing notes.

Changes
- docs/govcloud-deployment.md (new): prerequisites, install/run, IAM baseline, optional Security Hub, FedRAMP-relevant practices, troubleshooting, references.
- docs/requirements.md (new): goals, user stories, UC-01, ER-style relationships, NFRs, acceptance criteria.
- docs/testing-notes.md (new): pre-checkin steps, manual smoke tests, evidence checklist.

Testing
- mdformat passes locally.
- Links resolve.
- `python -m scubagear --version` validated.
- Output directories created and writable on Windows.
- (Optional) Security Hub ingestion sample limited to a small subset.

Scope
Docs-only change. No code modifications.

Issue Link
Closes #1845