### PR TITLE
Fix MS.AAD.6.1v1 error where multiple outputs were produced for the same inputs

### DIFF
--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -1089,6 +1089,11 @@ RootDomains contains Domain if {
 RootDomainFor(Domain) := Root.Id if {
     some Root in RootDomains
     endswith(Domain.Id, Root.Id)
+    # When multiple root domains match (e.g., "sub.example.com" and "example.com" both match
+    # "sub.sub.example.com"), select the most specific one (longest Id). 
+    # Otherwise, an eval_conflict_error error will occur due to multiple matching root domains.
+    MaxLength := max({count(R.Id) | some R in RootDomains; endswith(Domain.Id, R.Id)})
+    count(Root.Id) == MaxLength
 }
 
 IsValid(Domain) := true if {

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -1089,6 +1089,7 @@ RootDomains contains Domain if {
 RootDomainFor(Domain) := Root.Id if {
     some Root in RootDomains
     endswith(Domain.Id, Root.Id)
+
     # When multiple root domains match (e.g., "sub.example.com" and "example.com" both match
     # "sub.sub.example.com"), select the most specific one (longest Id). 
     # Otherwise, an eval_conflict_error error will occur due to multiple matching root domains.
@@ -1096,15 +1097,20 @@ RootDomainFor(Domain) := Root.Id if {
     count(Root.Id) == MaxLength
 }
 
+# For tenants created before Oct 2021, passwordValidityPeriodInDays is set to INT_MAX (2147483647), indicating passwords never expire.
+# For tenants created after Oct 2021, passwordValidityPeriodInDays is set to null by default, which also indicates passwords never expire. 
+PasswordNeverExpires(Domain) if Domain.PasswordValidityPeriodInDays == INT_MAX
+PasswordNeverExpires(Domain) if is_null(Domain.PasswordValidityPeriodInDays)
+
 IsValid(Domain) := true if {
     Domain.IsRoot = true
-    Domain.PasswordValidityPeriodInDays == INT_MAX
+    PasswordNeverExpires(Domain)
 } else := true if {
     Domain.IsRoot == false
     RootDomainFor(Domain) != null
     some Root in RootDomains
     Root.Id == RootDomainFor(Domain)
-    Root.PasswordValidityPeriodInDays == INT_MAX
+    PasswordNeverExpires(Root)
 } else := false
 
 ValidDomains contains Domain.Id if {

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_06_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_06_test.rego
@@ -21,9 +21,11 @@ test_PasswordValidityPeriodInDays_Correct if {
 }
 
 test_PasswordValidityPeriodInDays_Incorrect if {
+    # root1.com has an explicit expiry of 90 days (non-null, non-INT_MAX) so it fails.
+    # sub.root1.com fails because its root domain fails.
     # Set "federated.domain.com" (index 5 in DomainSettings base configuration) to false to skip federated domain warning
     Settings := json.patch(DomainSettings, [
-        {"op": "add", "path": "0/PasswordValidityPeriodInDays", "value": null},
+        {"op": "add", "path": "0/PasswordValidityPeriodInDays", "value": 90},
         {"op": "add", "path": "5/IsVerified", "value": false}
     ])
 
@@ -31,6 +33,32 @@ test_PasswordValidityPeriodInDays_Incorrect if {
 
     ReportDetailString := "2 domain(s) failed:<br/>root1.com, sub.root1.com"
     TestResult("MS.AAD.6.1v1", Output, ReportDetailString, false) == true
+}
+
+test_PasswordValidityPeriodInDays_NullRootDomain_Correct if {
+    # Post-Oct 2021 tenants have null for PasswordValidityPeriodInDays by default, which
+    # Microsoft treats as "passwords never expire" (equivalent to INT_MAX / 2147483647).
+    # root1.com and sub.root1.com must both be valid when root1.com is set to null.
+    Settings := json.patch(DomainSettings, [
+        {"op": "add", "path": "0/PasswordValidityPeriodInDays", "value": null},
+        {"op": "add", "path": "5/IsVerified", "value": false}
+    ])
+    Output := aad.tests with input.domain_settings as Settings
+
+    TestResult("MS.AAD.6.1v1", Output, PASS, true) == true
+}
+
+test_PasswordValidityPeriodInDays_AllNullRootDomains_Correct if {
+    # All root domains have null PasswordValidityPeriodInDays (fully post-Oct 2021 tenant).
+    # All managed, verified domains should be valid.
+    Settings := json.patch(DomainSettings, [
+        {"op": "add", "path": "0/PasswordValidityPeriodInDays", "value": null},
+        {"op": "add", "path": "1/PasswordValidityPeriodInDays", "value": null},
+        {"op": "add", "path": "5/IsVerified", "value": false}
+    ])
+    Output := aad.tests with input.domain_settings as Settings
+
+    TestResult("MS.AAD.6.1v1", Output, PASS, true) == true
 }
 
 test_IsVerified_Correct if {
@@ -54,8 +82,10 @@ test_AuthenticationType_Correct if {
 }
 
 test_PasswordValidityPeriodInDays_ExcludeFederatedDomains_Incorrect if {
+    # root1.com has an explicit expiry of 90 days so it and sub.root1.com fail.
+    # root2.com and sub.root2.com become Federated and are excluded from the validity check.
     Settings := json.patch(DomainSettings, [
-        {"op": "add", "path": "0/PasswordValidityPeriodInDays", "value": null},
+        {"op": "add", "path": "0/PasswordValidityPeriodInDays", "value": 90},
         {"op": "add", "path": "1/AuthenticationType", "value": "Federated"},
         {"op": "add", "path": "3/AuthenticationType", "value": "Federated"},
     ])

--- a/PowerShell/ScubaGear/baselines/aad.md
+++ b/PowerShell/ScubaGear/baselines/aad.md
@@ -843,14 +843,20 @@ User passwords SHALL NOT expire.
     $_.passwordValidityPeriodInDays -ne [int32]::MaxValue
   }
 
-  # Remediate a single specific domain
+  Write-Host $NonCompliantDomains | Format-List
+
+  # Remediate each non-compliant domain
   Invoke-MgGraphRequest -Method PATCH -Uri "https://graph.microsoft.com/v1.0/domains/example.com" `
     -Body @{ passwordValidityPeriodInDays = [int32]::MaxValue }
 
-  # Or remediate all domains
-  $NonCompliantDomains | ForEach-Object {
-    Invoke-MgGraphRequest -Method PATCH -Uri "https://graph.microsoft.com/v1.0/domains/$($_.id)" `
-      -Body @{ passwordValidityPeriodInDays = [int32]::MaxValue }
+  # Verify domain configurations
+  $AllDomains = (Invoke-MgGraphRequest -Method GET -Uri "https://graph.microsoft.com/v1.0/domains").value | Where-Object {
+    $_.isRoot -and $_.isVerified
+  }
+
+  Write-Host "All current domain password expiration policies"
+  foreach ($Domain in $AllDomains) {
+    Write-Host "Domain passwordValidityPeriodInDays: $($Domain.id) $($Domain.passwordValidityPeriodInDays)"
   }
   ```
 

--- a/PowerShell/ScubaGear/baselines/aad.md
+++ b/PowerShell/ScubaGear/baselines/aad.md
@@ -814,6 +814,8 @@ User passwords SHALL NOT expire.
 
 - [Password expiration requirements for users](https://learn.microsoft.com/en-us/microsoft-365/admin/misc/password-policy-recommendations?view=o365-worldwide#password-expiration-requirements-for-users)
 
+- [passwordValidityPeriodInDays property](https://learn.microsoft.com/en-us/graph/api/resources/domain?view=graph-rest-1.0#properties)
+
 - [Eliminate bad passwords using Microsoft Entra Password Protection](https://learn.microsoft.com/en-us/entra/identity/authentication/concept-password-ban-bad)
 
 - [NIST Special Publication 800-63B - Digital Identity Guidelines](https://pages.nist.gov/800-63-3/sp800-63b.html)
@@ -826,7 +828,31 @@ User passwords SHALL NOT expire.
 
 #### MS.AAD.6.1v1 Instructions
 
-1. [Configure the **Password expiration policy** to **Set passwords to never expire**](https://learn.microsoft.com/en-us/microsoft-365/admin/manage/set-password-expiration-policy?view=o365-worldwide#set-password-expiration-policy).
+> **Note:** Tenants created after October 2021 have password expiration disabled by default (`passwordValidityPeriodInDays = null`), which Microsoft treats as equivalent to "never expire." Tenants created before October 2021, or any tenant where the policy was explicitly configured and then reverted, will show `2147483647` (INT_MAX). ScubaGear treats both values as compliant. The M365 admin center password expiration checkbox applies to all managed domains in the tenant. If a tenant has **multiple root domains**, use the PowerShell in Step 2 to audit all of them and remediate any that have a finite expiration period set.
+
+1. Sign in to the [Microsoft 365 admin center](https://admin.microsoft.com) and [configure the **Password expiration policy** to **Set passwords to never expire**](https://learn.microsoft.com/en-us/microsoft-365/admin/manage/set-password-expiration-policy?view=o365-worldwide#set-password-expiration-policy).
+
+2. Optionally, verify and remediate all root domains via PowerShell. This is useful if any domain had a finite expiration configured explicitly. This uses `Invoke-MgGraphRequest`, which is included with the `Microsoft.Graph.Authentication` module already required by ScubaGear. To audit only, connect with `Domain.Read.All`; to also remediate, use `Domain.ReadWrite.All`.
+
+  ```powershell
+  Connect-MgGraph -Scopes "Domain.ReadWrite.All" # or alternatively "Domain.Read.All" for determining which domains are in a non-compliant state.
+
+  $NonCompliantDomains = (Invoke-MgGraphRequest -Method GET -Uri "https://graph.microsoft.com/v1.0/domains").value | Where-Object {
+    $_.isRoot -and $_.isVerified -and
+    $null -ne $_.passwordValidityPeriodInDays -and
+    $_.passwordValidityPeriodInDays -ne [int32]::MaxValue
+  }
+
+  # Remediate a single specific domain
+  Invoke-MgGraphRequest -Method PATCH -Uri "https://graph.microsoft.com/v1.0/domains/example.com" `
+    -Body @{ passwordValidityPeriodInDays = [int32]::MaxValue }
+
+  # Or remediate all domains
+  $NonCompliantDomains | ForEach-Object {
+    Invoke-MgGraphRequest -Method PATCH -Uri "https://graph.microsoft.com/v1.0/domains/$($_.id)" `
+      -Body @{ passwordValidityPeriodInDays = [int32]::MaxValue }
+  }
+  ```
 
 ## 7. Highly Privileged User Access
 

--- a/Testing/Functional/Products/TestPlans/aad.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/aad.testplan.yaml
@@ -1057,7 +1057,7 @@ TestPlan:
                     IsRoot: false
         Postconditions: []
         ExpectedResult: true
-      - TestDescription: MS.AAD.6.1v1 Non-Compliant case - User passwords for some domains are set to expire
+      - TestDescription: MS.AAD.6.1v1 Compliant case - root domains with null PasswordValidityPeriodInDays (Post-Oct 2021 behavior) 
         Preconditions:
           - Command: UpdateProviderExport
             Splat:
@@ -1065,6 +1065,44 @@ TestPlan:
                 domain_settings:
                   - Id: root1.com
                     PasswordValidityPeriodInDays: null
+                    IsVerified: true
+                    AuthenticationType: "Managed"
+                    IsRoot: true
+                  - Id: root2.com
+                    PasswordValidityPeriodInDays: null
+                    IsVerified: true
+                    AuthenticationType: "Managed"
+                    IsRoot: true
+                  - Id: sub.root1.com
+                    PasswordValidityPeriodInDays: null
+                    IsVerified: true
+                    AuthenticationType: "Managed"
+                    IsRoot: false
+                  - Id: sub.root2.com
+                    PasswordValidityPeriodInDays: null
+                    IsVerified: true
+                    AuthenticationType: "Managed"
+                    IsRoot: false
+                  - Id: unverified.domain.com
+                    PasswordValidityPeriodInDays: null
+                    IsVerified: false
+                    AuthenticationType: "Managed"
+                    IsRoot: false
+                  - Id: federated.domain.com
+                    PasswordValidityPeriodInDays: null
+                    IsVerified: false
+                    AuthenticationType: "Federated"
+                    IsRoot: false
+        Postconditions: []
+        ExpectedResult: true
+      - TestDescription: MS.AAD.6.1v1 Non-Compliant case - User passwords for some domains are set to expire
+        Preconditions:
+          - Command: UpdateProviderExport
+            Splat:
+              updates:
+                domain_settings:
+                  - Id: root1.com
+                    PasswordValidityPeriodInDays: 90
                     IsVerified: true
                     AuthenticationType: "Managed"
                     IsRoot: true

--- a/Testing/Functional/Products/TestPlans/aad.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/aad.testplan.yaml
@@ -1057,7 +1057,7 @@ TestPlan:
                     IsRoot: false
         Postconditions: []
         ExpectedResult: true
-      - TestDescription: MS.AAD.6.1v1 Compliant case - root domains with null PasswordValidityPeriodInDays (Post-Oct 2021 behavior) 
+      - TestDescription: MS.AAD.6.1v1 Compliant case - root domains with null PasswordValidityPeriodInDays (Post-Oct 2021 behavior)
         Preconditions:
           - Command: UpdateProviderExport
             Splat:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

An eval_conflict_error message occurs when multiple root domains match a subdomain, e.g. "sub.example.com" and "example.com" match for "sub.sub.example.com" in the rego. The existing code only used a `endswith(Domain.Id, Root.Id)` comparison which was brittle and did not specifically check what was the closest root domain. This PR resolves this issue by adding a max length check to determine the correct root domain.

New rego logic was also added to handle domains that are root and have their `passwordValidityPeriodInDays` set to null. For tenants created after October 2021, `passwordValidityPeriodInDays` is set to null by default, indicating passwords never expire. For tenants created before October 2021, `passwordValidityPeriodInDays` is set to INT_MAX (2147483647). The rego for MS.AAD.6.1v1 now takes both of these cases into account.

The implementation steps for MS.AAD.6.1v1 were updated to include additional remediation steps using PowerShell. This is for cases where domains were configured to use a finite password expiration outside of the standard M365 admin console approach.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

Closes #2055 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

1. To recreate the eval_conflict_error, run ScubaGear against the main branch against aad/entra. In the "domain_settings" field in the ScubaResults.json file, add the following objects:

```
{
        "IsRoot":  true,
        "State":  null,
        "IsInitial":  true,
        "IsDefault":  true,
        "PasswordNotificationWindowInDays":  14,
        "AuthenticationType":  "Managed",
        "Id":  "testdomain.onmicrosoft.com",
        "SupportedServices":  [
                                  "Email",
                                  "OfficeCommunicationsOnline"
                              ],
        "IsVerified":  true,
        "AvailabilityStatus":  null,
        "IsAdminManaged":  true,
        "PasswordValidityPeriodInDays":  2147483647
    },
    {
        "IsRoot":  true,
        "State":  null,
        "IsInitial":  true,
        "IsDefault":  false,
        "PasswordNotificationWindowInDays":  14,
        "AuthenticationType":  "Managed",
        "Id":  "sub.testdomain.onmicrosoft.com",
        "SupportedServices":  [
                                  "Email",
                                  "OfficeCommunicationsOnline"
                              ],
        "IsVerified":  true,
        "AvailabilityStatus":  null,
        "IsAdminManaged":  true,
        "PasswordValidityPeriodInDays":  2147483647
    },
    {
        "IsRoot":  false,
        "State":  null,
        "IsInitial":  false,
        "IsDefault":  false,
        "PasswordNotificationWindowInDays":  14,
        "AuthenticationType":  "Managed",
        "Id":  "sub.sub.testdomain.onmicrosoft.com",
        "SupportedServices":  [
                                  "Email",
                                  "OfficeCommunicationsOnline"
                              ],
        "IsVerified":  true,
        "AvailabilityStatus":  null,
        "IsAdminManaged":  true,
        "PasswordValidityPeriodInDays":  2147483647
    }
```

Using Invoke-SCuBACached, run ScubaGear against the same ScubaResults.json file that was previously generated.

```
Invoke-SCuBACached -ExportProvider $false -ProductNames aad -M365Environment <environment> -OutPath <output-path-from-previous-run> 
```

You should see the eval_conflict_error display.

Now, switch to this feature branch and rerun Invoke-SCuBACached again against the same ScubaResults.json file. You should not see the eval_conflict_error display.

2. Test the new PowerShell code added to the implementation steps for auditing/remediating domains with a finite expiration explicitly configured.

  ```powershell
Connect-MgGraph -Scopes "Domain.ReadWrite.All"

# 1. Get compliant domains
$CompliantDomains = (Invoke-MgGraphRequest -Method GET -Uri "https://graph.microsoft.com/v1.0/domains").value |
  Where-Object {
    $_.isRoot -and $_.isVerified -and
    ($null -eq $_.passwordValidityPeriodInDays -or $_.passwordValidityPeriodInDays -eq [int32]::MaxValue)
}

Write-Output $CompliantDomains | Format-List

2. Modify a compliant domain to be non compliant (do not modify primary domain, use a test domain)
Invoke-MgGraphRequest -Method PATCH -Uri "https://graph.microsoft.com/v1.0/domains/example.com" `
  -Body @{ passwordValidityPeriodInDays = 90 }

# 2. Now get the non-compliant domains
$NonCompliantDomains = (Invoke-MgGraphRequest -Method GET -Uri "https://graph.microsoft.com/v1.0/domains").value | Where-Object {
  $_.isRoot -and $_.isVerified -and
  $null -ne $_.passwordValidityPeriodInDays -and
  $_.passwordValidityPeriodInDays -ne [int32]::MaxValue
}

# 3. Run Write-Output $NonCompliantDomains | Format-List to check the values.

# 4. Remediate a single specific domain
Invoke-MgGraphRequest -Method PATCH -Uri "https://graph.microsoft.com/v1.0/domains/example.com" `
  -Body @{ passwordValidityPeriodInDays = [int32]::MaxValue }
  ```

3. Run rego unit tests locally or check CI 

```
./Testing/RunRegoUnitTests.ps1 -p aad
```

4. New functional tests that were added can be viewed here: https://github.com/cisagov/ScubaGear/actions/runs/25704258500/job/75471688853

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed.

  Use `Update branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [x] Resolved all merge conflicts on branch.
- [x] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the PR assignee to complete. -->
- [x] Feature branch deleted after merge to clean up repository.
- [x] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
