### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/cisagov/ScubaGear)
+
 ![ScubaGear Logo](docs/images/SCuBA%20GitHub%20Graphic%20v6-05.png)
 
 


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/cisagov/ScubaGear) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.