### PR TITLE
Add Application and Guest Exclusions Support

### DIFF
--- a/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfigSchema.json
+++ b/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfigSchema.json
@@ -472,6 +472,12 @@
         "type": "string",
         "pattern": "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
         "friendlyName": "User Principal Name (email format)"
+      },
+      "guestUserType": {
+        "_comment": "Valid guest user types for Conditional Access exclusions",
+        "pattern": "^(internalGuest|b2bCollaborationGuest|b2bCollaborationMember|b2bDirectConnectUser|otherExternalUser|serviceProvider)$",
+        "type": "string",
+        "friendlyName": "Guest user type"
       }
     },
 
@@ -493,6 +499,33 @@
             "type": "array",
             "items": {
               "$ref": "#/definitions/patterns/guid"
+            },
+            "uniqueItems": true
+          },
+          "Applications": {
+            "_comment": "Cloud app IDs to exclude from Conditional Access policies. Each entry must be either a valid GUID (e.g. '00000004-0000-0ff1-ce00-000000000000') or an alphanumeric named app string (e.g. 'Office365'). Malformed GUIDs will fail validation.",
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "_comment": "Valid GUID format",
+                  "$ref": "#/definitions/patterns/guid"
+                },
+                {
+                  "_comment": "Named app string (alphanumeric only, e.g. 'Office365', 'MicrosoftAdminPortals')",
+                  "type": "string",
+                  "pattern": "^[a-zA-Z0-9]+$",
+                  "minLength": 1
+                }
+              ]
+            },
+            "uniqueItems": true
+          },
+          "GuestUserTypes": {
+            "_comment": "Guest/external user types to exclude from Conditional Access policies. Values correspond to GuestOrExternalUserTypes in the MS Graph CAP schema.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/patterns/guestUserType"
             },
             "uniqueItems": true
           }

--- a/PowerShell/ScubaGear/Modules/ScubaConfigApp/ScubaConfigAppHelpers/ScubaConfigAppCommonUIHelper.psm1
+++ b/PowerShell/ScubaGear/Modules/ScubaConfigApp/ScubaConfigAppHelpers/ScubaConfigAppCommonUIHelper.psm1
@@ -299,20 +299,23 @@ Function Find-UIControlByName {
         }
     }
 
-    if ($parent.Content -and $parent.Content.Children) {
-        foreach ($child in $parent.Content.Children) {
-            $result = Find-UIControlByName -parent $child -targetName $targetName
-            if ($result) { return $result }
-        }
+    # Recurse into Content directly (handles ContentControl subclasses: ScrollViewer, etc.)
+    if ($parent.Content -and $parent.Content -isnot [string]) {
+        $result = Find-UIControlByName -parent $parent.Content -targetName $targetName
+        if ($result) { return $result }
+    }
+
+    # Recurse into Child directly (handles Border, Decorator subclasses)
+    if ($parent.Child -and $parent.Child -isnot [string]) {
+        $result = Find-UIControlByName -parent $parent.Child -targetName $targetName
+        if ($result) { return $result }
     }
 
     if ($parent.Items) {
         foreach ($item in $parent.Items) {
-            if ($item.Content -and $item.Content.Children) {
-                foreach ($child in $item.Content.Children) {
-                    $result = Find-UIControlByName -parent $child -targetName $targetName
-                    if ($result) { return $result }
-                }
+            if ($item.Content -and $item.Content -isnot [string]) {
+                $result = Find-UIControlByName -parent $item.Content -targetName $targetName
+                if ($result) { return $result }
             }
         }
     }

--- a/PowerShell/ScubaGear/Modules/ScubaConfigApp/ScubaConfigAppHelpers/ScubaConfigAppDynamicCardHelper.psm1
+++ b/PowerShell/ScubaGear/Modules/ScubaConfigApp/ScubaConfigAppHelpers/ScubaConfigAppDynamicCardHelper.psm1
@@ -56,6 +56,14 @@
                     $hasValue = $true
                 }
 
+            } elseif ($field.type -eq "multiselect") {
+                # For multiselect, check if any CheckBox in the panel is checked
+                $checkBoxPanelName = ($controlFieldName + "_CheckBoxPanel")
+                $checkBoxPanel = Find-UIControlByName -parent $detailsPanel -targetName $checkBoxPanelName
+                if ($checkBoxPanel) {
+                    $hasValue = $checkBoxPanel.Children | Where-Object { $_ -is [System.Windows.Controls.CheckBox] -and $_.IsChecked -eq $true } | Select-Object -First 1
+                }
+
             } elseif ($field.type -eq "boolean") {
                 # Boolean fields always have a value (true or false)
                 $hasValue = $true
@@ -159,6 +167,18 @@ Function Test-FieldValidation {
                                     $fieldValue += $textBlock.Text
                                 }
                             }
+                        }
+                    }
+                }
+                "multiselect" {
+                    $checkBoxPanelControl = Find-UIControlByName -parent $detailsPanel -targetName ($controlFieldName + "_CheckBoxPanel")
+                    if ($checkBoxPanelControl) {
+                        $checkedItems = $checkBoxPanelControl.Children | Where-Object { $_ -is [System.Windows.Controls.CheckBox] -and $_.IsChecked -eq $true }
+                        if ($checkedItems) {
+                            $hasValue = $true
+                            $fieldValue = @($checkedItems | ForEach-Object {
+                                if ($_.Tag) { $_.Tag.ToString() } else { $_.Content.ToString() }
+                            })
                         }
                     }
                 }
@@ -501,6 +521,42 @@ Function New-FieldListControl {
 
         # Add input row and list container to field panel
         [void]$fieldPanel.Children.Add($arrayContainer)
+
+    } elseif ($Field.type -eq "multiselect") {
+        # Create a compact scrollable checkbox panel sourced from JSON field items
+        $checkBoxPanel = New-Object System.Windows.Controls.StackPanel
+        $checkBoxPanel.Name = $fieldName + "_CheckBoxPanel"
+        $checkBoxPanel.Margin = "2,2,2,2"
+
+        # Source options from valueValidations.allowedValues (key=config value, value=display label)
+        $allowedValues = $syncHash.UIConfigs.valueValidations.($Field.valueType).allowedValues
+        if ($allowedValues) {
+            foreach ($configValue in $allowedValues.PSObject.Properties.Name) {
+                $cb = New-Object System.Windows.Controls.CheckBox
+                $cb.Content = $allowedValues.$configValue
+                $cb.Tag     = $configValue
+                $cb.Margin  = "0,3,0,3"
+                Add-UIControlEventHandler -Control $cb
+                [void]$checkBoxPanel.Children.Add($cb)
+            }
+        }
+
+        $scrollViewer = New-Object System.Windows.Controls.ScrollViewer
+        $scrollViewer.MaxHeight = 160
+        $scrollViewer.VerticalScrollBarVisibility = "Auto"
+        $scrollViewer.HorizontalScrollBarVisibility = "Disabled"
+        $scrollViewer.Content = $checkBoxPanel
+
+        $checkBorder = New-Object System.Windows.Controls.Border
+        $checkBorder.BorderThickness = "1"
+        $checkBorder.BorderBrush = $syncHash.Window.FindResource("BorderBrush")
+        $checkBorder.CornerRadius = "3"
+        $checkBorder.Padding = "6,4,6,4"
+        $checkBorder.Width = 260
+        $checkBorder.HorizontalAlignment = "Left"
+        $checkBorder.Child = $scrollViewer
+
+        [void]$fieldPanel.Children.Add($checkBorder)
 
     } elseif ($Field.type -eq "boolean") {
         # Create boolean checkbox control
@@ -1158,6 +1214,34 @@ Function New-FieldListCard {
                             Add-FieldListControl -FieldPanel $listContainer -ExistingValues $existingData
                         }
                     }
