### PR TITLE
fix: OutReportName config value ignored when using -ConfigFilePath

### DIFF
--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -1635,7 +1635,7 @@ function Invoke-ReportCreation {
 
             $ReportHTML = $ReportHTML.Replace("{JS_FILES}", "<script>`n $($JSFiles) `n</script>")
             Add-Type -AssemblyName System.Web -ErrorAction 'Stop'
-            $ReportFileName = Join-Path -Path $OutFolderPath "$($OutReportName).html" -ErrorAction 'Stop'
+            $ReportFileName = Join-Path -Path $OutFolderPath "$($ScubaConfig.OutReportName).html" -ErrorAction 'Stop'
             [System.Web.HttpUtility]::HtmlDecode($ReportHTML) | Out-File $ReportFileName -ErrorAction 'Stop'
 
             if (-Not $Quiet) {


### PR DESCRIPTION
## Summary

When using `-ConfigFilePath`, the `OutReportName` value from the config file is ignored. The report HTML is always named `BaselineReports.html` (the default) regardless of what `OutReportName` is set to in the YAML/JSON config.

## Root Cause

`Invoke-ReportCreation` receives `$ScubaConfig` (which contains `OutReportName`) but the function body on line 1638 still references the bare variable `$OutReportName`:

```powershell
$ReportFileName = Join-Path -Path $OutFolderPath "$($OutReportName).html" -ErrorAction 'Stop'
```

Since `$OutReportName` is not declared as a parameter of `Invoke-ReportCreation`, PowerShell resolves it via dynamic scoping back to the `$OutReportName` parameter of `Invoke-SCuBA`, which holds the default value `BaselineReports` when invoked via `-ConfigFilePath`.

## Fix

Single-line change — reference `$ScubaConfig.OutReportName` instead of the bare `$OutReportName`:

```powershell
$ReportFileName = Join-Path -Path $OutFolderPath "$($ScubaConfig.OutReportName).html" -ErrorAction 'Stop'
```

## Reproduction

1. Create a config file with `OutReportName: MyCustomReport`
2. Run `Invoke-SCuBA -ConfigFilePath config.yaml`
3. Output report is named `BaselineReports.html` instead of `MyCustomReport.html`