### PR TITLE
Detect single module versions outside min/max range.

### DIFF
--- a/PowerShell/ScubaGear/Dependencies.ps1
+++ b/PowerShell/ScubaGear/Dependencies.ps1
@@ -3,16 +3,11 @@
     Checks ScubaGear and dependency versions for issues that would prevent execution.
 
 .DESCRIPTION
-    Runs Test-ScubaGearVersion to identify version issues with ScubaGear or its dependencies.
-    If critical version issues are found, recommendations are displayed.
+    Runs Test-ScubaGearVersion to identify version issues with ScubaGear dependencies.
+    Displays detailed information from Test-ScubaGearVersion if issues are found.
 
 .EXAMPLE
     .\Dependencies.ps1
-
-.NOTES
-    Uses Host.UI.WriteErrorLine instead of Write-Warning to avoid duplicate warning
-    messages when dependencies.ps1 also issue warnings.
-
 #>
 
 [CmdletBinding()]
@@ -22,148 +17,8 @@ try {
     $SupportModulesPath = Join-Path -Path $PSScriptRoot -ChildPath "Modules/Support/Support.psm1"
     Import-Module -Name $SupportModulesPath
 
-    # Run version check with -Quiet to suppress detailed output
-    $VersionIssues = Test-ScubaGearVersion -Quiet
-
-    # Extract components
-    $DependencyStatus = $VersionIssues | Where-Object { $_.Component -eq "Dependencies" }
-
-    # Categorize issues by severity
-    $criticalIssues = @()
-    $warnings = @()
-    $hasVersionIssues = $false
-    $hasMissingModules = $false
-    $hasMultipleVersions = $false
-
-    # Parse ModuleFileLocations to categorize issues
-    if ($DependencyStatus.ModuleFileLocations) {
-        foreach ($moduleInfo in $DependencyStatus.ModuleFileLocations) {
-            $hasCritical = $false
-
-            foreach ($location in $moduleInfo.Locations) {
-                if ($location -match '\[ABOVE MAX:') {
-                    $hasCritical = $true
-                    $hasVersionIssues = $true
-
-                    # Extract version and max from location string
-                    # Match pattern: "2.34.0 [ABOVE MAX: 2.25.0]" or just "[ABOVE MAX: 2.25.0]"
-                    if ($location -match '([\d\.]+)?\s*\[ABOVE MAX:\s*([\d\.]+)\]') {
-                        $installedVer = if ($matches[1]) { $matches[1] } else { "unknown" }
-                        $maxVer = $matches[2]
-                        $criticalIssues += "  - $($moduleInfo.ModuleName) - version $installedVer exceeds maximum ($maxVer)"
-                    }
-                    else {
-                        # Fallback if regex doesn't match
-                        $criticalIssues += "  - $($moduleInfo.ModuleName) - version exceeds maximum"
-                    }
-                    break
-                }
-                elseif ($location -match '\[BELOW MIN:') {
-                    $hasCritical = $true
-                    $hasVersionIssues = $true
-
-                    if ($location -match '([\d\.]+)?\s*\[BELOW MIN:\s*([\d\.]+)\]') {
-                        $installedVer = if ($matches[1]) { $matches[1] } else { "unknown" }
-                        $minVer = $matches[2]
-                        $criticalIssues += "  - $($moduleInfo.ModuleName) - version $installedVer below minimum ($minVer)"
-                    }
-                    else {
-                        # Fallback if regex doesn't match
-                        $criticalIssues += "  - $($moduleInfo.ModuleName) - version below minimum"
-                    }
-                    break
-                }
-            }
-
-            # If no critical issue but multiple versions, add to warnings
-            if (-not $hasCritical) {
-                $hasMultipleVersions = $true
-                $versionCount = $moduleInfo.VersionCount
-                $warnings += "  - $($moduleInfo.ModuleName) - $versionCount versions installed (cleanup recommended)"
-            }
-        }
-    }
-
-    # Check for missing modules
-    if ($DependencyStatus.MissingModules -and $DependencyStatus.MissingModules.Count -gt 0) {
-        $hasMissingModules = $true
-        foreach ($module in $DependencyStatus.MissingModules) {
-            $criticalIssues += "  - $module - not installed"
-        }
-    }
-
-    # Determine overall severity and build appropriate message
-    $hasCriticalProblems = $hasVersionIssues -or $hasMissingModules
-    if ($hasCriticalProblems) {
-        # Critical issues - use error message
-        $errorMessage = @"
-CRITICAL: Dependency issues detected that may prevent ScubaGear from running!
-
-"@
-
-        if ($criticalIssues.Count -gt 0) {
-            $errorMessage += @"
-
-Critical Issues:
-$($criticalIssues -join "`n")
-
-
-"@
-        }
-
-        if ($hasMultipleVersions -and $warnings.Count -gt 0) {
-            $errorMessage += @"
-Additional Warnings:
-$($warnings -join "`n")
-
-
-"@
-        }
-
-        if ($DependencyStatus.AdminRequired) {
-            $errorMessage += @"
-Note: Administrator privileges required for some cleanup operations.
-
-
-"@
-        }
-
-        $errorMessage += @"
-Action Required:
-  Run 'Reset-ScubaGearDependencies' to resolve these issues.
-
-"@
-        $Host.UI.WriteErrorLine($errorMessage)
-    }
-        elseif ($hasMultipleVersions) {
-        # Only cleanup needed - use warning
-        $warningMessage = @"
-WARNING: Module cleanup recommended
-
-Multiple Versions Detected:
-$($warnings -join "`n")
-
-"@
-
-        if ($DependencyStatus.AdminRequired) {
-            $warningMessage += @"
-Note: Administrator privileges required for some cleanup operations.
-
-
-"@
-        }
-
-        $warningMessage += @"
-Recommended Action:
-  Run 'Reset-ScubaGearDependencies' to clean up multiple versions.
-
-"@
-        $Host.UI.WriteErrorLine($warningMessage)
-    }
-    else {
-        # All clear
-        Write-Information "All dependency checks passed. ScubaGear is ready to run." -InformationAction Continue
-    }
+    # Run version check and display its output
+    $null = Test-ScubaGearVersion
 }
 catch {
     Write-Error "An error occurred checking version status: $($_.Exception.Message)"

--- a/PowerShell/ScubaGear/Modules/Support/Support.psm1
+++ b/PowerShell/ScubaGear/Modules/Support/Support.psm1
@@ -1100,9 +1100,6 @@ function Test-ScubaGearVersion {
     .PARAMETER CheckGitHub
         Also check GitHub releases for the latest version.
 
-    .PARAMETER Quiet
-        Suppress detailed Write-Information output. Only return objects.
-
     .OUTPUTS
         PSCustomObject
 
@@ -1116,10 +1113,7 @@ function Test-ScubaGearVersion {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $false)]
-        [switch]$CheckGitHub,
-
-        [Parameter(Mandatory = $false)]
-        [switch]$Quiet
+        [switch]$CheckGitHub
     )
 
     try {
@@ -1221,91 +1215,74 @@ function Test-ScubaGearVersion {
         $results += $dependencyComponent
         Write-Output $results
 
-        if (-not $Quiet){
-            # Display formatted information for modules with multiple versions
-            if ($dependencyStatus.ModuleFileLocations.Count -gt 0) {
-                # Separate modules into critical (version outside range) vs cleanup (all versions OK)
-                $criticalModules = @()
-                $cleanupModules = @()
+        # Display formatted Details section if there are any issues
+        if ($dependencyStatus.Missing.Count -gt 0 -or $dependencyStatus.ModuleFileLocations.Count -gt 0) {
+            # Separate modules into critical (version outside range) vs cleanup (all versions OK)
+            $criticalModules = @()
+            $cleanupModules = @()
 
-                foreach ($moduleInfo in $dependencyStatus.ModuleFileLocations) {
-                    # Parse versions from location strings
-                    $versions = @()
-                    $hasCriticalIssue = $false
-
-                    foreach ($location in $moduleInfo.Locations) {
-                        # Extract version and status from format: "2.34.0 [STATUS] (Scope): Path"
-                        if ($location -match '^([\d\.]+)\s+\[([^\]]+)\]') {
-                            $version = $matches[1]
-                            $status = $matches[2]
-
-                            $versions += [PSCustomObject]@{
-                                Version = $version
-                                Status = $status
-                            }
-
-                            if ($status -like "ABOVE MAX*" -or $status -like "BELOW MIN*") {
-                                $hasCriticalIssue = $true
-                            }
-                        }
+            # Process missing modules (critical)
+            if($dependencyStatus.Missing.count -gt 0){
+                foreach ($missingModule in $dependencyStatus.Missing) {
+                    $criticalModules += [PSCustomObject]@{
+                        ModuleName = $missingModule
+                        HighestVersion = $null
+                        HighestStatus = "MISSING"
+                        VersionCount = 0
                     }
+                }
+            }
 
-                    # Sort versions descending (highest first)
-                    $versions = $versions | Sort-Object { [version]$_.Version } -Descending
-
-                    $moduleEntry = [PSCustomObject]@{
+            # Process installed modules with version issues or multiple versions
+            foreach ($moduleInfo in $dependencyStatus.ModuleFileLocations) {
+                # Check if highest version (what PowerShell will load) is acceptable
+                if ($moduleInfo.HighestVersionStatus -ne "OK") {
+                    # Highest version is out of range - CRITICAL
+                    $criticalModules += [PSCustomObject]@{
                         ModuleName = $moduleInfo.ModuleName
-                        Versions = $versions
-                        HighestVersion = $versions[0]
-                    }
-
-                    if ($hasCriticalIssue) {
-                        $criticalModules += $moduleEntry
-                    } else {
-                        $cleanupModules += $moduleEntry
+                        HighestVersion = $moduleInfo.HighestVersion
+                        HighestStatus = $moduleInfo.HighestVersionStatus
+                        VersionCount = $moduleInfo.VersionCount
                     }
                 }
-
-                # Details section
-                Write-Information "Details:" -InformationAction Continue
-
-                # Display critical issues first
-                foreach ($module in $criticalModules) {
-                    $highestVersion = $module.HighestVersion
-                    $statusTag = ""
-
-                    if ($highestVersion.Status -like "ABOVE MAX*") {
-                        # Extract max version from status like "ABOVE MAX: 2.25.0"
-                        if ($highestVersion.Status -match 'ABOVE MAX:\s*([\d\.]+)') {
-                            $maxVer = $matches[1]
-                            $statusTag = "[ABOVE MAX: $maxVer]"
-                        } else {
-                            $statusTag = "[ABOVE MAX]"
-                        }
-                    } elseif ($highestVersion.Status -like "BELOW MIN*") {
-                        if ($highestVersion.Status -match 'BELOW MIN:\s*([\d\.]+)') {
-                            $minVer = $matches[1]
-                            $statusTag = "[BELOW MIN: $minVer]"
-                        } else {
-                            $statusTag = "[BELOW MIN]"
-                        }
+                else {
+                    # Highest version is OK but multiple versions exist - CLEANUP
+                    $cleanupModules += [PSCustomObject]@{
+                        ModuleName = $moduleInfo.ModuleName
+                        HighestVersion = $moduleInfo.HighestVersion
+                        VersionCount = $moduleInfo.VersionCount
                     }
-
-                    Write-Information "  CRITICAL: $($module.ModuleName) - will load $($highestVersion.Version) $statusTag" -InformationAction Continue
                 }
+            }
 
-                # Display cleanup recommendations
-                foreach ($module in $cleanupModules) {
-                    $versionCount = $module.Versions.Count
-                    Write-Information "  CLEANUP: $($module.ModuleName) - will load $($module.HighestVersion.Version) ($versionCount versions installed)" -InformationAction Continue
+            # Details section
+            Write-Information "Details:" -InformationAction Continue
+
+            # Display critical issues first (missing modules or highest version out of range)
+            foreach ($module in $criticalModules) {
+                if ($module.HighestStatus -eq "MISSING") {
+                    Write-Information "  CRITICAL: $($module.ModuleName) - not installed" -InformationAction Continue
                 }
+                else {
+                    Write-Information "  CRITICAL: $($module.ModuleName) - will load $($module.HighestVersion) [$($module.HighestStatus)]" -InformationAction Continue
+                }
+            }
 
-                Write-Information "" -InformationAction Continue
+            # Display cleanup recommendations (highest version OK but multiple exist)
+            foreach ($module in $cleanupModules) {
+                Write-Information "  Cleanup Recommended: $($module.ModuleName) - will load $($module.HighestVersion) [OK] ($($module.VersionCount) versions installed)" -InformationAction Continue
+            }
+
+            Write-Information "" -InformationAction Continue
+
+            # If missing modules suggest Initialize-SCuBA otherwise suggest Reset-ScubaGearDependencies
+            if ($criticalModules.HighestStatus -eq "MISSING" -and -not $dependencyStatus.ModuleFileLocations) {
+                Write-Information "Run 'Initialize-SCuBA' to install missing modules." -InformationAction Continue
+            }else{
                 Write-Information "Run 'Reset-ScubaGearDependencies' to fix." -InformationAction Continue
                 Write-Information "" -InformationAction Continue
             }
         }
-
     }
     catch {
         throw "Error checking ScubaGear version: $($_.Exception.Message)"
@@ -1391,7 +1368,6 @@ function Get-DependencyStatus {
 
                 # Check for version mismatches
                 $versionIssues = @()
-                $hasValidVersion = $false
 
                 foreach ($module in $modules) {
                     $installedVersion = [version]$module.Version
@@ -1416,31 +1392,47 @@ function Get-DependencyStatus {
                             Location = $module.ModuleBase
                         }
                     }
-                    else {
-                        $hasValidVersion = $true
-                    }
                 }
 
-                # If there are version issues and no valid version exists, add to mismatch list
-                if ($versionIssues.Count -gt 0 -and -not $hasValidVersion) {
+                # Always record version issues (PowerShell loads highest version by default)
+                if ($versionIssues.Count -gt 0) {
                     $dependencyStatus.VersionMismatches += $versionIssues
                 }
 
-                # Check for multiple versions or version mismatches
-                if ($modules.Count -gt 1 -or ($versionIssues.Count -gt 0 -and -not $hasValidVersion)) {
+                # Determine highest version and its status (what PowerShell will actually load)
+                $sortedModules = $modules | Sort-Object -Property Version -Descending
+                $highestModule = $sortedModules[0]
+                $highestVersion = [version]$highestModule.Version
+
+                # Determine highest version status
+                $highestStatus = "OK"
+                if ($highestVersion -lt $minVersion) {
+                    $highestStatus = "BELOW MIN: $($minVersion)"
+                }
+                elseif ($highestVersion -gt $maxVersion) {
+                    $highestStatus = "ABOVE MAX: $($maxVersion)"
+                }
+
+                # Check for multiple versions or version issues
+                if ($modules.Count -gt 1 -or $versionIssues.Count -gt 0) {
                     # Only add to MultipleVersions if there are actually multiple versions
                     if ($modules.Count -gt 1) {
                         $dependencyStatus.MultipleVersions += $moduleName
                     }
 
-                    # Create simplified file location information
+                    # Create file location information with highest version tracking
                     $locationInfo = [PSCustomObject]@{
                         ModuleName = $moduleName
                         VersionCount = $modules.Count
                         MinVersion = $minVersion.ToString()
                         MaxVersion = $maxVersion.ToString()
+                        HighestVersion = $highestVersion.ToString()
+                        HighestVersionStatus = $highestStatus
                         Locations = @()
                     }
+
+                    # Sort modules by Version property to ensure correct min/max
+                    $modules = $modules | Sort-Object -Property Version
 
                     foreach ($module in $modules) {
                         $installedVersion = [version]$module.Version
@@ -1485,71 +1477,77 @@ function Get-DependencyStatus {
         }
     }
 
-    # Determine overall status
-    if ($dependencyStatus.Missing.Count -eq 0) {
-        if ($dependencyStatus.VersionMismatches.Count -gt 0) {
-            $dependencyStatus.Status = "Version Issues"  # Identify when a module version is either below the minimum or above the maximum required version.
+    # Determine overall status based on what PowerShell will actually load
+    if ($dependencyStatus.Missing.Count -gt 0) {
+        $dependencyStatus.Status = "Critical"
+    }
+    else {
+        # Check if any module's highest version (what will be loaded) is out of range
+        $criticalModules = $dependencyStatus.ModuleFileLocations | Where-Object { $_.HighestVersionStatus -ne "OK" }
+
+        if ($criticalModules) {
+            $dependencyStatus.Status = "Critical"
         }
-        elseif ($dependencyStatus.MultipleVersions.Count -eq 0) {
-            $dependencyStatus.Status = "Optimal" # Setup correctly, no issues
-        } else {
-            $dependencyStatus.Status = "Needs Cleanup" # Only multiple versions need to be addressed
+        elseif ($dependencyStatus.MultipleVersions.Count -gt 0) {
+            $dependencyStatus.Status = "Needs Cleanup"
         }
-    } else {
-        $dependencyStatus.Status = "Missing Modules"
+        else {
+            $dependencyStatus.Status = "OK"
+        }
     }
 
-    # Generate recommendations
+    # Generate recommendations based on severity
     $recommendations = @()
+    $criticalRecommendations = @()
+    $cleanupRecommendations = @()
 
-    # Handle version mismatch recommendations
-    if ($dependencyStatus.VersionMismatches.Count -gt 0) {
-        $belowMin = $dependencyStatus.VersionMismatches | Where-Object { $_.Issue -eq "Below Minimum" }
-        $aboveMax = $dependencyStatus.VersionMismatches | Where-Object { $_.Issue -eq "Above Maximum" }
-
-        $versionIssues = @()
-        if ($belowMin.Issue.Count -gt 0) {
-            $uniqueBelowMin = ($belowMin | Select-Object -ExpandProperty ModuleName -Unique) -join ', '
-            $versionIssues += "$uniqueBelowMin below minimum required version"
-        }
-        if ($aboveMax.Issue.Count -gt 0) {
-            $uniqueAboveMax = ($aboveMax | Select-Object -ExpandProperty ModuleName -Unique) -join ', '
-            $versionIssues += "$uniqueAboveMax above maximum required version"
-        }
-
-        if ($versionIssues.Count -gt 0) {
-            $recommendations += ($versionIssues -join ". ") + ". Run 'Reset-ScubaGearDependencies' to fix."
-        }
-    }
-
-    # Handle missing and multiple version scenarios
-    $hasMissing = $dependencyStatus.Missing.Count -gt 0
-    $hasMultiple = $dependencyStatus.MultipleVersions.Count -gt 0
-    $missingCount = $dependencyStatus.Missing.Count
-    $multipleCount = $dependencyStatus.MultipleVersions.Count
-
-    if ($hasMissing -and $hasMultiple) {
-        $moduleText = if ($multipleCount -eq 1) { "module has" } else { "modules have" }
-        $missingText = if ($missingCount -eq 1) { "module is" } else { "modules are" }
-        $recommendations += "$multipleCount $moduleText multiple versions installed. Also $missingCount $missingText missing. Run 'Reset-ScubaGearDependencies' to clean up."
-    }
-    elseif ($hasMissing) {
+    # Check for missing modules (critical)
+    if ($dependencyStatus.Missing.Count -gt 0) {
+        $missingCount = $dependencyStatus.Missing.Count
         $dependencyText = if ($missingCount -eq 1) { "dependency" } else { "dependencies" }
-        $recommendations += "Missing $missingCount $dependencyText. Run 'Initialize-SCuBA' to install."
+        $criticalRecommendations += "Missing $missingCount $dependencyText. Run 'Initialize-SCuBA' to install."
     }
-    elseif ($hasMultiple) {
-        $moduleText = if ($multipleCount -eq 1) { "module has" } else { "modules have" }
-        $recommendations += "$multipleCount $moduleText multiple versions installed. Run 'Reset-ScubaGearDependencies' to clean up."
+
+    # Check for modules where highest version is out of range (critical)
+    foreach ($moduleInfo in $dependencyStatus.ModuleFileLocations) {
+        if ($moduleInfo.HighestVersionStatus -ne "OK") {
+            $statusMsg = if ($moduleInfo.HighestVersionStatus -like "ABOVE MAX*") {
+                "above maximum ($($moduleInfo.MaxVersion))"
+            } else {
+                "below minimum ($($moduleInfo.MinVersion))"
+            }
+            $criticalRecommendations += "$($moduleInfo.ModuleName) will load version $($moduleInfo.HighestVersion) which is $statusMsg - this may cause failures. Run 'Reset-ScubaGearDependencies' to fix."
+        }
+        elseif ($moduleInfo.VersionCount -gt 1) {
+            # Multiple versions but highest is OK (cleanup only)
+            $cleanupRecommendations += "$($moduleInfo.ModuleName) has $($moduleInfo.VersionCount) versions installed but will load $($moduleInfo.HighestVersion) which is acceptable - cleanup recommended for best practice."
+        }
+    }
+
+    # Combine recommendations (critical first, then cleanup)
+    if ($criticalRecommendations.Count -gt 0) {
+        $recommendations += $criticalRecommendations
+    }
+    if ($cleanupRecommendations.Count -gt 0) {
+        if ($criticalRecommendations.Count -eq 0) {
+            # Only cleanup issues - summarize
+            $multipleCount = ($dependencyStatus.ModuleFileLocations | Where-Object { $_.VersionCount -gt 1 }).Count
+            $moduleText = if ($multipleCount -eq 1) { "module has" } else { "modules have" }
+            $recommendations += "$multipleCount $moduleText multiple versions installed. Run 'Reset-ScubaGearDependencies' to clean up."
+        } else {
+            # Both critical and cleanup - add note about cleanup
+            $recommendations += "Also cleanup recommended for modules with multiple versions."
+        }
+    }
+
+    # Default message if everything is OK
+    if ($recommendations.Count -eq 0) {
+        $recommendations += "No action needed."
     }
 
     # Add admin privilege notice if needed
-    if ($dependencyStatus.AdminRequired -and $dependencyStatus.Status -ne "Optimal") {
+    if ($dependencyStatus.AdminRequired -and $dependencyStatus.Status -ne "OK") {
         $recommendations += "Administrator privileges required for some operations."
-    }
-
-    # Add optimal status message
-    if ($dependencyStatus.Status -eq "Optimal") {
-        $recommendations += "All dependencies are installed."
     }
 
     $dependencyStatus.Recommendations = $recommendations


### PR DESCRIPTION

## 🗣 Description ##
Enhanced `Get-DependencyStatus` function to detect when required PowerShell modules are installed but the version is above/below the allowed module version range. This was an issue only applicable when one version was installed. The update now checks for multiple versions and any version issues (above/below) module required version ranges.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
Previously, `Get-DependencyStatus` only flagged modules with multiple versions installed but did not alert the user when only one acceptable version was outside the allowed range. This caused confusing behavior as `Test-ScubaGearVersion` identified the issue and could cause issues running ScubaGear.

This change improves the developer/user experience by:
- Detecting missing modules early in the dependency check
- Providing clear messages indicating which modules has issues

closes #1966 

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
**Testing Environment:**
- Windows PowerShell 5.1
- Test cases with missing modules, multiple module versions, and one module above or below the required version range

**Test Scenarios:**
1. Tested with all required modules installed (should pass)
2. Tested with one or more required modules missing
3. Tested with multiple versions of a module installed
4. Tested with combination of missing modules and version conflicts
5. Tested with a module above maximum version and verified no other versions are installed

**How to test:**
1. Uninstall a required module (e.g., `Uninstall-Module -Name Microsoft.Graph.Authentication`)
2. Import ScubaGear module
3. Verify message indicating the missing module
4. Reinstall module and verify check passes
5. Continue for other test scenarios

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] Changes are sized such that they do not touch excessive number of files.
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [ ] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] All relevant type-of-change labels added.
- [ ] All relevant project fields are set.
- [ ] All relevant repo and/or project documentation updated to reflect these changes.
- [ ] Unit tests added/updated to cover PowerShell and Rego changes.
- [ ] Functional tests added/updated to cover PowerShell and Rego changes.
- [ ] All relevant functional tests passed.
- [ ] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] PR passed smoke test check.
- [ ] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [ ] Resolved all merge conflicts on branch
- [ ] Notified merge coordinator that PR is ready for merge via comment mention
- [ ] Demonstrate changes to the team for questions and comments. 
    (Note: Only required for issues of size `Medium` or larger)

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