+                    elseif ($field.type -eq "multiselect") {
+                        # Pre-check checkboxes that match the existing data
+                        $checkBoxPanelName = ($fieldName + "_CheckBoxPanel")
+                        $checkBoxPanel = $null
+
+                        if ($validInputFields.Count -gt 1) {
+                            $tabControl = $detailsPanel.Children | Where-Object { $_ -is [System.Windows.Controls.TabControl] }
+                            foreach ($tabItem in $tabControl.Items) {
+                                if ($tabItem.Header -eq $FieldListDef.name) {
+                                    $tabContent = $tabItem.Content
+                                    $checkBoxPanel = Find-UIControlByName -parent $tabContent -targetName $checkBoxPanelName
+                                    if ($checkBoxPanel) { break }
+                                }
+                            }
+                        } else {
+                            $checkBoxPanel = Find-UIControlByName -parent $detailsPanel -targetName $checkBoxPanelName
+                        }
+
+                        if ($checkBoxPanel) {
+                            foreach ($cb in $checkBoxPanel.Children) {
+                                if ($cb -is [System.Windows.Controls.CheckBox]) {
+                                    # Match against Tag (config value) if present, else Content
+                                    $cbValue = if ($cb.Tag) { $cb.Tag.ToString() } else { $cb.Content.ToString() }
+                                    $cb.IsChecked = $existingData -contains $cbValue
+                                }
+                            }
+                        }
+                    }
                     elseif ($field.type -eq "boolean") {
                         # Pre-populate boolean field
                         $booleanFieldName = ($fieldName + "_CheckBox")
@@ -1404,6 +1488,24 @@ Function New-FieldListCard {
                         }
                     } else {
                         Write-DebugOutput -Message ("List container not found or empty for: {0}" -f $listContainerName) -Source $this.Name -Level "Error"
+                    }
+
+                } elseif ($field.type -eq "multiselect") {
+                    # Collect checked items from the checkbox panel
+                    $checkBoxPanelName = ($controlFieldName + "_CheckBoxPanel")
+                    $checkBoxPanel = Find-UIControlByName -parent $detailsPanel -targetName $checkBoxPanelName
+
+                    if ($checkBoxPanel) {
+                        $items = @($checkBoxPanel.Children | Where-Object { $_ -is [System.Windows.Controls.CheckBox] -and $_.IsChecked -eq $true } | ForEach-Object {
+                            # Use Tag (config value) if present, else fall back to Content
+                            if ($_.Tag) { $_.Tag.ToString() } else { $_.Content.ToString() }
+                        })
+                        if ($items.Count -gt 0) {
+                            $fieldCardData[$field.value] = $items
+                            Write-DebugOutput -Message ($syncHash.UIConfigs.LocaleInfoMessages.CollectedArrayField -f $inputData, $field.value, ($items -join ', ')) -Source $this.Name -Level "Info"
+                        }
+                    } else {
+                        Write-DebugOutput -Message ("CheckBox panel not found for: {0}" -f $checkBoxPanelName) -Source $this.Name -Level "Error"
                     }
 
                 } elseif ($field.type -eq "boolean") {

--- a/PowerShell/ScubaGear/Modules/ScubaConfigApp/ScubaConfigApp_CHANGELOG.md
+++ b/PowerShell/ScubaGear/Modules/ScubaConfigApp/ScubaConfigApp_CHANGELOG.md
@@ -1,4 +1,9 @@
 :  # SCUBACONFIGAPPUI CHANGELOG
+## 2.4.13 [4/13/2026] - Extended CAPExclusions Support and UI Enhancements
+
+### Enhancements
+- Extended `CapExclusions` support to `Applications` and `GuestUserTypes`.
+- Added multi select list boxes in the UI for easier management of guest user type exclusions.
 
 ## 1.9.22 [09/15/2025] - UI & Usability Improvements
 

--- a/PowerShell/ScubaGear/Modules/ScubaConfigApp/ScubaConfigApp_Control_en-US.json
+++ b/PowerShell/ScubaGear/Modules/ScubaConfigApp/ScubaConfigApp_Control_en-US.json
@@ -558,9 +558,9 @@
   },
   "inputTypes": {
     "CapExclusions": {
-      "name": "Conditional Access Policy Excluded Groups and Users",
+      "name": "Conditional Access Policy Excluded Groups, Users, Applications, and Guest User Types",
       "value": "CapExclusions",
-      "description": "Exclude specific groups or users from conditional access policies",
+      "description": "Exclude specific groups, users, applications, and guest user types from conditional access policies",
       "fields": [
         {
           "type": "array",
@@ -576,6 +576,53 @@
           "value": "Users",
           "description": "User IDs to exclude from this policy",
           "valueType": "guid",
+          "required": false
+        },
+        {
+          "type": "array",
+          "name": "Cloud Applications",
+          "value": "Applications",
+          "description": "Cloud Applications, GUIDS and names, to exclude from this policy",
+          "valueType": "guidOrName",
+          "required": false
+        },
+        {
+          "type": "multiselect",
+          "name": "Guest User Types",
+          "value": "GuestUserTypes",
+          "description": "Guest user types to exclude from this policy",
+          "valueType": "guestTypes",
+          "required": false
+        }
+      ]
+    },
+    "CapExclusionsWithoutApps": {
+      "name": "Conditional Access Policy Excluded Groups, Users, and Guest User Types Without Applications",
+      "value": "CapExclusions",
+      "description": "Exclude specific groups, users, and guest user types from conditional access policies without specifying applications",
+      "fields": [
+        {
+          "type": "array",
+          "name": "Group Object Id's",
+          "value": "Groups",
+          "description": "Group IDs to exclude from this policy",
+          "valueType": "guid",
+          "required": false
+        },
+        {
+          "type": "array",
+          "name": "User Object Id's",
+          "value": "Users",
+          "description": "User IDs to exclude from this policy",
+          "valueType": "guid",
+          "required": false
+        },
+        {
+          "type": "multiselect",
+          "name": "Guest User Types",
+          "value": "GuestUserTypes",
+          "description": "Guest user types to exclude from this policy",
+          "valueType": "guestTypes",
           "required": false
         }
       ]
@@ -841,6 +888,27 @@
       "invalidScriptMessage": "",
       "invalidScriptChecks": [],
       "sensitive": true
+    },
+    "guidOrName": {
+      "pattern": "^[{(]?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}[)}]?$|^[a-zA-Z0-9]+$",
+      "sample": "123e4567-e89b-12d3-a456-426614174000 or Office365",
+      "format": "123e4567-e89b-12d3-a456-426614174000 or Office365",
+      "invalidScriptMessage": "",
+      "invalidScriptChecks": [],
+      "sensitive": true
+    },
+    "guestTypes": {
+      "itemType": "string",
+      "format": "multiselect",
+      "allowedValues": {
+        "b2bCollaborationGuest":  "B2B collaboration guest users",
+        "b2bCollaborationMember": "B2B collaboration member users",
+        "b2bDirectConnectUser":   "B2B direct connect users",
+        "internalGuest":          "Local guest users",
+        "serviceProvider":        "Service provider users",
+        "otherExternalUser":      "Other external users"
+      },
+      "sensitive": false
     },
     "yearmonthday": {
       "pattern": "^(19|20)\\d{2}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$",

--- a/PowerShell/ScubaGear/Modules/ScubaConfigApp/ScubaConfigApp_Control_en-US.json
+++ b/PowerShell/ScubaGear/Modules/ScubaConfigApp/ScubaConfigApp_Control_en-US.json
@@ -1,5 +1,5 @@
 {
-  "Version": "2.1.23 (build 955)",
+  "Version": "2.4.13 (build 1205)",
   "DebugMode": true,
   "AutoSaveProgress": false,
   "EnableSearchAndFilter": true,

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -13,6 +13,8 @@ import data.utils.aad.ReportDetailsArrayLicenseWarningCap
 import data.utils.aad.ReportDetailsArrayLicenseWarning
 import data.utils.aad.UserExclusionsFullyExempt
 import data.utils.aad.GroupExclusionsFullyExempt
+import data.utils.aad.AppExclusionsFullyExempt
+import data.utils.aad.GuestUserExclusionsFullyExempt
 import data.utils.aad.Aad2P2Licenses
 import data.utils.aad.IsPhishingResistantMFA
 import data.utils.aad.IsGeneralMFA
@@ -50,7 +52,6 @@ LegacyAuthentication contains CAPolicy.DisplayName if {
     Contains(CAPolicy.Conditions.Users.IncludeUsers, "All") == true
     Contains(CAPolicy.Conditions.Applications.IncludeApplications, "All") == true
     Count(CAPolicy.Conditions.Users.ExcludeRoles) == 0
-    Count(CAPolicy.Conditions.Applications.ExcludeApplications) == 0
     CAPolicy.State == "enabled"
     ###
 
@@ -63,6 +64,8 @@ LegacyAuthentication contains CAPolicy.DisplayName if {
     # Only match policies with user and group exclusions per the confile file
     UserExclusionsFullyExempt(CAPolicy, "MS.AAD.1.1v1") == true
     GroupExclusionsFullyExempt(CAPolicy, "MS.AAD.1.1v1") == true
+    AppExclusionsFullyExempt(CAPolicy, "MS.AAD.1.1v1") == true
+    GuestUserExclusionsFullyExempt(CAPolicy, "MS.AAD.1.1v1") == true
 }
 
 # Pass if at least 1 policy meets all conditions
@@ -96,7 +99,6 @@ BlockHighRisk contains CAPolicy.DisplayName if {
     Contains(CAPolicy.Conditions.Users.IncludeUsers, "All") == true
     Contains(CAPolicy.Conditions.Applications.IncludeApplications, "All") == true
     Count(CAPolicy.Conditions.Users.ExcludeRoles) == 0
-    Count(CAPolicy.Conditions.Applications.ExcludeApplications) == 0
     CAPolicy.State == "enabled"
     ###
 
@@ -108,6 +110,8 @@ BlockHighRisk contains CAPolicy.DisplayName if {
     # Only match policies with user and group exclusions per the confile file
     UserExclusionsFullyExempt(CAPolicy, "MS.AAD.2.1v1") == true
     GroupExclusionsFullyExempt(CAPolicy, "MS.AAD.2.1v1") == true
+    AppExclusionsFullyExempt(CAPolicy, "MS.AAD.2.1v1") == true
+    GuestUserExclusionsFullyExempt(CAPolicy, "MS.AAD.2.1v1") == true
 }
 
 # Pass if at least 1 policy meets all conditions & has correct
@@ -157,7 +161,6 @@ SignInBlocked contains CAPolicy.DisplayName if {
     Contains(CAPolicy.Conditions.Users.IncludeUsers, "All") == true
     Contains(CAPolicy.Conditions.Applications.IncludeApplications, "All") == true
     Count(CAPolicy.Conditions.Users.ExcludeRoles) == 0
-    Count(CAPolicy.Conditions.Applications.ExcludeApplications) == 0
     CAPolicy.State == "enabled"
     ###
 
@@ -169,6 +172,8 @@ SignInBlocked contains CAPolicy.DisplayName if {
     # Only match policies with user and group exclusions per the confile file
     UserExclusionsFullyExempt(CAPolicy, "MS.AAD.2.3v1") == true
     GroupExclusionsFullyExempt(CAPolicy, "MS.AAD.2.3v1") == true
+    AppExclusionsFullyExempt(CAPolicy, "MS.AAD.2.3v1") == true
+    GuestUserExclusionsFullyExempt(CAPolicy, "MS.AAD.2.3v1") == true
 }
 
 # Pass if at least 1 policy meets all conditions & has correct
@@ -208,7 +213,6 @@ PhishingResistantMFAPolicies contains CAPolicy.DisplayName if {
     Contains(CAPolicy.Conditions.Users.IncludeUsers, "All") == true
     Contains(CAPolicy.Conditions.Applications.IncludeApplications, "All") == true
     Count(CAPolicy.Conditions.Users.ExcludeRoles) == 0
-    Count(CAPolicy.Conditions.Applications.ExcludeApplications) == 0
     CAPolicy.State == "enabled"
     ###
 
@@ -219,6 +223,8 @@ PhishingResistantMFAPolicies contains CAPolicy.DisplayName if {
     # Only match policies with user and group exclusions per the confile file
     UserExclusionsFullyExempt(CAPolicy, "MS.AAD.3.1v1") == true
     GroupExclusionsFullyExempt(CAPolicy, "MS.AAD.3.1v1") == true
+    AppExclusionsFullyExempt(CAPolicy, "MS.AAD.3.1v1") == true
+    GuestUserExclusionsFullyExempt(CAPolicy, "MS.AAD.3.1v1") == true
 }
 
 # Pass if at least 1 policy meets all conditions
@@ -248,7 +254,6 @@ NonSpecificMFAPolicies contains CAPolicy.DisplayName if {
     Contains(CAPolicy.Conditions.Users.IncludeUsers, "All") == true
     Contains(CAPolicy.Conditions.Applications.IncludeApplications, "All") == true
     Count(CAPolicy.Conditions.Users.ExcludeRoles) == 0
-    Count(CAPolicy.Conditions.Applications.ExcludeApplications) == 0
     CAPolicy.State == "enabled"
     ###
 
@@ -259,6 +264,8 @@ NonSpecificMFAPolicies contains CAPolicy.DisplayName if {
     # Only match policies with user and group exclusions per the confile file
     UserExclusionsFullyExempt(CAPolicy, "MS.AAD.3.2v2") == true
     GroupExclusionsFullyExempt(CAPolicy, "MS.AAD.3.2v2") == true
+    AppExclusionsFullyExempt(CAPolicy, "MS.AAD.3.2v2") == true
+    GuestUserExclusionsFullyExempt(CAPolicy, "MS.AAD.3.2v2") == true
 }
 
 # Pass if at least 1 policy meets all conditions
@@ -426,7 +433,6 @@ PhishingResistantMFAPrivilegedRoles contains CAPolicy.DisplayName if {
     ### We don't check IncludeUsers All because this is a role based policy
     Contains(CAPolicy.Conditions.Applications.IncludeApplications, "All") == true
     Count(CAPolicy.Conditions.Users.ExcludeRoles) == 0
-    Count(CAPolicy.Conditions.Applications.ExcludeApplications) == 0
     CAPolicy.State == "enabled"
     ###
 
@@ -440,6 +446,8 @@ PhishingResistantMFAPrivilegedRoles contains CAPolicy.DisplayName if {
     # Only match policies with user and group exclusions per the confile file
     UserExclusionsFullyExempt(CAPolicy, "MS.AAD.3.6v1") == true
     GroupExclusionsFullyExempt(CAPolicy, "MS.AAD.3.6v1") == true
+    AppExclusionsFullyExempt(CAPolicy, "MS.AAD.3.6v1") == true
+    GuestUserExclusionsFullyExempt(CAPolicy, "MS.AAD.3.6v1") == true
 }
 
 # Pass if at least 1 policy meets all conditions
@@ -469,7 +477,6 @@ ManagedDeviceAuth contains CAPolicy.DisplayName if {
     Contains(CAPolicy.Conditions.Users.IncludeUsers, "All") == true
     Contains(CAPolicy.Conditions.Applications.IncludeApplications, "All") == true
     Count(CAPolicy.Conditions.Users.ExcludeRoles) == 0
-    Count(CAPolicy.Conditions.Applications.ExcludeApplications) == 0
     CAPolicy.State == "enabled"
     ###
 
@@ -483,6 +490,8 @@ ManagedDeviceAuth contains CAPolicy.DisplayName if {
     # Only match policies with user and group exclusions per the confile file
     UserExclusionsFullyExempt(CAPolicy, "MS.AAD.3.7v1") == true
     GroupExclusionsFullyExempt(CAPolicy, "MS.AAD.3.7v1") == true
+    AppExclusionsFullyExempt(CAPolicy, "MS.AAD.3.7v1") == true
+    GuestUserExclusionsFullyExempt(CAPolicy, "MS.AAD.3.7v1") == true
 }
 
 # Pass if at least 1 policy meets all conditions
@@ -527,6 +536,7 @@ RequireManagedDeviceMFA contains CAPolicy.DisplayName if {
     # Only match policies with user and group exclusions per the confile file
     UserExclusionsFullyExempt(CAPolicy, "MS.AAD.3.8v1") == true
     GroupExclusionsFullyExempt(CAPolicy, "MS.AAD.3.8v1") == true
+    GuestUserExclusionsFullyExempt(CAPolicy, "MS.AAD.3.8v1") == true
 }
 
 # Pass if at least 1 policy meets all conditions
@@ -555,7 +565,6 @@ RequireDeviceCodeBlock contains CAPolicy.DisplayName if {
     Contains(CAPolicy.Conditions.Users.IncludeUsers, "All") == true
     Contains(CAPolicy.Conditions.Applications.IncludeApplications, "All") == true
     Count(CAPolicy.Conditions.Users.ExcludeRoles) == 0
-    Count(CAPolicy.Conditions.Applications.ExcludeApplications) == 0
     CAPolicy.State == "enabled"
     ###
 
@@ -567,6 +576,8 @@ RequireDeviceCodeBlock contains CAPolicy.DisplayName if {
     # Only match policies with user and group exclusions per the confile file
     UserExclusionsFullyExempt(CAPolicy, "MS.AAD.3.9v1") == true
     GroupExclusionsFullyExempt(CAPolicy, "MS.AAD.3.9v1") == true
+    AppExclusionsFullyExempt(CAPolicy, "MS.AAD.3.9v1") == true
+    GuestUserExclusionsFullyExempt(CAPolicy, "MS.AAD.3.9v1") == true
 }
 
 # Pass if at least 1 policy meets all conditions

--- a/PowerShell/ScubaGear/Rego/Utils/AAD.rego
+++ b/PowerShell/ScubaGear/Rego/Utils/AAD.rego
@@ -158,24 +158,23 @@ AppExclusionsFullyExempt(Policy, PolicyID) := true if {
 
 default GuestUserExclusionsFullyExempt(_, _) := false
 
-# Returns true when there are no guest exclusions on the policy (GuestOrExternalUserTypes null)
-# and no guest config is defined
+# Returns true (pass) when the CAP has no guest user type exclusions configured.
+# This covers cases where ExcludeGuestsOrExternalUsers is null, or has
+# no GuestOrExternalUserTypes value - meaning no guest types are being excluded
+# from the policy, so no config exemption is needed.
 GuestUserExclusionsFullyExempt(Policy, PolicyID) := true if {
-    GuestOrExternalUserTypes := Policy.Conditions.Users.ExcludeGuestsOrExternalUsers.GuestOrExternalUserTypes
-    GuestOrExternalUserTypes == null
-    not input.scuba_config.Aad[PolicyID].CapExclusions.GuestUserTypes
+    not Policy.Conditions.Users.ExcludeGuestsOrExternalUsers.GuestOrExternalUserTypes
 }
 
-GuestUserExclusionsFullyExempt(Policy, PolicyID) := true if {
-    Policy.Conditions.Users.ExcludeGuestsOrExternalUsers == null
-    not input.scuba_config.Aad[PolicyID].CapExclusions.GuestUserTypes
-}
-
-# Returns true when all excluded guest types are in the exemption list.
+# Returns true (pass) when the CAP does exclude specific guest user types, but every
+# excluded type appears in the ScubaConfig allowlist for this policy. The Graph API
+# returns the excluded types as a comma-separated string (e.g. "b2bCollaborationGuest,internalGuest"),
+# which is split into individual values and compared against the allowlist. If any
+# excluded type is NOT in the allowlist, this returns false and the policy fails.
 GuestUserExclusionsFullyExempt(Policy, PolicyID) := true if {
     GuestExclusions := Policy.Conditions.Users.ExcludeGuestsOrExternalUsers
     GuestExclusions != null
-    ExcludedTypes := {t | some t in split(GuestExclusions.GuestOrExternalUserTypes, ",")}
+    ExcludedTypes := ConvertToSet(split(GuestExclusions.GuestOrExternalUserTypes, ","))
     AllowedTypes := ConvertToSet(input.scuba_config.Aad[PolicyID].CapExclusions.GuestUserTypes)
     count(ExcludedTypes - AllowedTypes) == 0
 }

--- a/PowerShell/ScubaGear/Rego/Utils/AAD.rego
+++ b/PowerShell/ScubaGear/Rego/Utils/AAD.rego
@@ -138,6 +138,47 @@ GroupExclusionsFullyExempt(Policy, PolicyID) := true if {
     count({y | y := input.scuba_config.Aad[PolicyID].CapExclusions.Groups}) == 0
 }
 
+default AppExclusionsFullyExempt(_, _) := false
+
+# Returns true when all application exclusions present in the conditional
+# access policy are exempted in matching config variable for the
+# baseline policy item.  Undefined if no exclusions AND no exemptions.
+AppExclusionsFullyExempt(Policy, PolicyID) := true if {
+    ExemptedApps := input.scuba_config.Aad[PolicyID].CapExclusions.Applications
+    ExcludedApps := ConvertToSet(Policy.Conditions.Applications.ExcludeApplications)
+    AllowedExcludedApps := ConvertToSet(ExemptedApps)
+    count(ExcludedApps - AllowedExcludedApps) == 0
+}
+
+# Returns true when both the policy exclusion list and the config list are empty
+AppExclusionsFullyExempt(Policy, PolicyID) := true if {
+    count({x | some x in Policy.Conditions.Applications.ExcludeApplications}) == 0
+    count({y | y := input.scuba_config.Aad[PolicyID].CapExclusions.Applications}) == 0
+}
+
+default GuestUserExclusionsFullyExempt(_, _) := false
+
+# Returns true when there are no guest exclusions on the policy (GuestOrExternalUserTypes null)
+# and no guest config is defined
+GuestUserExclusionsFullyExempt(Policy, PolicyID) := true if {
+    GuestOrExternalUserTypes := Policy.Conditions.Users.ExcludeGuestsOrExternalUsers.GuestOrExternalUserTypes
+    GuestOrExternalUserTypes == null
+    not input.scuba_config.Aad[PolicyID].CapExclusions.GuestUserTypes
+}
+
+GuestUserExclusionsFullyExempt(Policy, PolicyID) := true if {
+    Policy.Conditions.Users.ExcludeGuestsOrExternalUsers == null
+    not input.scuba_config.Aad[PolicyID].CapExclusions.GuestUserTypes
+}
+
+# Returns true when all excluded guest types are in the exemption list.
+GuestUserExclusionsFullyExempt(Policy, PolicyID) := true if {
+    GuestExclusions := Policy.Conditions.Users.ExcludeGuestsOrExternalUsers
+    GuestExclusions != null
+    ExcludedTypes := {t | some t in split(GuestExclusions.GuestOrExternalUserTypes, ",")}
+    AllowedTypes := ConvertToSet(input.scuba_config.Aad[PolicyID].CapExclusions.GuestUserTypes)
+    count(ExcludedTypes - AllowedTypes) == 0
+}
 
 #########################
 # General AAD Functions #

--- a/PowerShell/ScubaGear/Rego/Utils/AAD.rego
+++ b/PowerShell/ScubaGear/Rego/Utils/AAD.rego
@@ -162,7 +162,7 @@ default GuestUserExclusionsFullyExempt(_, _) := false
 # This covers cases where ExcludeGuestsOrExternalUsers is null, or has
 # no GuestOrExternalUserTypes value - meaning no guest types are being excluded
 # from the policy, so no config exemption is needed.
-GuestUserExclusionsFullyExempt(Policy, PolicyID) := true if {
+GuestUserExclusionsFullyExempt(Policy, _) := true if {
     not Policy.Conditions.Users.ExcludeGuestsOrExternalUsers.GuestOrExternalUserTypes
 }
 

--- a/PowerShell/ScubaGear/Rego/Utils/AAD.rego
+++ b/PowerShell/ScubaGear/Rego/Utils/AAD.rego
@@ -159,11 +159,10 @@ AppExclusionsFullyExempt(Policy, PolicyID) := true if {
 default GuestUserExclusionsFullyExempt(_, _) := false
 
 # Returns true (pass) when the CAP has no guest user type exclusions configured.
-# This covers cases where ExcludeGuestsOrExternalUsers is null, or has
-# no GuestOrExternalUserTypes value - meaning no guest types are being excluded
-# from the policy, so no config exemption is needed.
+# The Graph API returns ExcludeGuestsOrExternalUsers as null when no guest types
+# are excluded from the policy, meaning no config exemption is needed.
 GuestUserExclusionsFullyExempt(Policy, _) := true if {
-    not Policy.Conditions.Users.ExcludeGuestsOrExternalUsers.GuestOrExternalUserTypes
+    Policy.Conditions.Users.ExcludeGuestsOrExternalUsers == null
 }
 
 # Returns true (pass) when the CAP does exclude specific guest user types, but every

--- a/PowerShell/ScubaGear/Sample-Config-Files/full_config.yaml
+++ b/PowerShell/ScubaGear/Sample-Config-Files/full_config.yaml
@@ -85,6 +85,16 @@ Aad:
         - 1a0161f4-318c-4415-b2a0-862bde2c9cde # Example Group 1
       Users:
         - 9d9ac7b2-5aa6-4830-a17a-6557e52140b0 # Example User 1
+      Applications:
+        - 49b4dcdf-1f90-41a7-9b42-5cfe9dd7e3b4 # Example Application 1
+        - Office365 # Example Application 2
+      GuestUserTypes:
+        - internalGuest
+        - b2bCollaborationGuest
+        - b2bCollaborationMember
+        - b2bDirectConnectUser
+        - otherExternalUser
+        - serviceProvider
 
   # Users detected as high risk SHALL be blocked.
   MS.AAD.2.1v1: *CommonCapExclusions
@@ -100,6 +110,10 @@ Aad:
         - cb075a02-09cf-4754-a673-90345120e03b # Example Group 3
       Users:
         - 9d9ac7b2-5aa6-4830-a17a-6557e52140b0 # Example User 1
+      Applications:
+        - 49b4dcdf-1f90-41a7-9b42-5cfe9dd7e3b4 # Example Application 1
+      GuestUserTypes:
+        - b2bCollaborationGuest
 
   # MFA SHALL be enforced for all users.
   MS.AAD.3.2v2: *MfaCapExclusions

--- a/PowerShell/ScubaGear/Sample-Config-Files/scuba_compliance.yaml
+++ b/PowerShell/ScubaGear/Sample-Config-Files/scuba_compliance.yaml
@@ -45,14 +45,18 @@ Aad:
         - ""
       Users:
         - ""
+      Applications:
+        - ""
+      GuestUserTypes:
+        - ""
   MS.AAD.2.1v1: *OrgCapExclusions
   MS.AAD.2.3v1: *OrgCapExclusions
   MS.AAD.3.1v1: *OrgCapExclusions
   MS.AAD.3.2v2: *OrgCapExclusions
-  MS.AAD.3.3v2: *OrgCapExclusions
   MS.AAD.3.6v1: *OrgCapExclusions
   MS.AAD.3.7v1: *OrgCapExclusions
   MS.AAD.3.8v1: *OrgCapExclusions
+  MS.AAD.3.9v1: *OrgCapExclusions
   MS.AAD.7.4v1:
     RoleExclusions:
       Groups:

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADBaseConfig.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADBaseConfig.rego
@@ -60,7 +60,9 @@ ConditionalAccessPolicies := {
 ScubaConfig := {
             "CapExclusions": {
                 "Users": [],
-                "Groups": []
+                "Groups": [],
+                "Applications": [],
+                "GuestUserTypes": []
             },
             "RoleExclusions": {
                 "Users": [],

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADBaseConfig.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADBaseConfig.rego
@@ -20,12 +20,7 @@ ConditionalAccessPolicies := {
             "ExcludeUsers": [],
             "ExcludeGroups": [],
             "ExcludeRoles": [],
-            "ExcludeGuestsOrExternalUsers":  {
-                "ExternalTenants":  {
-                    "MembershipKind":  null
-                },
-                "GuestOrExternalUserTypes":  null
-            },
+            "ExcludeGuestsOrExternalUsers":  null,
         },
         "UserRiskLevels": [
             "high"

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_01_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_01_test.rego
@@ -477,4 +477,61 @@ test_UserGroupExclusionTooFewUserExempts_Incorrect if {
 
     TestResult("MS.AAD.1.1v1", Output, ReportDetailStr, false) == true
 }
+
+# tests for Application exclusions
+test_AppExclusionConditions_Correct if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "Conditions/Applications/ExcludeApplications", "value": ["Office365"]}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+                        with input.scuba_config.Aad["MS.AAD.1.1v1"] as ScubaConfig
+                        with input.scuba_config.Aad["MS.AAD.1.1v1"].CapExclusions.Applications as ["Office365"]
+
+    ReportDetailStr := concat("", [
+        "1 conditional access policy(s) found that meet(s) all requirements:",
+        "<br/>Test Policy. <a href='#caps'>View all CA policies</a>."
+    ])
+
+    TestResult("MS.AAD.1.1v1", Output, ReportDetailStr, true) == true
+}
+
+# tests for guest user type exclusions
+test_GuestUserTypeExclusionConditions_Correct if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "Conditions/Users/ExcludeGuestsOrExternalUsers",
+                "value": {
+                    "GuestOrExternalUserTypes": "b2bCollaborationGuest,internalGuest",
+                    "ExternalTenants": {"MembershipKind": "all"}
+                }}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+                        with input.scuba_config.Aad["MS.AAD.1.1v1"] as ScubaConfig
+                        with input.scuba_config.Aad["MS.AAD.1.1v1"].CapExclusions.GuestUserTypes as [
+                            "b2bCollaborationGuest",
+                            "internalGuest"
+                        ]
+
+    ReportDetailStr := concat("", [
+        "1 conditional access policy(s) found that meet(s) all requirements:",
+        "<br/>Test Policy. <a href='#caps'>View all CA policies</a>."
+    ])
+
+    TestResult("MS.AAD.1.1v1", Output, ReportDetailStr, true) == true
+}
+
+test_GuestUserTypeExclusionNoExempt_Incorrect if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "Conditions/Users/ExcludeGuestsOrExternalUsers",
+                "value": {
+                    "GuestOrExternalUserTypes": "b2bCollaborationGuest",
+                    "ExternalTenants": {"MembershipKind": "all"}
+                }}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+
+    ReportDetailStr :=
+        "0 conditional access policy(s) found that meet(s) all requirements. <a href='#caps'>View all CA policies</a>."
+
+    TestResult("MS.AAD.1.1v1", Output, ReportDetailStr, false) == true
+}
 #--

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_02_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_02_test.rego
@@ -406,6 +406,66 @@ test_ServicePlans_Incorrect if {
         "**NOTE: Your tenant does not have a Microsoft Entra ID P2 license, which is required for this feature**"
     TestResult("MS.AAD.2.1v1", Output, ReportDetailStr, false) == true
 }
+
+# tests for Application exclusions
+test_AppExclusionConditions_Correct_V2 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "Conditions/Applications/ExcludeApplications", "value": ["Office365"]}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+                        with input.service_plans as ServicePlans
+                        with input.scuba_config.Aad["MS.AAD.2.1v1"] as ScubaConfig
+                        with input.scuba_config.Aad["MS.AAD.2.1v1"].CapExclusions.Applications as ["Office365"]
+
+    ReportDetailStr := concat("", [
+        "1 conditional access policy(s) found that meet(s) all requirements:",
+        "<br/>Test Policy. <a href='#caps'>View all CA policies</a>."
+    ])
+
+    TestResult("MS.AAD.2.1v1", Output, ReportDetailStr, true) == true
+}
+
+# tests for guest user type exclusions
+test_GuestUserTypeExclusionConditions_Correct_V2 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "Conditions/Users/ExcludeGuestsOrExternalUsers",
+                "value": {
+                    "GuestOrExternalUserTypes": "b2bCollaborationGuest,internalGuest",
+                    "ExternalTenants": {"MembershipKind": "all"}
+                }}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+                        with input.service_plans as ServicePlans
+                        with input.scuba_config.Aad["MS.AAD.2.1v1"] as ScubaConfig
+                        with input.scuba_config.Aad["MS.AAD.2.1v1"].CapExclusions.GuestUserTypes as [
+                            "b2bCollaborationGuest",
+                            "internalGuest"
+                        ]
+
+    ReportDetailStr := concat("", [
+        "1 conditional access policy(s) found that meet(s) all requirements:",
+        "<br/>Test Policy. <a href='#caps'>View all CA policies</a>."
+    ])
+
+    TestResult("MS.AAD.2.1v1", Output, ReportDetailStr, true) == true
+}
+
+test_GuestUserTypeExclusionNoExempt_Incorrect_V2 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "Conditions/Users/ExcludeGuestsOrExternalUsers",
+                "value": {
+                    "GuestOrExternalUserTypes": "b2bCollaborationGuest",
+                    "ExternalTenants": {"MembershipKind": "all"}
+                }}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+                        with input.service_plans as ServicePlans
+
+    ReportDetailStr :=
+        "0 conditional access policy(s) found that meet(s) all requirements. <a href='#caps'>View all CA policies</a>."
+
+    TestResult("MS.AAD.2.1v1", Output, ReportDetailStr, false) == true
+}
 #--
 
 #
@@ -820,6 +880,66 @@ test_State_Incorrect_V2 if {
 
     ReportDetailStr :=
         "0 conditional access policy(s) found that meet(s) all requirements. <a href='#caps'>View all CA policies</a>."
+    TestResult("MS.AAD.2.3v1", Output, ReportDetailStr, false) == true
+}
+
+# tests for Application exclusions
+test_AppExclusionConditions_Correct_V3 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "Conditions/Applications/ExcludeApplications", "value": ["Office365"]}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+                        with input.service_plans as ServicePlans
+                        with input.scuba_config.Aad["MS.AAD.2.3v1"] as ScubaConfig
+                        with input.scuba_config.Aad["MS.AAD.2.3v1"].CapExclusions.Applications as ["Office365"]
+
+    ReportDetailStr := concat("", [
+        "1 conditional access policy(s) found that meet(s) all requirements:",
+        "<br/>Test Policy. <a href='#caps'>View all CA policies</a>."
+    ])
+
+    TestResult("MS.AAD.2.3v1", Output, ReportDetailStr, true) == true
+}
+
+# tests for guest user type exclusions
+test_GuestUserTypeExclusionConditions_Correct_V3 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "Conditions/Users/ExcludeGuestsOrExternalUsers",
+                "value": {
+                    "GuestOrExternalUserTypes": "b2bCollaborationGuest,internalGuest",
+                    "ExternalTenants": {"MembershipKind": "all"}
+                }}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+                        with input.service_plans as ServicePlans
+                        with input.scuba_config.Aad["MS.AAD.2.3v1"] as ScubaConfig
+                        with input.scuba_config.Aad["MS.AAD.2.3v1"].CapExclusions.GuestUserTypes as [
+                            "b2bCollaborationGuest",
+                            "internalGuest"
+                        ]
+
+    ReportDetailStr := concat("", [
+        "1 conditional access policy(s) found that meet(s) all requirements:",
+        "<br/>Test Policy. <a href='#caps'>View all CA policies</a>."
+    ])
+
+    TestResult("MS.AAD.2.3v1", Output, ReportDetailStr, true) == true
+}
+
+test_GuestUserTypeExclusionNoExempt_Incorrect_V3 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "Conditions/Users/ExcludeGuestsOrExternalUsers",
+                "value": {
+                    "GuestOrExternalUserTypes": "b2bCollaborationGuest",
+                    "ExternalTenants": {"MembershipKind": "all"}
+                }}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+                        with input.service_plans as ServicePlans
+
+    ReportDetailStr :=
+        "0 conditional access policy(s) found that meet(s) all requirements. <a href='#caps'>View all CA policies</a>."
+
     TestResult("MS.AAD.2.3v1", Output, ReportDetailStr, false) == true
 }
 #--

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_03_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_03_test.rego
@@ -630,15 +630,15 @@ test_AppExclusionConditions_Correct_V5 if {
                 {"op": "add", "path": "Conditions/Applications/ExcludeApplications", "value": ["Office365"]}])
 
     Output := aad.tests with input.conditional_access_policies as [CAP]
