### PR TITLE
Fix failed control comments not displaying in "FailedAnnotatedControls"

### DIFF
--- a/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
+++ b/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
@@ -316,7 +316,7 @@ function New-Report {
                 if ($Result.DisplayString -eq "Fail") {
                     $ReportSummary["AnnotatedFailedPolicies"][$Control.Id] = @{}
                     $ReportSummary["AnnotatedFailedPolicies"][$Control.Id].IncorrectResult = $IncorrectResult
-                    $ReportSummary["AnnotatedFailedPolicies"][$Control.Id].Comment = $UserComment
+                    $ReportSummary["AnnotatedFailedPolicies"][$Control.Id].Comment = $PolicyComment
                     $ReportSummary["AnnotatedFailedPolicies"][$Control.Id].RemediationDate = $RemediationDate
                 }
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -126,6 +126,37 @@ New-SCuBAConfig -Organization "example.onmicrosoft.com" -ProductNames "aad,defen
 
 The generated file can then be manually edited to add your specific configuration settings.
 
+## Annotate Policies
+
+ScubaGear supports annotating results for individual policies. Annotated policies will be shown in the HTML with the
+annotation appended to the details column. Annotated policies are intended to:
+- Document action plans for any failed controls. ScubaGear will output a warning for any failing controls that are not
+documented in the config file, though this warning can be silenced with the `-SilenceBODWarnings` flag.
+- Help contextualize results
+- Allow users to identify incorrect results
+
+The `AnnotatePolicy` top-level key allows the user to specify the policies that should be annotated.
+
+Example policy annotations configuration:
+
+```yaml
+AnnotatePolicy:
+  MS.AAD.2.1v1:
+    IncorrectResult: false
+    Comment: "Remediation scheduled for Q2 2024"
+    RemediationDate: 2025-06-30
+  MS.EXO.3.1v1:
+    IncorrectResult: true
+    Comment: "False positive - DMARC is properly configured via third-party service"
+```
+
+For each annotated policy, the config file allows you to indicate the following:
+- `Comment`: **Required for failed controls.** The annotation message to add to the report. A warning will be printed if the control is marked incorrect with no comment provided as justification.
+- `RemediationDate`: **Optional.** The date a failing control is anticipated to be implemented. The expected format is yyyy-mm-dd.
+- `IncorrectResult`: **Optional.** Acceptable values: true or false. Whether or not to mark the result incorrect. Defaults to false.
+
+**Exercise care when marking incorrect results because this can inadvertently introduce blind spots when assessing your system.**
+
 ## Omit Policies
 
 In some cases, it may be appropriate to omit specific policies from ScubaGear evaluation. For example:
@@ -148,37 +179,6 @@ OmitPolicy:
 For each omitted policy, the config file allows you to indicate the following:
 - `Rationale`: The reason the policy should be omitted from the report. This value will be displayed in the "Details" column of the report. ScubaGear will output a warning if no rationale is provided.
 - `Expiration`: Optional. A date after which the policy should no longer be omitted from the report. The expected format is yyyy-mm-dd.
-
-## Annotate Policies
-
-ScubaGear supports annotating results for individual policies. Annotated policies will be shown in the HTML with the
-annotation appended to the details column. Annotated policies are intended to:
-- Document action plans for any failed controls. ScubaGear will output a warning for any failing controls that are not
-documented in the config file, though this warning can be silenced with the `-SilenceBODWarnings` flag.
-- Allow users to identify incorrect results
-- Help contextualize results
-
-The `AnnotatePolicy` top-level key allows the user to specify the policies that should be annotated.
-
-Example policy annotations configuration:
-
-```yaml
-AnnotatePolicy:
-  MS.AAD.2.1v1:
-    IncorrectResult: false
-    Comment: "Remediation scheduled for Q2 2024"
-    RemediationDate: 2025-06-30
-  MS.EXO.3.1v1:
-    IncorrectResult: true
-    Comment: "False positive - DMARC is properly configured via third-party service"
-```
-
-For each annotated policy, the config file allows you to indicate the following:
-- `IncorrectResult`: Boolean, whether or not to mark the result incorrect. Optional, defaults to false.
-- `Comment`: The annotation to add to the report. A warning will be printed if control is marked incorrect with no comment provided as justification.
-- `RemediationDate`: Optional. The date a failing control is anticipated to be implemented. The expected format is yyyy-mm-dd.
-
-**Exercise care when marking incorrect results because this can inadvertently introduce blind spots when assessing your system.**
 
 ## Product-specific Configuration
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

- Fixes a bug where the `FailedAnnotatedControls` key in ScubaResults.json was not correctly displaying the comments added to failed controls.
- Update Configuration.md such that the annotations documentation is displayed above omissions. Also adds required/optional text to each of the annotated fields.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

Closes #2026
Closes #2028 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Run ScubaGear with a configuration file, below is an example snippet you can use for some of the EXO policies to get started.

```
AnnotatePolicy:
  MS.EXO.2.2v3:
    IncorrectResult: true
    Comment: "tool report indicates fail but we have this implemented correctly"
    RemediationDate: "2026-12-31"
  MS.EXO.4.1v1:
    Comment: "This is failing for reasons"
    RemediationDate: "2026-12-31"
  MS.EXO.4.2v1:
    Comment: "This is failing for reasons"
    RemediationDate: "2026-12-31"
  MS.EXO.4.3v1:
    Comment: "This is failing for reasons"
    RemediationDate: "2026-12-31"
```

First, run ScubaGear from the main branch to replicate the issue. After the tool runs, confirm the warning message is output to terminal that `x controls are failing and are not documented in the config file` even though they are configured.

<img width="1267" height="25" alt="image" src="https://github.com/user-attachments/assets/6bf9eb06-ba21-463a-9dd9-5c1df9cbd615" />

Next, confirm that the `scuba_config` data reflects the policy annotations defined in your configuration file.

<img width="675" height="253" alt="image" src="https://github.com/user-attachments/assets/7261457f-00f7-4d94-8c5c-a145c2fbad50" />

Then, check `AnnotatedFailedControls` and you should see `null` for each of the `Comment` fields.

<img width="306" height="280" alt="image" src="https://github.com/user-attachments/assets/24fd6c26-d0c2-489b-b521-19a27059e526" />
 
Now, switch to this feature branch. Run ScubaGear again with the same configuration file. 

- Verify that no warning message is output to the terminal.
- Check `scuba_config` to make sure the data is displayed there.
- Check `AnnotatedFailedControls` to confirm comments are shown in each of the `Comment` fields.

<img width="549" height="282" alt="image" src="https://github.com/user-attachments/assets/ffb9db28-89e2-4285-8f8a-4d94ced12012" />

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [ ] ~~Unit tests added/updated to cover PowerShell and Rego changes.~~
- [ ] ~~Functional tests added/updated to cover PowerShell and Rego changes.~~
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] PR passed smoke test check.
- [ ] Feature branch has been rebased against changes from parent branch, as needed

  Use `Rebase branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [ ] Resolved all merge conflicts on branch
- [ ] Notified merge coordinator that PR is ready for merge via comment mention
- [ ] Demonstrate changes to the team for questions and comments. 
    (Note: Only required for issues of size `Medium` or larger)

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->
- [x] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
