### PR TITLE
Fixes OPA deletion Bug

### DIFF
--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-ScubaConfig.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-ScubaConfig.Tests.ps1
@@ -19,14 +19,18 @@ BeforeDiscovery {
         $OPAExeName = "opa_windows_amd64.exe"
     }
     $OPAExePath = Join-Path -Path $DefaultOPAPath -ChildPath $OPAExeName
+    $script:DiscoveryDefaultOPACreatedByTests = $false
     if (-not (Test-Path $OPAExePath)) {
         New-Item -Path $OPAExePath -ItemType File -Force | Out-Null
+        $script:DiscoveryDefaultOPACreatedByTests = $true
     }
 
     # Also create OPA in test directory (for OPAPath: . in orchestrator_config_test.yaml)
     $TestOPAPath = Join-Path -Path $PSScriptRoot -ChildPath $OPAExeName
+    $script:DiscoveryTestOPACreatedByTests = $false
     if (-not (Test-Path $TestOPAPath)) {
         New-Item -Path $TestOPAPath -ItemType File -Force | Out-Null
+        $script:DiscoveryTestOPACreatedByTests = $true
     }
 
     $ModuleRootPath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\..\..\Modules'
@@ -64,15 +68,19 @@ InModuleScope Orchestrator {
             $script:DummyOPAName = "opa_windows_amd64.exe"
         }
         $script:DummyOPAPath = Join-Path -Path $script:DefaultOPAPath -ChildPath $script:DummyOPAName
+        $script:DummyOPACreatedByTests = $false
         # Create empty file to satisfy OPA validation
         if (-not (Test-Path $script:DummyOPAPath)) {
             New-Item -Path $script:DummyOPAPath -ItemType File -Force | Out-Null
+            $script:DummyOPACreatedByTests = $true
         }
 
         # Also create OPA in test directory (for OPAPath: . in orchestrator_config_test.yaml)
         $TestOPAPath = Join-Path -Path $PSScriptRoot -ChildPath $script:DummyOPAName
+        $script:InModuleTestOPACreatedByTests = $false
         if (-not (Test-Path $TestOPAPath)) {
             New-Item -Path $TestOPAPath -ItemType File -Force | Out-Null
+            $script:InModuleTestOPACreatedByTests = $true
         }
 
         # Define stub functions that will be mocked