-                        with input.scuba_config.Aad["MS.AAD.3.2v1"] as ScubaConfig
-                        with input.scuba_config.Aad["MS.AAD.3.2v1"].CapExclusions.Applications as ["Office365"]
+                        with input.scuba_config.Aad["MS.AAD.3.2v2"] as ScubaConfig
+                        with input.scuba_config.Aad["MS.AAD.3.2v2"].CapExclusions.Applications as ["Office365"]
 
     ReportDetailStr := concat("", [
         "1 conditional access policy(s) found that meet(s) all requirements:",
         "<br/>Test Policy. <a href='#caps'>View all CA policies</a>."
     ])
 
-    TestResult("MS.AAD.3.2v1", Output, ReportDetailStr, true) == true
+    TestResult("MS.AAD.3.2v2", Output, ReportDetailStr, true) == true
 }
 
 # tests for guest user type exclusions
@@ -652,8 +652,8 @@ test_GuestUserTypeExclusionConditions_Correct_V5 if {
                 }}])
 
     Output := aad.tests with input.conditional_access_policies as [CAP]
-                        with input.scuba_config.Aad["MS.AAD.3.2v1"] as ScubaConfig
-                        with input.scuba_config.Aad["MS.AAD.3.2v1"].CapExclusions.GuestUserTypes as [
+                        with input.scuba_config.Aad["MS.AAD.3.2v2"] as ScubaConfig
+                        with input.scuba_config.Aad["MS.AAD.3.2v2"].CapExclusions.GuestUserTypes as [
                             "b2bCollaborationGuest",
                             "internalGuest"
                         ]
@@ -663,7 +663,7 @@ test_GuestUserTypeExclusionConditions_Correct_V5 if {
         "<br/>Test Policy. <a href='#caps'>View all CA policies</a>."
     ])
 
