### PR TITLE
Removed gcch & dod message from validator

### DIFF
--- a/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfigValidator.psm1
+++ b/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfigValidator.psm1
@@ -318,13 +318,6 @@ class ScubaConfigValidator {
             }
         }
 
-        # Validate M365Environment warnings for government tenants
-        if ($ConfigObject.M365Environment -in @('gcchigh', 'dod')) {
-            $EnvName = if ($ConfigObject.M365Environment -eq 'gcchigh') { 'GCC High' } else { 'DoD' }
-            [void]$Validation.Warnings.Add("$EnvName environment selected. Ensure you have appropriate security clearance and authorization."
-)
-        }
-
         # Check for product exclusions on products that don't support them
         [ScubaConfigValidator]::ValidateUnsupportedProductExclusions($ConfigObject, $Validation)
 


### PR DESCRIPTION
# Remove hardcoded GCC High / DoD warning from config validator

## 🗣 Description ##

This PR removes the hardcoded warning message emitted when `Invoke-Scuba` is run with a configuration file that specifies **GCC High (GGCH)** or **DoD**.

The warning message stating:
> *"GCC High Environment selected. Ensure you have appropriate security clearance and authorization."*

was not intended to be enforced directly within `scubaConfigValidator.psm1`. Instead, this message was meant to be optionally configurable via the schema definition. As part of this change, the hardcoded warning has been removed completely with no optional schema controlled message.

## 💭 Motivation and context ##

The current behavior introduces an opinionated, non-configurable warning during validation that does not align with the intent of schema-driven messaging for configuration validation.

Removing the hardcoded warning:
- Restores separation of concerns between validation logic and messaging
- Prevents unintended or misleading output for environments where authorization is already established
- Keeps schema files as the authoritative source for optional, environment-specific messaging

This change resolves the behavior described in **Issue #1979**.

Closes #1979.

## 🧪 Testing ##

The following scenarios were validated:
- Ran `Invoke-Scuba` with a configuration file specifying `GGCH`
- Ran `Invoke-Scuba` with a configuration file specifying `DoD`
- Confirmed the warning message is no longer emitted during validation
- Verified no regression in configuration validation behavior
- Confirmed schema-based validation continues to function as expected

Testing was performed locally using existing ScubaGear test configurations.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch.
- [x] Changes are limited to a single goal.
- [x] Changes are sized such that they do not touch an excessive number of files.
- [x] These code changes follow the ScubaGear content style guide.
- [x] Related issue is linked using a closing keyword.
- [x] All relevant automated checks passed.

## ✅ Pre-merge checklist ##

- [ ] PR passed smoke test check.
- [ ] Feature branch rebased against parent branch, as needed.
- [ ] All merge conflicts resolved.
- [ ] Merge coordinator notified that PR is ready for merge.
- [ ] Changes demonstrated to the team (if required).

## ✅ Post-merge checklist ##

- [ ] Feature branch deleted after merge.
- [ ] Verified all checks pass on the parent branch after merge.