### PR TITLE
Fix `Description` field `maxLength` in config schema to allow sample config files to pass validation

### DIFF
--- a/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfigSchema.json
+++ b/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfigSchema.json
@@ -92,7 +92,7 @@
       "_comment": "Detailed description of this configuration file, its purpose, and any special considerations",
       "type": "string",
       "minLength": 1,
-      "maxLength": 500,
+      "maxLength": 1000,
       "caseSensitive": false
     },
 


### PR DESCRIPTION
## 🗣 Description ##

Increases the `maxLength` for the `Description` field in `ScubaConfigSchema.json` from `500` to `1000` to accommodate the descriptions used in the ScubaGear sample configuration files.

## 💭 Motivation and context ##

The `Description` field in `ScubaConfigSchema.json` had a `maxLength` of `500`, but the `full_config.yaml` sample configuration file contains a description that is approximately 675 characters. This caused schema validation to fail when users ran ScubaGear with the provided sample configuration files despite those files being shipped as valid, ready-to-use examples.

Increasing the limit to `1000` accommodates the existing sample content and provides sufficient headroom for real-world organizational descriptions without being unreasonably permissive.

Resolves #2155

## 🧪 Testing ##

Validate the two affected sample configuration files pass schema validation by running them against `Invoke-SCuBA`:

```powershell
# Test full_config.yaml
Invoke-SCuBA -ConfigFilePath "PowerShell/ScubaGear/Sample-Config-Files/full_config.yaml"

# Test scuba_compliance.yaml
Invoke-SCuBA -ConfigFilePath "PowerShell/ScubaGear/Sample-Config-Files/scuba_compliance.yaml"
```
## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [ ] All relevant repo and/or project documentation updated to reflect these changes.
- [ ] Unit tests added/updated to cover PowerShell and Rego changes.
- [ ] Functional tests added/updated to cover PowerShell and Rego changes.
- [ ] All relevant functional tests passed.
- [ ] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] PR passed smoke test check.
- [ ] Feature branch has been rebased against changes from parent branch, as needed.

  Use `Update branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [ ] Resolved all merge conflicts on branch.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the PR assignee to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