-    TestResult("MS.AAD.3.2v1", Output, ReportDetailStr, true) == true
+    TestResult("MS.AAD.3.2v2", Output, ReportDetailStr, true) == true
 }
 
 test_GuestUserTypeExclusionNoExempt_Incorrect_V5 if {
@@ -679,7 +679,7 @@ test_GuestUserTypeExclusionNoExempt_Incorrect_V5 if {
     ReportDetailStr :=
         "0 conditional access policy(s) found that meet(s) all requirements. <a href='#caps'>View all CA policies</a>."
 
-    TestResult("MS.AAD.3.2v1", Output, ReportDetailStr, false) == true
+    TestResult("MS.AAD.3.2v2", Output, ReportDetailStr, false) == true
 }
 #--
 

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_03_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_03_test.rego
@@ -123,6 +123,63 @@ test_PhishingResistantMFAUserGroupExclusion_Correct if {
 
     TestResult("MS.AAD.3.1v1", Output, ReportDetailStr, true) == true
 }
+
+# tests for Application exclusions
+test_AppExclusionConditions_Correct_V4 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "Conditions/Applications/ExcludeApplications", "value": ["Office365"]}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+                        with input.scuba_config.Aad["MS.AAD.3.1v1"] as ScubaConfig
+                        with input.scuba_config.Aad["MS.AAD.3.1v1"].CapExclusions.Applications as ["Office365"]
+
+    ReportDetailStr := concat("", [
+        "1 conditional access policy(s) found that meet(s) all requirements:",
+        "<br/>Test Policy. <a href='#caps'>View all CA policies</a>."
+    ])
+
+    TestResult("MS.AAD.3.1v1", Output, ReportDetailStr, true) == true
+}
+
+# tests for guest user type exclusions
+test_GuestUserTypeExclusionConditions_Correct_V4 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "Conditions/Users/ExcludeGuestsOrExternalUsers",
+                "value": {
+                    "GuestOrExternalUserTypes": "b2bCollaborationGuest,internalGuest",
+                    "ExternalTenants": {"MembershipKind": "all"}
+                }}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+                        with input.scuba_config.Aad["MS.AAD.3.1v1"] as ScubaConfig
+                        with input.scuba_config.Aad["MS.AAD.3.1v1"].CapExclusions.GuestUserTypes as [
+                            "b2bCollaborationGuest",
+                            "internalGuest"
+                        ]
+
+    ReportDetailStr := concat("", [
+        "1 conditional access policy(s) found that meet(s) all requirements:",
+        "<br/>Test Policy. <a href='#caps'>View all CA policies</a>."
+    ])
+
+    TestResult("MS.AAD.3.1v1", Output, ReportDetailStr, true) == true
+}
+
+test_GuestUserTypeExclusionNoExempt_Incorrect_V4 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "Conditions/Users/ExcludeGuestsOrExternalUsers",
+                "value": {
+                    "GuestOrExternalUserTypes": "b2bCollaborationGuest",
+                    "ExternalTenants": {"MembershipKind": "all"}
+                }}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+
+    ReportDetailStr :=
+        "0 conditional access policy(s) found that meet(s) all requirements. <a href='#caps'>View all CA policies</a>."
+
+    TestResult("MS.AAD.3.1v1", Output, ReportDetailStr, false) == true
+}
 #--
 
 #