@@ -231,13 +239,13 @@ InModuleScope Orchestrator {
     # Cleanup - remove dummy OPA executables
     AfterAll {
         # Clean up default location OPA
-        if (Test-Path $script:DummyOPAPath) {
+        if ($script:DummyOPACreatedByTests -and (Test-Path $script:DummyOPAPath)) {
             Remove-Item -Path $script:DummyOPAPath -Force -ErrorAction SilentlyContinue
         }
 
         # Clean up test directory OPA (for OPAPath: . in orchestrator_config_test.yaml)
         $TestOPAPath = Join-Path -Path $PSScriptRoot -ChildPath $script:DummyOPAName
-        if (Test-Path $TestOPAPath) {
+        if ($script:InModuleTestOPACreatedByTests -and (Test-Path $TestOPAPath)) {
             Remove-Item -Path $TestOPAPath -Force -ErrorAction SilentlyContinue
         }
     }
@@ -261,13 +269,13 @@ AfterAll {
     }
 
     $OPAExePath = Join-Path -Path $DefaultOPAPath -ChildPath $OPAExeName
-    if (Test-Path $OPAExePath) {
+    if ($script:DiscoveryDefaultOPACreatedByTests -and (Test-Path $OPAExePath)) {
         Remove-Item -Path $OPAExePath -Force -ErrorAction SilentlyContinue
     }
 
     # Test directory OPA (for OPAPath: . in orchestrator_config_test.yaml)
     $TestOPAPath = Join-Path -Path $PSScriptRoot -ChildPath $OPAExeName
-    if (Test-Path $TestOPAPath) {
+    if ($script:DiscoveryTestOPACreatedByTests -and (Test-Path $TestOPAPath)) {
         Remove-Item -Path $TestOPAPath -Force -ErrorAction SilentlyContinue
     }
 }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfig.JsonDefaults.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfig.JsonDefaults.Tests.ps1
@@ -23,8 +23,10 @@ Describe "JSON-based Configuration System" {
             $script:OPAExeName = "opa_windows_amd64.exe"
         }
         $script:OPAExePath = Join-Path -Path $script:DefaultOPAPath -ChildPath $script:OPAExeName
+        $script:OPAExeCreatedByTests = $false
         if (-not (Test-Path $script:OPAExePath)) {
             New-Item -Path $script:OPAExePath -ItemType File -Force | Out-Null
+            $script:OPAExeCreatedByTests = $true
         }
 
         # Initialize the system
@@ -155,7 +157,7 @@ Describe "JSON-based Configuration System" {
         [ScubaConfig]::ResetInstance()
 
         # Clean up dummy OPA executable
-        if ($script:OPAExePath -and (Test-Path $script:OPAExePath)) {
+        if ($script:OPAExeCreatedByTests -and $script:OPAExePath -and (Test-Path $script:OPAExePath)) {
             Remove-Item -Path $script:OPAExePath -Force -ErrorAction SilentlyContinue
         }
     }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfig.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfig.Tests.ps1
@@ -21,8 +21,10 @@ Describe "ScubaConfig Module Unit Tests" {
             $script:OPAExeName = "opa_windows_amd64.exe"
         }
         $script:OPAExePath = Join-Path -Path $script:DefaultOPAPath -ChildPath $script:OPAExeName
+        $script:OPAExeCreatedByTests = $false
         if (-not (Test-Path $script:OPAExePath)) {
             New-Item -Path $script:OPAExePath -ItemType File -Force | Out-Null
+            $script:OPAExeCreatedByTests = $true
         }
 
         # Create a global mock for ConvertFrom-Yaml to avoid needing powershell-yaml module in CI/CD
@@ -61,7 +63,7 @@ Describe "ScubaConfig Module Unit Tests" {
         Remove-Item -Path Function:\ConvertFrom-Yaml -ErrorAction SilentlyContinue
         
         # Clean up dummy OPA executable and directory if created by tests
-        if ($script:OPAExePath -and (Test-Path $script:OPAExePath)) {
+        if ($script:OPAExeCreatedByTests -and $script:OPAExePath -and (Test-Path $script:OPAExePath)) {
             Remove-Item -Path $script:OPAExePath -Force -ErrorAction SilentlyContinue
         }
         # Note: We don't remove the .scubagear\Tools directory as it might be needed by other tests

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfig.YamlAdditionalProperties.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfig.YamlAdditionalProperties.Tests.ps1
@@ -20,9 +20,11 @@ Describe "ScubaConfig Additional Properties Validation" {
             $script:DummyOPAName = "opa_windows_amd64.exe"
         }
         $script:DummyOPAPath = Join-Path -Path $PSScriptRoot -ChildPath "..\..\..\..\..\..\$script:DummyOPAName"
+        $script:DummyOPACreatedByTests = $false
         # Create empty file to satisfy OPA validation
         if (-not (Test-Path $script:DummyOPAPath)) {
             New-Item -Path $script:DummyOPAPath -ItemType File -Force | Out-Null
+            $script:DummyOPACreatedByTests = $true
         }
 
         # Mock ConvertFrom-Yaml to avoid dependency on powershell-yaml module in CI
@@ -94,7 +96,7 @@ Describe "ScubaConfig Additional Properties Validation" {
         [ScubaConfig]::ResetInstance()
         
         # Remove dummy OPA executable
-        if (Test-Path $script:DummyOPAPath) {
+        if ($script:DummyOPACreatedByTests -and (Test-Path $script:DummyOPAPath)) {
             Remove-Item -Path $script:DummyOPAPath -Force -ErrorAction SilentlyContinue
         }
     }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfig.YamlAdvancedProperties.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfig.YamlAdvancedProperties.Tests.ps1
@@ -83,8 +83,10 @@ Describe "ScubaConfigValidator Basic Validation" {
             $script:OPAExeName = "opa_windows_amd64.exe"
         }
         $script:OPAExePath = Join-Path -Path $script:DefaultOPAPath -ChildPath $script:OPAExeName
+        $script:OPAExeCreatedByTests = $false
         if (-not (Test-Path $script:OPAExePath)) {
             New-Item -Path $script:OPAExePath -ItemType File -Force | Out-Null
+            $script:OPAExeCreatedByTests = $true
         }
 
         # Initialize the validator
@@ -266,7 +268,7 @@ Defender:
         }
         
         # Clean up dummy OPA executable
-        if ($script:OPAExePath -and (Test-Path $script:OPAExePath)) {
+        if ($script:OPAExeCreatedByTests -and $script:OPAExePath -and (Test-Path $script:OPAExePath)) {
             Remove-Item -Path $script:OPAExePath -Force -ErrorAction SilentlyContinue
         }
     }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfig.YamlBasicValidation.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfig.YamlBasicValidation.Tests.ps1
@@ -21,8 +21,10 @@ Describe "ScubaConfig Basic Root Configuration Tests" {
             $script:OPAExeName = "opa_windows_amd64.exe"
         }
         $script:OPAExePath = Join-Path -Path $script:DefaultOPAPath -ChildPath $script:OPAExeName
+        $script:OPAExeCreatedByTests = $false
         if (-not (Test-Path $script:OPAExePath)) {
             New-Item -Path $script:OPAExePath -ItemType File -Force | Out-Null
+            $script:OPAExeCreatedByTests = $true
         }
 
         # Initialize the system
@@ -47,7 +49,7 @@ Describe "ScubaConfig Basic Root Configuration Tests" {
         [ScubaConfig]::ResetInstance()
         
         # Clean up dummy OPA executable
-        if ($script:OPAExePath -and (Test-Path $script:OPAExePath)) {
+        if ($script:OPAExeCreatedByTests -and $script:OPAExePath -and (Test-Path $script:OPAExePath)) {
             Remove-Item -Path $script:OPAExePath -Force -ErrorAction SilentlyContinue
         }
     }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfig.YamlExclusionsAndPolicy.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfig.YamlExclusionsAndPolicy.Tests.ps1
@@ -21,8 +21,10 @@ Describe "ScubaConfig Exclusions and Policy Validation Tests" {
             $script:OPAExeName = "opa_windows_amd64.exe"
         }
         $script:OPAExePath = Join-Path -Path $script:DefaultOPAPath -ChildPath $script:OPAExeName
+        $script:OPAExeCreatedByTests = $false
         if (-not (Test-Path $script:OPAExePath)) {
             New-Item -Path $script:OPAExePath -ItemType File -Force | Out-Null
+            $script:OPAExeCreatedByTests = $true
         }
 
         # Initialize the system
@@ -47,7 +49,7 @@ Describe "ScubaConfig Exclusions and Policy Validation Tests" {
         [ScubaConfig]::ResetInstance()
         
         # Clean up dummy OPA executable
-        if ($script:OPAExePath -and (Test-Path $script:OPAExePath)) {
+        if ($script:OPAExeCreatedByTests -and $script:OPAExePath -and (Test-Path $script:OPAExePath)) {
             Remove-Item -Path $script:OPAExePath -Force -ErrorAction SilentlyContinue
         }
     }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfig.YamlLoadConfig.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfig.YamlLoadConfig.Tests.ps1
@@ -22,8 +22,10 @@ InModuleScope ScubaConfig {
                 $script:OPAExeName = "opa_windows_amd64.exe"
             }
             $script:OPAExePath = Join-Path -Path $script:DefaultOPAPath -ChildPath $script:OPAExeName
+            $script:OPAExeCreatedByTests = $false
             if (-not (Test-Path $script:OPAExePath)) {
                 New-Item -Path $script:OPAExePath -ItemType File -Force | Out-Null
+                $script:OPAExeCreatedByTests = $true
             }
 
             Mock -CommandName Write-Warning {}
@@ -37,7 +39,7 @@ InModuleScope ScubaConfig {
             [ScubaConfig]::ResetInstance()
             
             # Clean up dummy OPA executable
-            if ($script:OPAExePath -and (Test-Path $script:OPAExePath)) {
+            if ($script:OPAExeCreatedByTests -and $script:OPAExePath -and (Test-Path $script:OPAExePath)) {
                 Remove-Item -Path $script:OPAExePath -Force -ErrorAction SilentlyContinue
             }
         }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfigLoadConfig.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfigLoadConfig.Tests.ps1
@@ -22,8 +22,10 @@ InModuleScope ScubaConfig {
                 $script:OPAExeName = "opa_windows_amd64.exe"
             }
             $script:OPAExePath = Join-Path -Path $script:DefaultOPAPath -ChildPath $script:OPAExeName
+            $script:OPAExeCreatedByTests = $false
             if (-not (Test-Path $script:OPAExePath)) {
                 New-Item -Path $script:OPAExePath -ItemType File -Force | Out-Null
+                $script:OPAExeCreatedByTests = $true
             }
 
             Mock -CommandName Write-Warning {}
@@ -37,7 +39,7 @@ InModuleScope ScubaConfig {
             [ScubaConfig]::ResetInstance()
             
             # Clean up dummy OPA executable
-            if ($script:OPAExePath -and (Test-Path $script:OPAExePath)) {
+            if ($script:OPAExeCreatedByTests -and $script:OPAExePath -and (Test-Path $script:OPAExePath)) {
                 Remove-Item -Path $script:OPAExePath -Force -ErrorAction SilentlyContinue
             }
         }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfigValidator.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfigValidator.Tests.ps1
@@ -21,8 +21,10 @@ Describe "ScubaConfigValidator Module Unit Tests" {
             $script:OPAExeName = "opa_windows_amd64.exe"
         }
         $script:OPAExePath = Join-Path -Path $script:DefaultOPAPath -ChildPath $script:OPAExeName
+        $script:OPAExeCreatedByTests = $false
         if (-not (Test-Path $script:OPAExePath)) {
             New-Item -Path $script:OPAExePath -ItemType File -Force | Out-Null
+            $script:OPAExeCreatedByTests = $true
         }
 
         # Initialize the validator
@@ -31,7 +33,7 @@ Describe "ScubaConfigValidator Module Unit Tests" {
 
     AfterAll {
         # Clean up dummy OPA executable
-        if ($script:OPAExePath -and (Test-Path $script:OPAExePath)) {
+        if ($script:OPAExeCreatedByTests -and $script:OPAExePath -and (Test-Path $script:OPAExePath)) {
             Remove-Item -Path $script:OPAExePath -Force -ErrorAction SilentlyContinue
         }
     }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##
Fixes issue brought up by Ted where running `./testing/RunPowerShellUnitTests.ps1` results in a deletion of the OPA executable
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
Closes #2141 
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
Run `./testing/RunPowerShellUnitTests.ps1`
OPA executable file should still persist at path: `C:\Users\[username]\.scubagear\Tools`
 With the name of the file: `opa_windows_amd64.exe`

If the script is ran against main notice that OPA executable gets removed but when it is ran against this branch the OPA executable persists at the path listed above

If the file does get removed at any point run `Initialize-Scuba` to have it reinstalled to the correct location
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] Changes are sized such that they do not touch excessive number of files.
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [ ] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] All relevant type-of-change labels added.
- [ ] All relevant project fields are set.
- [ ] All relevant repo and/or project documentation updated to reflect these changes.
- [ ] Unit tests added/updated to cover PowerShell and Rego changes.
- [ ] Functional tests added/updated to cover PowerShell and Rego changes.
- [ ] All relevant functional tests passed.
- [ ] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] PR passed smoke test check.
- [ ] Feature branch has been rebased against changes from parent branch, as needed.

  Use `Update branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [ ] Resolved all merge conflicts on branch.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the PR assignee to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