@@ -564,6 +621,65 @@ test_State_Incorrect_V1 if {
     ReportDetailStr :=
         "0 conditional access policy(s) found that meet(s) all requirements. <a href='#caps'>View all CA policies</a>."
     TestResult("MS.AAD.3.2v2", Output, ReportDetailStr, false) == true
+}
+
+# tests for Application exclusions
+test_AppExclusionConditions_Correct_V5 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "GrantControls/BuiltInControls", "value": ["mfa"]},
+                {"op": "add", "path": "Conditions/Applications/ExcludeApplications", "value": ["Office365"]}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+                        with input.scuba_config.Aad["MS.AAD.3.2v1"] as ScubaConfig
+                        with input.scuba_config.Aad["MS.AAD.3.2v1"].CapExclusions.Applications as ["Office365"]
+
+    ReportDetailStr := concat("", [
+        "1 conditional access policy(s) found that meet(s) all requirements:",
+        "<br/>Test Policy. <a href='#caps'>View all CA policies</a>."
+    ])
+
+    TestResult("MS.AAD.3.2v1", Output, ReportDetailStr, true) == true
+}
+
+# tests for guest user type exclusions
+test_GuestUserTypeExclusionConditions_Correct_V5 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "GrantControls/BuiltInControls", "value": ["mfa"]},
+                {"op": "add", "path": "Conditions/Users/ExcludeGuestsOrExternalUsers",
+                "value": {
+                    "GuestOrExternalUserTypes": "b2bCollaborationGuest,internalGuest",
+                    "ExternalTenants": {"MembershipKind": "all"}
+                }}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+                        with input.scuba_config.Aad["MS.AAD.3.2v1"] as ScubaConfig
+                        with input.scuba_config.Aad["MS.AAD.3.2v1"].CapExclusions.GuestUserTypes as [
+                            "b2bCollaborationGuest",
+                            "internalGuest"
+                        ]
+
+    ReportDetailStr := concat("", [
+        "1 conditional access policy(s) found that meet(s) all requirements:",
+        "<br/>Test Policy. <a href='#caps'>View all CA policies</a>."
+    ])
+
+    TestResult("MS.AAD.3.2v1", Output, ReportDetailStr, true) == true
+}
+
+test_GuestUserTypeExclusionNoExempt_Incorrect_V5 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "Conditions/Users/ExcludeGuestsOrExternalUsers",
+                "value": {
+                    "GuestOrExternalUserTypes": "b2bCollaborationGuest",
+                    "ExternalTenants": {"MembershipKind": "all"}
+                }}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+
+    ReportDetailStr :=
+        "0 conditional access policy(s) found that meet(s) all requirements. <a href='#caps'>View all CA policies</a>."
+
+    TestResult("MS.AAD.3.2v1", Output, ReportDetailStr, false) == true
 }
 #--
 
@@ -1384,6 +1500,69 @@ test_GroupExclusionsConditions_Correct_V2 if {
 
     TestResult("MS.AAD.3.6v1", Output, ReportDetailStr, true) == true
 }
+
+# tests for Application exclusions
+test_AppExclusionConditions_Correct_V6 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "Conditions/Users/IncludeRoles", "value": ["Role1", "Role2"]},
+                {"op": "add", "path": "Conditions/Applications/ExcludeApplications", "value": ["Office365"]}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+                        with input.privileged_roles as PrivilegedRoles
+                        with input.scuba_config.Aad["MS.AAD.3.6v1"] as ScubaConfig
+                        with input.scuba_config.Aad["MS.AAD.3.6v1"].CapExclusions.Applications as ["Office365"]
+
+    ReportDetailStr := concat("", [
+        "1 conditional access policy(s) found that meet(s) all requirements:",
+        "<br/>Test Policy. <a href='#caps'>View all CA policies</a>."
+    ])
+
+    TestResult("MS.AAD.3.6v1", Output, ReportDetailStr, true) == true
+}
+
+# tests for guest user type exclusions
+test_GuestUserTypeExclusionConditions_Correct_V6 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "Conditions/Users/IncludeRoles", "value": ["Role1", "Role2"]},
+                {"op": "add", "path": "Conditions/Users/ExcludeGuestsOrExternalUsers",
+                "value": {
+                    "GuestOrExternalUserTypes": "b2bCollaborationGuest,internalGuest",
+                    "ExternalTenants": {"MembershipKind": "all"}
+                }}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+                        with input.privileged_roles as PrivilegedRoles
+                        with input.scuba_config.Aad["MS.AAD.3.6v1"] as ScubaConfig
+                        with input.scuba_config.Aad["MS.AAD.3.6v1"].CapExclusions.GuestUserTypes as [
+                            "b2bCollaborationGuest",
+                            "internalGuest"
+                        ]
+
+    ReportDetailStr := concat("", [
+        "1 conditional access policy(s) found that meet(s) all requirements:",
+        "<br/>Test Policy. <a href='#caps'>View all CA policies</a>."
+    ])
+
+    TestResult("MS.AAD.3.6v1", Output, ReportDetailStr, true) == true
+}
+
+test_GuestUserTypeExclusionNoExempt_Incorrect_V6 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "Conditions/Users/IncludeRoles", "value": ["Role1", "Role2"]},
+                {"op": "add", "path": "Conditions/Users/ExcludeGuestsOrExternalUsers",
+                "value": {
+                    "GuestOrExternalUserTypes": "b2bCollaborationGuest",
+                    "ExternalTenants": {"MembershipKind": "all"}
+                }}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+                        with input.privileged_roles as PrivilegedRoles
+
+    ReportDetailStr :=
+        "0 conditional access policy(s) found that meet(s) all requirements. <a href='#caps'>View all CA policies</a>."
+
+    TestResult("MS.AAD.3.6v1", Output, ReportDetailStr, false) == true
+}
 #--
 
 #
@@ -1569,6 +1748,69 @@ test_ApplicationExclusions_Incorrect_V3 if {
 
     TestResult("MS.AAD.3.7v1", Output, ReportDetailStr, false) == true
 }
+
+# tests for Application exclusions
+test_AppExclusionConditions_Correct_V7 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "GrantControls/BuiltInControls", "value": ["compliantDevice", "domainJoinedDevice"]},
+                {"op": "add", "path": "GrantControls/Operator", "value": "OR"},
+                {"op": "add", "path": "Conditions/Applications/ExcludeApplications", "value": ["Office365"]}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+                        with input.scuba_config.Aad["MS.AAD.3.7v1"] as ScubaConfig
+                        with input.scuba_config.Aad["MS.AAD.3.7v1"].CapExclusions.Applications as ["Office365"]
+
+    ReportDetailStr := concat("", [
+        "1 conditional access policy(s) found that meet(s) all requirements:",
+        "<br/>Test Policy. <a href='#caps'>View all CA policies</a>."
+    ])
+
+    TestResult("MS.AAD.3.7v1", Output, ReportDetailStr, true) == true
+}
+
+# tests for guest user type exclusions
+test_GuestUserTypeExclusionConditions_Correct_V7 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "GrantControls/BuiltInControls", "value": ["compliantDevice", "domainJoinedDevice"]},
+                {"op": "add", "path": "GrantControls/Operator", "value": "OR"},
+                {"op": "add", "path": "Conditions/Users/ExcludeGuestsOrExternalUsers",
+                "value": {
+                    "GuestOrExternalUserTypes": "b2bCollaborationGuest,internalGuest",
+                    "ExternalTenants": {"MembershipKind": "all"}
+                }}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+                        with input.scuba_config.Aad["MS.AAD.3.7v1"] as ScubaConfig
+                        with input.scuba_config.Aad["MS.AAD.3.7v1"].CapExclusions.GuestUserTypes as [
+                            "b2bCollaborationGuest",
+                            "internalGuest"
+                        ]
+
+    ReportDetailStr := concat("", [
+        "1 conditional access policy(s) found that meet(s) all requirements:",
+        "<br/>Test Policy. <a href='#caps'>View all CA policies</a>."
+    ])
+
+    TestResult("MS.AAD.3.7v1", Output, ReportDetailStr, true) == true
+}
+
+test_GuestUserTypeExclusionNoExempt_Incorrect_V7 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "GrantControls/BuiltInControls", "value": ["compliantDevice", "domainJoinedDevice"]},
+                {"op": "add", "path": "GrantControls/Operator", "value": "OR"},
+                {"op": "add", "path": "Conditions/Users/ExcludeGuestsOrExternalUsers",
+                "value": {
+                    "GuestOrExternalUserTypes": "b2bCollaborationGuest",
+                    "ExternalTenants": {"MembershipKind": "all"}
+                }}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+
+    ReportDetailStr :=
+        "0 conditional access policy(s) found that meet(s) all requirements. <a href='#caps'>View all CA policies</a>."
+
+    TestResult("MS.AAD.3.7v1", Output, ReportDetailStr, false) == true
+}
 #--
 
 #
@@ -1710,6 +1952,44 @@ test_ApplicationExclusions_Incorrect_V4 if {
 
     TestResult("MS.AAD.3.8v1", Output, ReportDetailStr, false) == true
 }
+
+# tests for guest user type exclusions
+test_GuestUserTypeExclusionConditions_Correct_V8 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "GrantControls/BuiltInControls", "value": ["compliantDevice", "domainJoinedDevice"]},
+                {"op": "add", "path": "Conditions/Users/ExcludeGuestsOrExternalUsers",
+                "value": {
+                    "GuestOrExternalUserTypes": "b2bCollaborationGuest,internalGuest",
+                    "ExternalTenants": {"MembershipKind": "all"}
+                }}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+                        with input.scuba_config.Aad["MS.AAD.3.8v1"] as ScubaConfig
+                        with input.scuba_config.Aad["MS.AAD.3.8v1"].CapExclusions.GuestUserTypes as [
+                            "b2bCollaborationGuest",
+                            "internalGuest"
+                        ]
+
+    ReportDetailArrayStrs := ["conditional access policy(s) found that meet(s) all requirements:"]
+    TestResultContains("MS.AAD.3.8v1", Output, ReportDetailArrayStrs, true) == true
+}
+
+test_GuestUserTypeExclusionNoExempt_Incorrect_V8 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "add", "path": "GrantControls/BuiltInControls", "value": ["compliantDevice", "domainJoinedDevice"]},
+                {"op": "add", "path": "Conditions/Users/ExcludeGuestsOrExternalUsers",
+                "value": {
+                    "GuestOrExternalUserTypes": "b2bCollaborationGuest",
+                    "ExternalTenants": {"MembershipKind": "all"}
+                }}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+
+    ReportDetailStr :=
+        "0 conditional access policy(s) found that meet(s) all requirements. <a href='#caps'>View all CA policies</a>."
+
+    TestResult("MS.AAD.3.8v1", Output, ReportDetailStr, false) == true
+}
 #--
 
 #
@@ -1807,6 +2087,58 @@ test_Entra_3_9_Application_Exclusion_Incorrect_V1 if {
 
     ReportDetailStr :=
         "0 conditional access policy(s) found that meet(s) all requirements. <a href='#caps'>View all CA policies</a>."
+    TestResult("MS.AAD.3.9v1", Output, ReportDetailStr, false) == true
+}
+
+# tests for Application exclusions
+test_AppExclusionConditions_Correct_V8 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "replace", "path": "Conditions/AuthenticationFlows/TransferMethods", "value": "deviceCodeFlow"},
+                {"op": "add", "path": "Conditions/Applications/ExcludeApplications", "value": ["Office365"]}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+                        with input.scuba_config.Aad["MS.AAD.3.9v1"] as ScubaConfig
+                        with input.scuba_config.Aad["MS.AAD.3.9v1"].CapExclusions.Applications as ["Office365"]
+
+    ReportDetailArrayStrs := ["conditional access policy(s) found that meet(s) all requirements:"]
+    TestResultContains("MS.AAD.3.9v1", Output, ReportDetailArrayStrs, true) == true
+}
+
+# tests for guest user type exclusions
+test_GuestUserTypeExclusionConditions_Correct_V9 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "replace", "path": "Conditions/AuthenticationFlows/TransferMethods", "value": "deviceCodeFlow"},
+                {"op": "add", "path": "Conditions/Users/ExcludeGuestsOrExternalUsers",
+                "value": {
+                    "GuestOrExternalUserTypes": "b2bCollaborationGuest,internalGuest",
+                    "ExternalTenants": {"MembershipKind": "all"}
+                }}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+                        with input.scuba_config.Aad["MS.AAD.3.9v1"] as ScubaConfig
+                        with input.scuba_config.Aad["MS.AAD.3.9v1"].CapExclusions.GuestUserTypes as [
+                            "b2bCollaborationGuest",
+                            "internalGuest"
+                        ]
+
+    ReportDetailArrayStrs := ["conditional access policy(s) found that meet(s) all requirements:"]
+    TestResultContains("MS.AAD.3.9v1", Output, ReportDetailArrayStrs, true) == true
+}
+
+test_GuestUserTypeExclusionNoExempt_Incorrect_V9 if {
+    CAP := json.patch(ConditionalAccessPolicies,
+                [{"op": "replace", "path": "Conditions/AuthenticationFlows/TransferMethods", "value": "deviceCodeFlow"},
+                {"op": "add", "path": "Conditions/Users/ExcludeGuestsOrExternalUsers",
+                "value": {
+                    "GuestOrExternalUserTypes": "b2bCollaborationGuest",
+                    "ExternalTenants": {"MembershipKind": "all"}
+                }}])
+
+    Output := aad.tests with input.conditional_access_policies as [CAP]
+
+    ReportDetailStr :=
+        "0 conditional access policy(s) found that meet(s) all requirements. <a href='#caps'>View all CA policies</a>."
+
     TestResult("MS.AAD.3.9v1", Output, ReportDetailStr, false) == true
 }
 

--- a/PowerShell/ScubaGear/baselines/aad.md
+++ b/PowerShell/ScubaGear/baselines/aad.md
@@ -366,7 +366,7 @@ Managed Devices SHOULD be required to register MFA.
 [![Configurable](https://img.shields.io/badge/Configurable-005288)](../../../docs/configuration/configuration.md#conditional-access-policy-exclusions)
 
 <!--Policy: MS.AAD.3.8v1; Criticality: SHOULD -->
-<!--ExclusionType: CapExclusions-->
+<!--ExclusionType: CapExclusionsWithoutApps-->
 - _Rationale:_ Reduce risk of an adversary using stolen user credentials and then registering their own MFA device to access the tenant by requiring a managed device provisioned and controlled by the agency to perform registration actions. This prevents the adversary from using their own unmanaged device to perform the registration.
 - _Last modified:_ June 2023
 - _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-20b, IA-3

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -11,6 +11,9 @@ ScubaGear allows users to specify most of the `Invoke-SCuBA` cmdlet [parameters]
 > [!IMPORTANT]
 > When a parameter is specified on both the command line and the configuration file, the parameter value provided on the command line has precedence and the configuration file value will be disregarded.
 
+> [!TIP]
+> It is highly recommended to use the **[Configuration UI](scubaconfigapp.md)** to create and manage ScubaGear configuration files. The UI provides an interactive experience that reduces the risk of errors and makes it easy to configure exclusions, annotations, and omissions without manually editing YAML.
+
 ## Sample Configuration Files
 
 [Sample config files](../../PowerShell/ScubaGear/Sample-Config-Files) are available in the repo. Several of these sample config files are explained in more detail in the sections below.
@@ -188,7 +191,7 @@ Under a product key, there can be policy keys that provide configuration values 
 
 ### Entra ID Configuration
 
-The ScubaGear configuration file provides the capability to exclude specific users or groups from some of the Entra ID policy checks. For example, a user could exclude emergency access accounts from some of the policy checks. Exclusions must only be used if they are approved within an organization's security risk acceptance process. **Exclusions can introduce grave risks to your system and must be managed carefully**.
+The ScubaGear configuration file provides the capability to exclude specific users, groups, applications, or guest user types from some of the Entra ID policy checks. For example, a user could exclude emergency access accounts from some of the policy checks. Exclusions must only be used if they are approved within an organization's security risk acceptance process. **Exclusions can introduce grave risks to your system and must be managed carefully**.
 
 Example Entra ID configuration:
 
@@ -201,6 +204,28 @@ Aad:
         - "87654321-4321-4321-4321-210987654321"  # Emergency access account 2
       Groups:
         - "11111111-1111-1111-1111-111111111111"  # Break glass admin group
+      Applications:
+        - "49b4dcdf-1f90-41a7c3-9b42-5cfe9dd7e3b4"  # Example Cloud App 1
+      GuestUserTypes:
+        - b2bCollaborationGuest
+        - b2bCollaborationMember
+  MS.AAD.2.1v1:
+    CapExclusions:
+      Users:
+        - "12345678-1234-1234-1234-123456789012"  # Emergency access account 1
+        - "87654321-4321-4321-4321-210987654321"  # Emergency access account 2
+      Groups:
+        - "11111111-1111-1111-1111-111111111111"  # Break glass admin group
+      Applications:
+        - "49b4dcdf-1f90-41a7c3-9b42-5cfe9dd7e3b4"  # Example Application 1
+        -  Office365 # Example Application 2
+      GuestUserTypes:
+        - internalGuest
+        - b2bCollaborationGuest
+        - b2bCollaborationMember
+        - b2bDirectConnectUser
+        - otherExternalUser
+        - serviceProvider
   MS.AAD.7.4v1:
     RoleExclusions:
       Users:
@@ -211,7 +236,33 @@ Aad:
 
 #### Conditional Access Policy Exclusions
 
-The `Aad` top level key allows the user to specify configurations specific to the Entra Id baseline. Under the `Aad` key is the policy identifier such as `MS.AAD.1.1v1` and under that is the `CapExclusions` key where the excluded users or groups are defined. The `CapExclusions` key supports both a `Users` or `Groups` list with each entry representing the UUID of a user or group from the tenant that will be excluded from the respective policy check.
+The `Aad` top level key allows the user to specify configurations specific to the Entra Id baseline. Under the `Aad` key is the policy identifier such as `MS.AAD.1.1v1` and under that is the `CapExclusions` key where exclusions are defined. `CapExclusions` supports four fields:
+
+- **`Applications`**: A list of Applications to exclude. The value to use depends on how the application appears in the Entra portal under the CAP's **Exclude > Select specific resources** section:
+
+  - **Display name only** (no GUID shown beneath the name, e.g., *Microsoft Admin Portals*, *Office 365*): Remove all spaces from the display name.
+    ```yaml
+    Applications:
+      - "MicrosoftAdminPortals"
+      - "Office365"
+    ```
+
+  - **Display name with a GUID beneath it** (e.g., *Azure Cosmos DB* with `a232010e-820c-4083-83bb-3ace5fc29d0b`): Use the GUID.
+    ```yaml
+    Applications:
+      - "a232010e-820c-4083-83bb-3ace5fc29d0b"
+    ```
+
+  > **Note:** `Applications` is not supported for `MS.AAD.3.8v1`.
+- **`Groups`**: A list of group Object IDs (GUIDs) to exclude from the policy check.
+- **`GuestUserTypes`**: A list of guest/external user types to exclude. Valid values are:
+  - `b2bCollaborationGuest`
+  - `b2bCollaborationMember`
+  - `b2bDirectConnectUser`
+  - `internalGuest`
+  - `otherExternalUser`
+  - `serviceProvider`
+- **`Users`**: A list of user Object IDs (GUIDs) to exclude from the policy check.
 
 CapExclusions are supported for the following policies:
 


### PR DESCRIPTION
## 🗣 Description ##
Extend `CapExclusions` to support two new exclusion types for Conditional Access Policy (CAP):

- **`Applications`** - Allows administrators to declare a list of excluded application GUIDs/names. If a CAP excludes only applications listed in the config allowlist, the policy is still counted as compliant.
- **`GuestUserTypes`** - Allows administrators to declare specific guest/external user types (e.g., `b2bCollaborationGuest`, `internalGuest`) that are excluded from a CAP. If a CAP's `ExcludeGuestsOrExternalUsers` types match exactly the config allowlist, the policy is still counted as compliant.

## 💭 Motivation and context ##
Organizations often have legitimate reasons to exclude specific applications or guest user types from certain CAPs. This allows organizations to properly document their exemptions and exclude documented applications and GuestUserTypes in ScubaGear.

Closes #1942
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
## Option 1: Cached run with modified ScubaResults JSON

1. Run `Invoke-SCuBA -ProductNames aad` against your tenant to generate a results folder.

2. Open `ScubaResults_*.json` in the results folder and modify a CAP entry under `conditional_access_policies` to add the following exclusions:

   **Application exclusions** - under `Conditions` > `Applications`:
   ```json
   "ExcludeApplications": [
       "MicrosoftAdminPortals",
       "a232010e-820c-4083-83bb-3ace5fc29d0b",
       "Office365"
   ]
   ```

   **Guest user type exclusions** - under `Conditions` > `Users`:
   ```json
   "ExcludeGuestsOrExternalUsers": {
       "GuestOrExternalUserTypes": "b2bCollaborationGuest,b2bCollaborationMember",
       "ExternalTenants": {
           "@odata.type": "#microsoft.graph.conditionalAccessAllExternalTenants",
           "MembershipKind": "all"
       }
   }
   ```

3. Create a ScubaConfig YAML file declaring matching allowlists under `CapExclusions`. Replace `*.*v*` with the relevant policy ID and version (e.g. `1.1v1`):
   ```yaml
   Aad:
     MS.AAD.*.*v*:
       CapExclusions:
         Applications:
           - "a232010e-820c-4083-83bb-3ace5fc29d0b"
           - "Office365"
           - "MicrosoftAdminPortals"
         GuestUserTypes:
           - b2bCollaborationGuest
           - b2bCollaborationMember
   ```

4. Run `Invoke-SCuBACached` pointing at the modified results folder and your config file.

**Expected results:**
- With the `CapExclusions` allowlists present, affected policies report **pass**.
- After removing the `CapExclusions` block and re-running, the same policies report **fail**.

## Option 2: Live tenant run with a real CAP change

1. In the Entra ID admin center, edit an existing Conditional Access Policy and add an application exclusion and/or a guest/external user type exclusion.

2. Create a ScubaConfig YAML file declaring the matching allowlists under `CapExclusions`. Replace `*.*v*` with the relevant policy ID and version (e.g. `1.1v1`):
   ```yaml
   Aad:
     MS.AAD.*.*v*:
       CapExclusions:
         Applications:
           - <excluded app GUID/Name from the CAP>
         GuestUserTypes:
           - b2bCollaborationGuest
   ```

3. Run `Invoke-SCuBA -ProductNames aad -ConfigFilePath <path-to-yaml>`.

**Expected results:**
- With the `CapExclusions` allowlists present, affected policies report **pass**.
- After removing the `CapExclusions` block and re-running, the same policies report **fail**, reflecting the unapproved exclusion.

## ScubaConfigApp UI validation

1. Run `Start-SCuBAConfigApp` to launch the configuration UI.
2. Navigate to the **AAD** product section and select a policy that supports CAP exclusions (e.g., MS.AAD.1.1v1, MS.AAD.3.2v2).
3. Expand the **CAP Exclusions** section and verify the following new fields are present:
   - **Applications** - Input accepts app GUIDs or names
   - **Guest User Types** - Multi-select with guest/external user type options (e.g., `b2bCollaborationGuest`, `b2bCollaborationMember`, `internalGuest`)
4. Enter values in both fields and complete the form.
5. Export/save the generated config YAML and verify it contains the correct structure:
   ```yaml
   Aad:
     MS.AAD.*.*v*:
       CapExclusions:
         Applications:
           - "a232010e-820c-4083-83bb-3ace5fc29d0b"
           - "Office365"
         GuestUserTypes:
           - b2bCollaborationGuest
           - b2bCollaborationMember
   ```
6. Confirm that invalid application values (e.g., entries containing hyphens that aren't valid GUIDs) are rejected by the UI validation.

**Expected results:**
- New `Applications` and `GuestUserTypes` fields are visible and functional in the UI.
- Generated YAML matches the entered values with correct `CapExclusions` structure.
- Invalid application entries are rejected with a validation error.


<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed.

  Use `Update branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [x] Resolved all merge conflicts on branch.
- [x] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the PR assignee to complete. -->
- [x] Feature branch deleted after merge to clean up repository.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
- [x] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
