### PR TITLE
Prevent TryCommand and API retrieval errors from terminating ScubaGear. Rewrite SharePoint Rego to be resilient to errors fetching settings.

### DIFF
--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -361,7 +361,7 @@ function Invoke-SCuBA {
         }
 
         Remove-Resources # Unload helper modules if they are still in the PowerShell session
-        Import-Resources # Imports Providers, RunRego, CreateReport, Connection
+        Import-Resources # Imports Providers, RunRego, etc.
 
         # Loads and executes parameters from a Configuration file
         if ($PSCmdlet.ParameterSetName -eq 'Configuration'){
@@ -2210,6 +2210,9 @@ function Invoke-SCuBACached {
             $OutFolderPath = $OutPath
             $ProductNames = $ProductNames | Sort-Object -Unique
 
+            Remove-Resources
+            Import-Resources # Imports Providers, RunRego, etc.
+
             # Initialize logging for troubleshooting - debug logs are ALWAYS created
             # Logs are placed in a DebugLogs subfolder within the output folder
             # Transcript logging is optional and enabled only when -Transcript is specified
@@ -2259,7 +2262,7 @@ function Invoke-SCuBACached {
                 # Capture environment diagnostics using Write-ScubaRunDetails
                 Write-ScubaLog -Message "Capturing environment diagnostics (Cached Mode)" -Level "Info" -Source "ScubaCached"
                 try {
-                    Write-ScubaRunDetails -IncludeLoadedModules -IncludeErrors -ConfiguredOPAPath $OPAPath -ErrorAction Stop
+                    Write-ScubaRunDetails -IncludeLoadedModules -IncludeErrors -ConfiguredOPAPath $OPAPath -TestNetworkConnectivity $false -ErrorAction Stop
                 }
                 catch {
                     Write-ScubaLog -Message "Failed to capture environment diagnostics" -Level "Warning" -Source "ScubaCached" -Data @{
@@ -2276,10 +2279,6 @@ function Invoke-SCuBACached {
                 Write-Warning "Failed to initialize ScubaGear logging: $_"
                 $Script:ScubaLoggingEnabled = $false
             }
-
-            Remove-Resources
-            Import-Resources # Imports Providers, RunRego, CreateReport, Connection, Support, Utility
-            Write-ScubaLog -Message "Resources imported successfully" -Level "Debug" -Source "ScubaCached"
 
             # Authenticate - parameters consolidated into a temporary ScubaConfig for cached execution
             $TempScubaConfig = New-Object -Type PSObject -Property @{

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -1868,7 +1868,7 @@ function Get-ServicePrincipalParams {
         $ServicePrincipalParams += @{CertThumbprintParams = $CertThumbprintParams}
     }
     else {
-        throw "Missing parameters required for authentication with Service Principal Auth; Run Get-Help Invoke-Scuba for details on correct arguments"
+        throw "When authenticating with Service Principal authentication, the following command line parameters must be provided: -AppID, -CertificateThumbprint and -Organization."
     }
     $ServicePrincipalParams
 }

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -506,10 +506,10 @@ function Invoke-SCuBA {
                 InvocationLine = $MyInvocation.Line
             }
 
-            # Capture environment diagnostics using Get-ScubaRunDetails
+            # Capture environment diagnostics using Write-ScubaRunDetails
             Write-ScubaLog -Message "Capturing environment diagnostics" -Level "Info" -Source "InvokeScuba"
             try {
-                Get-ScubaRunDetails -IncludeLoadedModules -IncludeErrors -ConfiguredOPAPath $ScubaConfig.OPAPath -ErrorAction Stop
+                Write-ScubaRunDetails -IncludeLoadedModules -IncludeErrors -ConfiguredOPAPath $ScubaConfig.OPAPath -ErrorAction Stop
             }
             catch {
                 Write-ScubaLog -Message "Failed to capture environment diagnostics" -Level "Warning" -Source "InvokeScuba" -Data @{
@@ -2256,10 +2256,10 @@ function Invoke-SCuBACached {
                     InvocationLine = $MyInvocation.Line
                 }
 
-                # Capture environment diagnostics using Get-ScubaRunDetails
+                # Capture environment diagnostics using Write-ScubaRunDetails
                 Write-ScubaLog -Message "Capturing environment diagnostics (Cached Mode)" -Level "Info" -Source "ScubaCached"
                 try {
-                    Get-ScubaRunDetails -IncludeLoadedModules -IncludeErrors -ConfiguredOPAPath $OPAPath -ErrorAction Stop
+                    Write-ScubaRunDetails -IncludeLoadedModules -IncludeErrors -ConfiguredOPAPath $OPAPath -ErrorAction Stop
                 }
                 catch {
                     Write-ScubaLog -Message "Failed to capture environment diagnostics" -Level "Warning" -Source "ScubaCached" -Data @{

--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -353,7 +353,8 @@ function Get-PrivilegedUser {
     $AADRoles = (Invoke-GraphDirectly -Commandlet "Get-MgBetaDirectoryRole" -M365Environment $M365Environment).Value | Where-Object { $_.DisplayName -in $PrivilegedRoles }
 
     # Construct a list of privileged users based on the Active role assignments
-    Trace-ScubaFunction -FunctionName "Get-PrivilegedUser Active assignments" -ScriptBlock {
+    # We set LogErrors to false because we handle errors locally
+    Trace-ScubaFunction -FunctionName "Get-PrivilegedUser Active assignments" -LogErrors $false -ScriptBlock {
         foreach ($Role in $AADRoles) {
 
             # Get a list of all the users and groups Actively assigned to this role
@@ -381,7 +382,8 @@ function Get-PrivilegedUser {
 
     # Process the Eligible role assignments if the premium license for PIM is there
     if ($TenantHasPremiumLicense) {
-        Trace-ScubaFunction -FunctionName "Get-PrivilegedUser Eligible assignments" -ScriptBlock {
+        # We set LogErrors to false because we handle errors locally
+        Trace-ScubaFunction -FunctionName "Get-PrivilegedUser Eligible assignments" -LogErrors $false -ScriptBlock {
             # Get a list of all the users and groups that have Eligible assignments, this will retrieve information from the Graph API directly and not use the cmdlet.
             $AllPIMRoleAssignments = (Invoke-GraphDirectly -Commandlet "Get-MgBetaRoleManagementDirectoryRoleEligibilityScheduleInstance" -M365Environment $M365Environment).Value
 
@@ -755,22 +757,24 @@ function Get-PrivilegedRole {
 
     # If the tenant has the premium license then you can access the PIM service to get the role configuration policies and the active role assigments
     if ($TenantHasPremiumLicense) {
+        # In this block We set LogErrors to false when calling Trace-ScubaFunction because we handle errors locally
+
         # Get ALL the roles and users actively assigned to them, API information is contained within the Permissions JSON file.
-        $AllRoleAssignments = Trace-ScubaFunction -FunctionName "Get-MgBetaRoleManagementDirectoryRoleAssignmentScheduleInstance" -ScriptBlock {
+        $AllRoleAssignments = Trace-ScubaFunction -FunctionName "Get-MgBetaRoleManagementDirectoryRoleAssignmentScheduleInstance" -LogErrors $false -ScriptBlock {
             (Invoke-GraphDirectly -Commandlet "Get-MgBetaRoleManagementDirectoryRoleAssignmentScheduleInstance" -M365Environment $M365Environment).Value
         }
-        $AllEligibleRoleAssignments = Trace-ScubaFunction -FunctionName "Get-MgBetaRoleManagementDirectoryRoleEligibilityScheduleInstance" -ScriptBlock {
+        $AllEligibleRoleAssignments = Trace-ScubaFunction -FunctionName "Get-MgBetaRoleManagementDirectoryRoleEligibilityScheduleInstance" -LogErrors $false -ScriptBlock {
             (Invoke-GraphDirectly -Commandlet "Get-MgBetaRoleManagementDirectoryRoleEligibilityScheduleInstance" -M365Environment $M365Environment).Value
         }
 
         # Each of the helper functions below add configuration settings (aka rules) to the role array.
         # Get the PIM configurations for the roles
-        Trace-ScubaFunction -FunctionName "GetConfigurationsForRoles" -ScriptBlock {
+        Trace-ScubaFunction -FunctionName "GetConfigurationsForRoles" -LogErrors $false -ScriptBlock {
             GetConfigurationsForRoles -PrivilegedRoleArray $PrivilegedRoleArray -AllRoleAssignments $AllRoleAssignments
         }
         # Get the PIM configurations for the groups
         $AllRoleAssignments += $AllEligibleRoleAssignments # Add eligible only for PIM groups
-        Trace-ScubaFunction -FunctionName "GetConfigurationsForPimGroups" -ScriptBlock {
+        Trace-ScubaFunction -FunctionName "GetConfigurationsForPimGroups" -LogErrors $false -ScriptBlock {
             GetConfigurationsForPimGroups -PrivilegedRoleArray $PrivilegedRoleArray -AllRoleAssignments $AllRoleAssignments -M365Environment $M365Environment
         }
     }

--- a/PowerShell/ScubaGear/Modules/Providers/ExportPowerBIProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportPowerBIProvider.psm1
@@ -24,7 +24,7 @@ function Export-PowerBIProvider {
     )
 
     # Initialize the tenant settings to create an empty JSON if there was an error or no license.
-    $TenantSettings = $null
+    $TenantSettingsJson = ConvertTo-Json @()
 
     $HelperFolderPath = Join-Path -Path $PSScriptRoot -ChildPath "ProviderHelpers"
     Import-Module (Join-Path -Path $HelperFolderPath -ChildPath "CommandTracker.psm1")
@@ -54,17 +54,16 @@ function Export-PowerBIProvider {
         # If successfully retrieved the tenant settings
         if ($AdminSettings.count -gt 0) {
             $TenantSettings = $AdminSettings[0].tenantSettings
+            $TenantSettingsJson = ConvertTo-Json @($TenantSettings) -Depth 10
         }
         # If there was an error retrieving the tenant settings, TryCommand already handles it so we don't need to do anything additional.
     }
     # License not found. We must mark Invoke-RestMethod as successful even if we don't call it.
     # The absence of a license is not an error and the Rego displays a no license message.
     else {
-        # $TenantSettingsJson = ConvertTo-Json @()
         $Tracker.AddSuccessfulCommand("Invoke-RestMethod")
     }
-
-    $TenantSettingsJson = ConvertTo-Json @($TenantSettings) -Depth 10
+    
     $LicenseFoundJson = ConvertTo-Json $LicenseFound
     $PowerBISuccessfulCommands = ConvertTo-Json @($Tracker.GetSuccessfulCommands())
     $PowerBIUnSuccessfulCommands = ConvertTo-Json @($Tracker.GetUnSuccessfulCommands())

--- a/PowerShell/ScubaGear/Modules/Providers/ExportSharePointProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportSharePointProvider.psm1
@@ -25,8 +25,7 @@ function Export-SharePointProvider {
     $SPOTenantJson = ConvertTo-Json @()
 
     # Use access token acquired by Connection.psm1
-    # $TenantData = $Tracker.TryCommand("Get-SPOTenantRest", @{AdminUrl = $AdminUrl; AccessToken = $AccessToken})
-    $TenantData = $Tracker.TryCommand("Get-SPOTenantRest", @{AdminUrl = "https://www.github.com"; AccessToken = "NoToken"})
+    $TenantData = $Tracker.TryCommand("Get-SPOTenantRest", @{AdminUrl = $AdminUrl; AccessToken = $AccessToken})
     # If successfully retrieved the tenant settings
     if ($TenantData.count -gt 0) {
         $SPOTenantJson = ConvertTo-Json @($TenantData) -Depth 10

--- a/PowerShell/ScubaGear/Modules/Providers/ExportSharePointProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportSharePointProvider.psm1
@@ -22,19 +22,22 @@ function Export-SharePointProvider {
     Import-Module (Join-Path -Path $HelperFolderPath -ChildPath "SPORestHelper.psm1")
     $Tracker = Get-CommandTracker
 
-    $UsedPnP = ConvertTo-Json $false
+    $SPOTenantJson = ConvertTo-Json @()
 
     # Use access token acquired by Connection.psm1
-    $TenantData = $Tracker.TryCommand("Get-SPOTenantRest", @{AdminUrl = $AdminUrl; AccessToken = $AccessToken})
-    $SPOTenant = ConvertTo-Json @($TenantData) -Depth 10
-
+    # $TenantData = $Tracker.TryCommand("Get-SPOTenantRest", @{AdminUrl = $AdminUrl; AccessToken = $AccessToken})
+    $TenantData = $Tracker.TryCommand("Get-SPOTenantRest", @{AdminUrl = "https://www.github.com"; AccessToken = "NoToken"})
+    # If successfully retrieved the tenant settings
+    if ($TenantData.count -gt 0) {
+        $SPOTenantJson = ConvertTo-Json @($TenantData) -Depth 10
+    }
+    
     $SuccessfulCommands = ConvertTo-Json @($Tracker.GetSuccessfulCommands())
     $UnSuccessfulCommands = ConvertTo-Json @($Tracker.GetUnSuccessfulCommands())
 
     # Note the spacing and the last comma in the json is important
     $json = @"
-    "SPO_tenant": $SPOTenant,
-    "OneDrive_PnP_Flag": $UsedPnp,
+    "SPO_tenant": $SPOTenantJson,
     "SharePoint_successful_commands": $SuccessfulCommands,
     "SharePoint_unsuccessful_commands": $UnSuccessfulCommands,
 "@

--- a/PowerShell/ScubaGear/Modules/Providers/ProviderHelpers/CommandTracker.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ProviderHelpers/CommandTracker.psm1
@@ -5,7 +5,6 @@ Import-Module -Name $PSScriptRoot/AADHybridExchangeHelper.psm1 -Function Get-Leg
 Import-Module -Name $PSScriptRoot/PowerPlatformRestHelper.psm1 -Function Get-PowerPlatformTenantSettingsRest, Get-PowerPlatformEnvironmentsRest, Get-PowerPlatformDlpPoliciesRest, Get-PowerPlatformTenantIsolationRest
 Import-Module -Name $PSScriptRoot/SPORestHelper.psm1 -Function Get-SPOTenantRest
 Import-Module -Name $PSScriptRoot/../../Utility/Utility.psm1 -Function Invoke-GraphDirectly, ConvertFrom-GraphHashtable
-# Import-Module -Name $PSScriptRoot/../../Utility/ScubaLogging.psm1 -Function Write-ScubaLog
 Import-Module -Name $PSScriptRoot/AADAppManagementPolicyHelper.psm1 -Function Get-AppManagementPolicies
 
 class CommandTracker {

--- a/PowerShell/ScubaGear/Modules/Providers/ProviderHelpers/CommandTracker.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ProviderHelpers/CommandTracker.psm1
@@ -5,7 +5,7 @@ Import-Module -Name $PSScriptRoot/AADHybridExchangeHelper.psm1 -Function Get-Leg
 Import-Module -Name $PSScriptRoot/PowerPlatformRestHelper.psm1 -Function Get-PowerPlatformTenantSettingsRest, Get-PowerPlatformEnvironmentsRest, Get-PowerPlatformDlpPoliciesRest, Get-PowerPlatformTenantIsolationRest
 Import-Module -Name $PSScriptRoot/SPORestHelper.psm1 -Function Get-SPOTenantRest
 Import-Module -Name $PSScriptRoot/../../Utility/Utility.psm1 -Function Invoke-GraphDirectly, ConvertFrom-GraphHashtable
-Import-Module -Name $PSScriptRoot/../../Utility/ScubaLogging.psm1 -Function Write-ScubaLog
+# Import-Module -Name $PSScriptRoot/../../Utility/ScubaLogging.psm1 -Function Write-ScubaLog
 Import-Module -Name $PSScriptRoot/AADAppManagementPolicyHelper.psm1 -Function Get-AppManagementPolicies
 
 class CommandTracker {
@@ -45,7 +45,8 @@ class CommandTracker {
             if ($isGraphDirect) {
                 # This will pull the Graph API vice the PowerShell module
                 Write-Verbose "Running $($Command) API Call"
-                $ModCommand = Trace-ScubaFunction -FunctionName $Command -ScriptBlock {
+                # We set LogErrors to false because we handle the logging of errors here in the TryCommand catch block.
+                $ModCommand = Trace-ScubaFunction -FunctionName $Command -LogErrors $false -ScriptBlock {
                     Invoke-GraphDirectly -Commandlet $Command @CommandArgs
                 }
                 $Result = $ModCommand
@@ -57,7 +58,8 @@ class CommandTracker {
             }
             else {
                 Write-Verbose "Running $($Command) with arguments: $($CommandArgs)"
-                $Result = Trace-ScubaFunction -FunctionName $Command -ScriptBlock {
+                # We set LogErrors to false because we handle the logging of errors here in the TryCommand catch block.
+                $Result = Trace-ScubaFunction -FunctionName $Command -LogErrors $false -ScriptBlock {
                     & $Command @CommandArgs
                 }
             }
@@ -69,7 +71,8 @@ class CommandTracker {
                 Write-Warning "Error running $($Command): $($_.Exception.Message)`n$($_.ScriptStackTrace)"
             }
 
-            Write-ScubaLog -Message "Error running command" -Level "Warning" -Source "ProviderList" -Data @{
+            # We set the log level to Info here because Write-ScubaLog will track Warning or Error as a terminating error.
+            Write-ScubaLog -Message "Error running command" -Level "Info" -Source "TryCommand" -Data @{
                 Command = $Command
                 Error   = $_.Exception.Message
                 StackTrace = $_.ScriptStackTrace

--- a/PowerShell/ScubaGear/Modules/Utility/ScubaLogging.psm1
+++ b/PowerShell/ScubaGear/Modules/Utility/ScubaLogging.psm1
@@ -588,7 +588,7 @@ function Stop-ScubaLogging {
     }
 }
 
-function Get-ScubaRunDetails {
+function Write-ScubaRunDetails {
     <#
     .SYNOPSIS
     Capture ScubaGear runtime diagnostic information
@@ -617,12 +617,15 @@ function Get-ScubaRunDetails {
     Include the most recent PowerShell errors from the $Error automatic variable.
     Useful for diagnosing what went wrong during a failed ScubaGear run.
 
+    .PARAMETER TestNetworkConnectivity
+    Passing $false prevents the function from performing a network connectivity test since it is not necessary for Invoke-ScubaCached
+
     .EXAMPLE
-    Get-ScubaRunDetails
+    Write-ScubaRunDetails
     Collect basic diagnostic information about the current ScubaGear environment.
 
     .EXAMPLE
-    Get-ScubaRunDetails -IncludeLoadedModules -IncludeErrors
+    Write-ScubaRunDetails -IncludeLoadedModules -IncludeErrors
     Collect diagnostic information including loaded modules and recent errors.
 
     .NOTES
@@ -639,7 +642,9 @@ function Get-ScubaRunDetails {
         [switch]$IncludeErrors,
 
         [Parameter(Mandatory = $false)]
-        [string]$ConfiguredOPAPath
+        [string]$ConfiguredOPAPath,
+
+        [bool]$TestNetworkConnectivity = $true
     )
 
     try {
@@ -843,63 +848,65 @@ function Get-ScubaRunDetails {
         }
 
         # 6. Network Connectivity Status
-        Write-ScubaLog -Message "Checking network connectivity..." -Level "Debug" -Source "RunDetails"
-        try {
-            $connectivityData = @{
-                InternetConnected = $false
-                DNSResolution = $false
-                TestTarget = "www.microsoft.com"
-            }
-
-            # Test internet connectivity via HTTPS (port 443) rather than ICMP ping.
-            # ICMP is blocked in many corporate environments, causing false "not connected" results.
+        if ($TestNetworkConnectivity) {
+            Write-ScubaLog -Message "Checking network connectivity..." -Level "Debug" -Source "RunDetails"
             try {
-                $testConnection = Test-NetConnection -ComputerName $connectivityData.TestTarget -Port 443 -InformationLevel Quiet -ErrorAction Stop -WarningAction SilentlyContinue
-                $connectivityData.InternetConnected = $testConnection
-            }
-            catch {
-                $connectivityData.InternetError = $_.Exception.Message
-            }
+                $connectivityData = @{
+                    InternetConnected = $false
+                    DNSResolution = $false
+                    TestTarget = "www.microsoft.com"
+                }
 
-            # Test DNS resolution
-            try {
-                $dnsTest = Resolve-DnsName $connectivityData.TestTarget -ErrorAction Stop
-                $connectivityData.DNSResolution = $null -ne $dnsTest
-                if ($dnsTest) {
-                    # Resolve-DnsName returns IP4Address for A records and IP6Address for AAAA records;
-                    # find the first A record and fall back to IP6Address if none exists
-                    $aRecord = $dnsTest | Where-Object { $_.QueryType -eq 'A' } | Select-Object -First 1
-                    $connectivityData.DNSResult = if ($aRecord) { $aRecord.IP4Address } else {
-                        ($dnsTest | Where-Object { $_.IP6Address } | Select-Object -First 1).IP6Address
+                # Test internet connectivity via HTTPS (port 443) rather than ICMP ping.
+                # ICMP is blocked in many corporate environments, causing false "not connected" results.
+                try {
+                    $testConnection = Test-NetConnection -ComputerName $connectivityData.TestTarget -Port 443 -InformationLevel Quiet -ErrorAction Stop -WarningAction SilentlyContinue
+                    $connectivityData.InternetConnected = $testConnection
+                }
+                catch {
+                    $connectivityData.InternetError = $_.Exception.Message
+                }
+
+                # Test DNS resolution
+                try {
+                    $dnsTest = Resolve-DnsName $connectivityData.TestTarget -ErrorAction Stop
+                    $connectivityData.DNSResolution = $null -ne $dnsTest
+                    if ($dnsTest) {
+                        # Resolve-DnsName returns IP4Address for A records and IP6Address for AAAA records;
+                        # find the first A record and fall back to IP6Address if none exists
+                        $aRecord = $dnsTest | Where-Object { $_.QueryType -eq 'A' } | Select-Object -First 1
+                        $connectivityData.DNSResult = if ($aRecord) { $aRecord.IP4Address } else {
+                            ($dnsTest | Where-Object { $_.IP6Address } | Select-Object -First 1).IP6Address
+                        }
                     }
                 }
+                catch {
+                    $connectivityData.DNSError = $_.Exception.Message
+                }
+
+                # Check for proxy settings
+                # GetProxy() requires an absolute URI, so prefix the hostname with https://
+                try {
+                    $proxySettings = [System.Net.WebRequest]::GetSystemWebProxy()
+                    $testUri       = [uri]"https://$($connectivityData.TestTarget)"
+                    $proxyUri      = $proxySettings.GetProxy($testUri)
+                    if ($proxyUri.Host -ne $connectivityData.TestTarget) {
+                        $connectivityData.ProxyDetected = $true
+                        $connectivityData.ProxyAddress = $proxyUri.ToString()
+                    }
+                    else {
+                        $connectivityData.ProxyDetected = $false
+                    }
+                }
+                catch {
+                    $connectivityData.ProxyCheckError = $_.Exception.Message
+                }
+
+                Write-ScubaLog -Message "Network connectivity status captured" -Level "Info" -Source "RunDetails" -Data $connectivityData
             }
             catch {
-                $connectivityData.DNSError = $_.Exception.Message
+                Write-ScubaLog -Message "Failed to check network connectivity: $($_.Exception.Message)" -Level "Warning" -Source "RunDetails"
             }
-
-            # Check for proxy settings
-            # GetProxy() requires an absolute URI, so prefix the hostname with https://
-            try {
-                $proxySettings = [System.Net.WebRequest]::GetSystemWebProxy()
-                $testUri       = [uri]"https://$($connectivityData.TestTarget)"
-                $proxyUri      = $proxySettings.GetProxy($testUri)
-                if ($proxyUri.Host -ne $connectivityData.TestTarget) {
-                    $connectivityData.ProxyDetected = $true
-                    $connectivityData.ProxyAddress = $proxyUri.ToString()
-                }
-                else {
-                    $connectivityData.ProxyDetected = $false
-                }
-            }
-            catch {
-                $connectivityData.ProxyCheckError = $_.Exception.Message
-            }
-
-            Write-ScubaLog -Message "Network connectivity status captured" -Level "Info" -Source "RunDetails" -Data $connectivityData
-        }
-        catch {
-            Write-ScubaLog -Message "Failed to check network connectivity: $($_.Exception.Message)" -Level "Warning" -Source "RunDetails"
         }
 
         # 7. Current Command/Invocation Details
@@ -1351,13 +1358,13 @@ function Get-ScubaDebugLogReport {
     $versionMismatch    = ($scubaLoaded -ne 'Unknown' -and $scubaInstalled -ne 'Unknown' -and $scubaLoaded -ne $scubaInstalled)
 
     # --- OPA ---
-    # Default-location discovery: what Get-ScubaRunDetails found in ~/.scubagear/Tools
+    # Default-location discovery: what Write-ScubaRunDetails found in ~/.scubagear/Tools
     $opaEntry   = Find-Entry 'RunDetails' 'OPA Executable found'
     $opaVersion = if ($opaEntry.Data.Version)  { ($opaEntry.Data.Version -replace 'Version:\s*', '').Trim() } else { 'Unknown' }
     $opaPath    = if ($opaEntry.Data.Path)     { $opaEntry.Data.Path }     else { 'Unknown' }
     $opaSize    = if ($opaEntry.Data.SizeMB)   { "$($opaEntry.Data.SizeMB) MB" } else { 'Unknown' }
 
-    # Configured-path check: logged by Get-ScubaRunDetails when called with -ConfiguredOPAPath $ScubaConfig.OPAPath.
+    # Configured-path check: logged by Write-ScubaRunDetails when called with -ConfiguredOPAPath $ScubaConfig.OPAPath.
     # This reflects the path ScubaGear will actually use at runtime (from -OPAPath param or YAML OPAPath key).
     # Regex matches both "OPA Executable at configured path" and "OPA Executable NOT found at configured path"
     $opaConfiguredEntry = Find-Entry 'RunDetails' 'OPA Executable (NOT found )?at configured path'
@@ -1581,7 +1588,7 @@ function Get-ScubaDebugLogReport {
     }
     else {
         # Fallback to old behavior if no snapshots found (legacy logs)
-        $sb.AppendLine('_No module snapshots captured. Use Get-ScubaRunDetails with -IncludeLoadedModules to enable module tracking._') | Out-Null
+        $sb.AppendLine('_No module snapshots captured. Use Write-ScubaRunDetails with -IncludeLoadedModules to enable module tracking._') | Out-Null
     }
     $sb.AppendLine('') | Out-Null
 
@@ -1791,7 +1798,7 @@ function Get-ScubaDebugLogReport {
 # Explicitly export only the public API surface of this module.
 # Internal helpers (e.g. module-level variables, private utility logic) are not exported.
 # Callers in Orchestrator.psm1 use: Initialize-ScubaLogging, Write-ScubaLog, Trace-ScubaFunction,
-# Get-ScubaRunDetails, and Stop-ScubaLogging.  The remaining exports (Enable-ScubaAutoTrace,
+# Write-ScubaRunDetails, and Stop-ScubaLogging.  The remaining exports (Enable-ScubaAutoTrace,
 # Write-ScubaFunctionEntry, Write-ScubaFunctionExit) are available for future instrumentation use.
 Export-ModuleMember -Function @(
     'Initialize-ScubaLogging',
@@ -1801,7 +1808,7 @@ Export-ModuleMember -Function @(
     'Enable-ScubaAutoTrace',
     'Write-ScubaFunctionEntry',
     'Write-ScubaFunctionExit',
-    'Get-ScubaRunDetails',
+    'Write-ScubaRunDetails',
     'Update-ScubaModuleSnapshot',
     'Get-ScubaDebugLogReport'
 )

--- a/PowerShell/ScubaGear/Modules/Utility/ScubaLogging.psm1
+++ b/PowerShell/ScubaGear/Modules/Utility/ScubaLogging.psm1
@@ -301,6 +301,10 @@ function Trace-ScubaFunction {
     .PARAMETER LogReturnValue
     Whether to log the return value (disable for large objects)
 
+    .PARAMETER LogErrors
+    $false suppreses writing to the log and prevents ScubaLogging from thinking that a terminating error occurred if the traced function call fails.
+    The caller will use $false when they want to handle the error themselves.
+
     .EXAMPLE
     $result = Trace-ScubaFunction -FunctionName "Get-MgUser" -Parameters @{UserId="test@domain.com"} -ScriptBlock {
         Get-MgUser -UserId $UserId
@@ -316,7 +320,9 @@ function Trace-ScubaFunction {
         [Parameter(Mandatory = $true)]
         [scriptblock]$ScriptBlock,
 
-        [bool]$LogReturnValue = $false
+        [bool]$LogReturnValue = $false,
+
+        [bool]$LogErrors = $true
     )
 
     if (-not $Script:ScubaLogEnabled) {
@@ -376,8 +382,11 @@ function Trace-ScubaFunction {
             ErrorType = $_.Exception.GetType().Name           # Type of exception that occurred
         }
 
-        # Log the error exit with full exception details
-        Write-ScubaLog -Message "EXIT: $FunctionName (ERROR)" -Level "Error" -Source "FunctionTrace" -Data $exitData -Exception $_.Exception
+        if ($LogErrors) {
+            # Log the error exit with full exception details
+            Write-ScubaLog -Message "EXIT: $FunctionName (ERROR)" -Level "Error" -Source "FunctionTrace" -Data $exitData -Exception $_.Exception
+        }
+
         throw  # Re-throw the exception to maintain original error handling
     }
 }

--- a/PowerShell/ScubaGear/Rego/SharepointConfig.rego
+++ b/PowerShell/ScubaGear/Rego/SharepointConfig.rego
@@ -11,7 +11,7 @@ import data.utils.key.PASS
 
 
 #############
-# Constants #
+# Constants and helper rulesets
 #############
 
 # Values in json for slider sharepoint/onedrive sharing settings
@@ -19,10 +19,6 @@ ONLYPEOPLEINORG := 0        # "Disabled" in functional tests
 EXISTINGGUESTS := 3         # "ExistingExternalUserSharingOnly" in functional tests
 NEWANDEXISTINGGUESTS := 1   # "ExternalUserSharingOnly" in functional tests
 ANYONE := 2                 # "ExternalUserAndGuestSharing" in functional tests
-
-######################################
-# External sharing support functions #
-######################################
 
 SliderSettings(0) := "Only People In Your Organization"
 
@@ -33,12 +29,6 @@ SliderSettings(2) := "Anyone"
 SliderSettings(3) := "Existing Guests"
 
 SliderSettings(Value) := "Unknown" if not Value in [0, 1, 2, 3]
-
-Tenant := input.SPO_tenant[0] if {
-    count(input.SPO_tenant) == 1
-}
-
-SharingCapability := Tenant.SharingCapability
 
 NAString(SharingSetting, Negation) := concat("", [
     "This policy is only applicable if the external sharing slider in the SharePoint admin center is set to ",
@@ -53,15 +43,16 @@ else := concat("", [
     "See %v for more info"
 ]) if Negation == true
 
-### Fix added by Ted
+# All of the SharePoint settings
 SharepointSettings := {
     key: value |
     SPOTenantObject := object.get(input, "SPO_tenant", [])[0]
     some key, value in SPOTenantObject
 }
 
+# SharingCapability is referenced by many of the policies
 SharingCapabilitySetting := object.get(SharepointSettings, "SharingCapability", null)
-###
+### End Constants and helper rulesets
 
 
 ###################
@@ -92,6 +83,7 @@ tests contains {
     Status := count(FilterArray(Conditions, true)) == 1
 }
 
+# Test for settings not found in JSON
 tests contains {
     "PolicyId": "MS.SHAREPOINT.1.1v1",
     "Criticality": "Shall",
@@ -136,6 +128,7 @@ tests contains {
     Status := count(FilterArray(Conditions, true)) == 1
 }
 
+# Test for settings not found in JSON
 tests contains {
     "PolicyId": "MS.SHAREPOINT.1.2v1",
     "Criticality": "Shall",
@@ -207,6 +200,7 @@ tests contains {
     Reason := NAString(SliderSettings(0), true)
 }
 
+# Test for settings not found in JSON
 tests contains {
     "PolicyId": "MS.SHAREPOINT.1.3v1",
     "Criticality": "Shall",
@@ -252,6 +246,7 @@ tests contains {
     Status := DefaultSharingLinkTypeSetting == 1
 }
 
+# Test for settings not found in JSON
 tests contains {
     "PolicyId": "MS.SHAREPOINT.2.1v1",
     "Criticality": "Shall",
@@ -293,6 +288,7 @@ tests contains {
     Status := DefaultLinkPermissionSetting == 1
 }
 
+# Test for settings not found in JSON
 tests contains {
     "PolicyId": "MS.SHAREPOINT.2.2v1",
     "Criticality": "Shall",
@@ -333,7 +329,7 @@ tests contains {
     "Criticality": "Shall",
     "Commandlet": ["Get-SPOTenantRest"],
     "ActualValue": [
-        SharingCapability,
+        SharingCapabilitySetting,
         RequireAnonymousLinksExpireInDaysSetting
     ],
     "ReportDetails": ReportDetailsString(Status, ErrStr),
@@ -365,6 +361,7 @@ tests contains {
     Reason := NAString(SliderSettings(2), false)
 }
 
+# Test for settings not found in JSON
 tests contains {
     "PolicyId": "MS.SHAREPOINT.3.1v1",
     "Criticality": "Shall",
@@ -388,6 +385,9 @@ tests contains {
 #
 # MS.SHAREPOINT.3.2v1
 #--
+
+FileAnonymousLinkTypeSetting := object.get(SharepointSettings, "FileAnonymousLinkType", null)
+FolderAnonymousLinkTypeSetting := object.get(SharepointSettings, "FolderAnonymousLinkType", null)
 
 # Create Report Details string based on File link type & Folder link type
 PERMISSION_STRING := "are not limited to view for Anyone"
@@ -415,33 +415,56 @@ tests contains {
     "PolicyId": "MS.SHAREPOINT.3.2v1",
     "Criticality": "Shall",
     "Commandlet": ["Get-SPOTenantRest"],
-    "ActualValue": [FileLinkType, FolderLinkType],
-    "ReportDetails": FileAndFolderLinkPermission(FileLinkType, FolderLinkType),
+    "ActualValue": [FileAnonymousLinkTypeSetting, FolderAnonymousLinkTypeSetting],
+    "ReportDetails": FileAndFolderLinkPermission(FileAnonymousLinkTypeSetting, FolderAnonymousLinkTypeSetting),
     "RequirementMet": Status
 } if {
-    SharingCapability == ANYONE
+    SharingCapabilitySetting != null
+    SharingCapabilitySetting == ANYONE
 
-    FileLinkType := Tenant.FileAnonymousLinkType
-    FolderLinkType := Tenant.FolderAnonymousLinkType
+    FileAnonymousLinkTypeSetting != null
+    FolderAnonymousLinkTypeSetting != null
     Conditions := [
-        FileLinkType == 1,
-        FolderLinkType == 1
+        FileAnonymousLinkTypeSetting == 1,
+        FolderAnonymousLinkTypeSetting == 1
     ]
     Status := count(FilterArray(Conditions, true)) == 2
 }
 
 # Test for N/A case where sharing is set to New and existing guests, Existing guests, or Only people in your organization.
 tests contains {
-    "PolicyId": PolicyId,
+    "PolicyId": "MS.SHAREPOINT.3.2v1",
     "Criticality": "Shall",
     "Commandlet": ["Get-SPOTenantRest"],
     "ActualValue": [],
-    "ReportDetails": CheckedSkippedDetails(PolicyId, Reason),
+    "ReportDetails": CheckedSkippedDetails("MS.SHAREPOINT.3.2v1", Reason),
     "RequirementMet": true
 } if {
-    PolicyId := "MS.SHAREPOINT.3.2v1"
-    SharingCapability != ANYONE
+    SharingCapabilitySetting != null
+    SharingCapabilitySetting != ANYONE
+    FileAnonymousLinkTypeSetting != null
+    FolderAnonymousLinkTypeSetting != null
     Reason := NAString(SliderSettings(2), false)
+}
+
+# Test for settings not found in JSON
+tests contains {
+    "PolicyId": "MS.SHAREPOINT.3.2v1",
+    "Criticality": "Shall",
+    "Commandlet": ["Get-SPOTenantRest"],
+    "ActualValue": "Setting Not Found in JSON",
+    "ReportDetails": "SPO_tenant or FileAnonymousLinkType or FolderAnonymousLinkType or SharingCapability are missing from input JSON",
+    "RequirementMet": false
+} if {
+    MissingConditions := [
+        count(SharepointSettings) == 0,
+        SharingCapabilitySetting == null,
+        FileAnonymousLinkTypeSetting == null,
+        FolderAnonymousLinkTypeSetting == null
+    ]
+
+    some condition in MissingConditions
+    condition
 }
 #--
 
@@ -450,25 +473,27 @@ tests contains {
 # MS.SHAREPOINT.3.3v2
 #--
 
+EmailAttestationRequiredSetting := object.get(SharepointSettings, "EmailAttestationRequired", null)
+EmailAttestationReAuthDaysSetting := object.get(SharepointSettings, "EmailAttestationReAuthDays", null)
+
 VERIFICATION_STRING := "Expiration time for 'People who use a verification code' NOT"
 
-# PolicyNotApplicable_Group3 handles the correct SharingCapability setting.
 # This ruleset only checks if verification code reauthentication is enabled,
 # and if the verification time is valid (less than or equal to 30 days)
-VerificationCodeReAuthExpiration(tenant) := [PASS, true] if {
-    tenant.EmailAttestationRequired == true
-    tenant.EmailAttestationReAuthDays <= 30
+VerificationCodeReAuthExpiration := [PASS, true] if {
+    EmailAttestationRequiredSetting == true
+    EmailAttestationReAuthDaysSetting <= 30
 } else := [ErrStr, false] if {
-    tenant.EmailAttestationRequired == false
-    tenant.EmailAttestationReAuthDays <= 30
+    EmailAttestationRequiredSetting == false
+    EmailAttestationReAuthDaysSetting <= 30
     ErrStr := concat(": ", [FAIL, concat(" ", [VERIFICATION_STRING, "enabled"])])
 } else := [ErrStr, false] if {
-    tenant.EmailAttestationRequired == true
-    tenant.EmailAttestationReAuthDays > 30
+    EmailAttestationRequiredSetting == true
+    EmailAttestationReAuthDaysSetting > 30
     ErrStr := concat(": ", [FAIL, concat(" ", [VERIFICATION_STRING, "set to 30 days or less"])])
 } else := [ErrStr, false] if {
-    tenant.EmailAttestationRequired == false
-    tenant.EmailAttestationReAuthDays > 30
+    EmailAttestationRequiredSetting == false
+    EmailAttestationReAuthDaysSetting > 30
     ErrStr := concat(": ", [FAIL, concat(" ", [VERIFICATION_STRING, "enabled and set to 30 days or more"])])
 } else := [FAIL, false]
 
@@ -479,16 +504,19 @@ tests contains {
     "Criticality": "Shall",
     "Commandlet": ["Get-SPOTenantRest"],
     "ActualValue": [
-        SharingCapability,
-        Tenant.EmailAttestationRequired,
-        Tenant.EmailAttestationReAuthDays
+        SharingCapabilitySetting,
+        EmailAttestationRequiredSetting,
+        EmailAttestationReAuthDaysSetting
     ],
     "ReportDetails": ReportDetailsString(Status, ErrMsg),
     "RequirementMet": Status
 } if {
-    SharingCapability in [ANYONE, NEWANDEXISTINGGUESTS, EXISTINGGUESTS]
+    SharingCapabilitySetting != null
+    SharingCapabilitySetting in [ANYONE, NEWANDEXISTINGGUESTS, EXISTINGGUESTS]
 
-    [ErrMsg, Status] := VerificationCodeReAuthExpiration(Tenant)
+    EmailAttestationRequiredSetting != null
+    EmailAttestationReAuthDaysSetting != null
+    [ErrMsg, Status] := VerificationCodeReAuthExpiration
 }
 
 # Test for N/A case where sharing is set to Only people in your organization.
@@ -497,11 +525,14 @@ tests contains {
     "Criticality": "Shall",
     "Commandlet": ["Get-SPOTenantRest"],
     "ActualValue": [],
-    "ReportDetails": CheckedSkippedDetails(PolicyId, Reason),
+    "ReportDetails": CheckedSkippedDetails("MS.SHAREPOINT.3.3v2", Reason),
     "RequirementMet": true
 } if {
-    PolicyId := "MS.SHAREPOINT.3.3v2"
-    not SharingCapability in [ANYONE, NEWANDEXISTINGGUESTS, EXISTINGGUESTS]
+    SharingCapabilitySetting != null
+    not SharingCapabilitySetting in [ANYONE, NEWANDEXISTINGGUESTS, EXISTINGGUESTS]
+
+    EmailAttestationRequiredSetting != null
+    EmailAttestationReAuthDaysSetting != null
     Reason := NAString(
         concat(" ", [
             SliderSettings(2), 
@@ -512,5 +543,25 @@ tests contains {
         ]),
         false
     )
+}
+
+# Test for settings not found in JSON
+tests contains {
+    "PolicyId": "MS.SHAREPOINT.3.3v2",
+    "Criticality": "Shall",
+    "Commandlet": ["Get-SPOTenantRest"],
+    "ActualValue": "Setting Not Found in JSON",
+    "ReportDetails": "SPO_tenant or EmailAttestationRequired or EmailAttestationReAuthDays or SharingCapability are missing from input JSON",
+    "RequirementMet": false
+} if {
+    MissingConditions := [
+        count(SharepointSettings) == 0,
+        SharingCapabilitySetting == null,
+        EmailAttestationRequiredSetting == null,
+        EmailAttestationReAuthDaysSetting == null
+    ]
+
+    some condition in MissingConditions
+    condition
 }
 #--

--- a/PowerShell/ScubaGear/Rego/SharepointConfig.rego
+++ b/PowerShell/ScubaGear/Rego/SharepointConfig.rego
@@ -43,16 +43,14 @@ else := concat("", [
 ]) if Negation == true
 
 # All of the SharePoint settings
-SharepointSettings[settingname] := setting if {
-    tenants := object.get(input, "SPO_tenant", [])
-    count(tenants) > 0
-
-    tenant := tenants[0]
-    some settingname, setting in tenant
-}
+default SPOTenant := {}
+SPOTenant := object.get(input, "SPO_tenant", [{}])[0] if {
+    count(object.get(input, "SPO_tenant", [])) > 0
+} 
 
 # SharingCapability is referenced by many of the policies
-SharingCapabilitySetting := object.get(SharepointSettings, "SharingCapability", null)
+SharingCapabilitySetting := object.get(SPOTenant, "SharingCapability", null)
+
 ### End Constants and helper rulesets
 
 
@@ -94,7 +92,8 @@ tests contains {
     "RequirementMet": false
 } if {
     MissingConditions := [
-        count(SharepointSettings) == 0,
+        # count(SharepointSettings) == 0,
+        count(SPOTenant) == 0,
         SharingCapabilitySetting == null
     ]
 
@@ -107,7 +106,8 @@ tests contains {
 # MS.SHAREPOINT.1.2v1
 #--
 
-ODBSharingCapabilitySetting := object.get(SharepointSettings, "ODBSharingCapability", null)
+ODBSharingCapabilitySetting := object.get(SPOTenant, "ODBSharingCapability", null)
+
 
 # If ODBSharingCapability is set to Only People In Organization
 # OR Existing Guests, the policy should pass.
@@ -139,7 +139,8 @@ tests contains {
     "RequirementMet": false
 } if {
     MissingConditions := [
-        count(SharepointSettings) == 0,
+        # count(SharepointSettings) == 0,
+        count(SPOTenant) == 0,
         ODBSharingCapabilitySetting == null
     ]
 
@@ -156,7 +157,7 @@ tests contains {
 # SharingDomainRestrictionMode == 1 Checked
 # SharingAllowedDomainList == "domains" Domain list
 
-SharingDomainRestrictionModeSetting := object.get(SharepointSettings, "SharingDomainRestrictionMode", null)
+SharingDomainRestrictionModeSetting := object.get(SPOTenant, "SharingDomainRestrictionMode", null)
 
 # At this time we are unable to test for approved security groups
 # because we have yet to find the setting to check
@@ -211,7 +212,8 @@ tests contains {
     "RequirementMet": false
 } if {
     MissingConditions := [
-        count(SharepointSettings) == 0,
+        # count(SharepointSettings) == 0,
+        count(SPOTenant) == 0,
         SharingCapabilitySetting == null,
         SharingDomainRestrictionModeSetting == null
     ]
@@ -229,7 +231,7 @@ tests contains {
 # MS.SHAREPOINT.2.1v1
 #--
 
-DefaultSharingLinkTypeSetting := object.get(SharepointSettings, "DefaultSharingLinkType", null)
+DefaultSharingLinkTypeSetting := object.get(SPOTenant, "DefaultSharingLinkType", null)
 
 # DefaultSharingLinkType == 1 for Specific People
 # DefaultSharingLinkType == 2 for Only people in your organization
@@ -257,7 +259,7 @@ tests contains {
     "RequirementMet": false
 } if {
     MissingConditions := [
-        count(SharepointSettings) == 0,
+        count(SPOTenant) == 0,
         DefaultSharingLinkTypeSetting == null
     ]
 
@@ -270,7 +272,7 @@ tests contains {
 # MS.SHAREPOINT.2.2v1
 #--
 
-DefaultLinkPermissionSetting := object.get(SharepointSettings, "DefaultLinkPermission", null)
+DefaultLinkPermissionSetting := object.get(SPOTenant, "DefaultLinkPermission", null)
 
 # DefaultLinkPermission == 1 view
 # DefaultLinkPermission == 2 edit
@@ -299,7 +301,7 @@ tests contains {
     "RequirementMet": false
 } if {
     MissingConditions := [
-        count(SharepointSettings) == 0,
+        count(SPOTenant) == 0,
         DefaultLinkPermissionSetting == null
     ]
 
@@ -316,7 +318,7 @@ tests contains {
 # MS.SHAREPOINT.3.1v1
 #--
 
-RequireAnonymousLinksExpireInDaysSetting := object.get(SharepointSettings, "RequireAnonymousLinksExpireInDays", null)
+RequireAnonymousLinksExpireInDaysSetting := object.get(SPOTenant, "RequireAnonymousLinksExpireInDays", null)
 
 ErrStr := concat(" ", [
     "Requirement not met:",
@@ -372,7 +374,7 @@ tests contains {
     "RequirementMet": false
 } if {
     MissingConditions := [
-        count(SharepointSettings) == 0,
+        count(SPOTenant) == 0,
         SharingCapabilitySetting == null,
         RequireAnonymousLinksExpireInDaysSetting == null
     ]
@@ -387,8 +389,8 @@ tests contains {
 # MS.SHAREPOINT.3.2v1
 #--
 
-FileAnonymousLinkTypeSetting := object.get(SharepointSettings, "FileAnonymousLinkType", null)
-FolderAnonymousLinkTypeSetting := object.get(SharepointSettings, "FolderAnonymousLinkType", null)
+FileAnonymousLinkTypeSetting := object.get(SPOTenant, "FileAnonymousLinkType", null)
+FolderAnonymousLinkTypeSetting := object.get(SPOTenant, "FolderAnonymousLinkType", null)
 
 # Create Report Details string based on File link type & Folder link type
 PERMISSION_STRING := "are not limited to view for Anyone"
@@ -458,7 +460,7 @@ tests contains {
     "RequirementMet": false
 } if {
     MissingConditions := [
-        count(SharepointSettings) == 0,
+        count(SPOTenant) == 0,
         SharingCapabilitySetting == null,
         FileAnonymousLinkTypeSetting == null,
         FolderAnonymousLinkTypeSetting == null
@@ -474,8 +476,8 @@ tests contains {
 # MS.SHAREPOINT.3.3v2
 #--
 
-EmailAttestationRequiredSetting := object.get(SharepointSettings, "EmailAttestationRequired", null)
-EmailAttestationReAuthDaysSetting := object.get(SharepointSettings, "EmailAttestationReAuthDays", null)
+EmailAttestationRequiredSetting := object.get(SPOTenant, "EmailAttestationRequired", null)
+EmailAttestationReAuthDaysSetting := object.get(SPOTenant, "EmailAttestationReAuthDays", null)
 
 VERIFICATION_STRING := "Expiration time for 'People who use a verification code' NOT"
 
@@ -556,7 +558,7 @@ tests contains {
     "RequirementMet": false
 } if {
     MissingConditions := [
-        count(SharepointSettings) == 0,
+        count(SPOTenant) == 0,
         SharingCapabilitySetting == null,
         EmailAttestationRequiredSetting == null,
         EmailAttestationReAuthDaysSetting == null

--- a/PowerShell/ScubaGear/Rego/SharepointConfig.rego
+++ b/PowerShell/ScubaGear/Rego/SharepointConfig.rego
@@ -43,10 +43,12 @@ else := concat("", [
 ]) if Negation == true
 
 # All of the SharePoint settings
-SharepointSettings := {
-    key: value |
-    SPOTenantObject := object.get(input, "SPO_tenant", [])[0]
-    some key, value in SPOTenantObject
+SharepointSettings[settingname] := setting if {
+    tenants := object.get(input, "SPO_tenant", [])
+    count(tenants) > 0
+
+    tenant := tenants[0]
+    some settingname, setting in tenant
 }
 
 # SharingCapability is referenced by many of the policies

--- a/PowerShell/ScubaGear/Rego/SharepointConfig.rego
+++ b/PowerShell/ScubaGear/Rego/SharepointConfig.rego
@@ -1,6 +1,5 @@
 package sharepoint
 import rego.v1
-import data.utils.report.NotCheckedDetails
 import data.utils.report.CheckedSkippedDetails
 import data.utils.report.ReportDetailsBoolean
 import data.utils.report.ReportDetailsBooleanWarning

--- a/PowerShell/ScubaGear/Rego/SharepointConfig.rego
+++ b/PowerShell/ScubaGear/Rego/SharepointConfig.rego
@@ -53,6 +53,15 @@ else := concat("", [
     "See %v for more info"
 ]) if Negation == true
 
+### Fix added by Ted
+SharepointSettings := {
+    key: value |
+    SPOTenantObject := object.get(input, "SPO_tenant", [])[0]
+    some key, value in SPOTenantObject
+}
+
+SharingCapabilitySetting := object.get(SharepointSettings, "SharingCapability", null)
+###
 
 
 ###################
@@ -69,15 +78,35 @@ tests contains {
     "PolicyId": "MS.SHAREPOINT.1.1v1",
     "Criticality": "Shall",
     "Commandlet": ["Get-SPOTenantRest"],
-    "ActualValue": [SharingCapability],
+    "ActualValue": [SharingCapabilitySetting],
     "ReportDetails": ReportDetailsBoolean(Status),
     "RequirementMet": Status
 } if {
+    SharingCapabilitySetting != null
+
     Conditions := [
-        SharingCapability == ONLYPEOPLEINORG,
-        SharingCapability == EXISTINGGUESTS
+        SharingCapabilitySetting == ONLYPEOPLEINORG,
+        SharingCapabilitySetting == EXISTINGGUESTS
     ]
+
     Status := count(FilterArray(Conditions, true)) == 1
+}
+
+tests contains {
+    "PolicyId": "MS.SHAREPOINT.1.1v1",
+    "Criticality": "Shall",
+    "Commandlet": ["Get-SPOTenantRest"],
+    "ActualValue": "Setting Not Found in JSON",
+    "ReportDetails": "SPO_tenant or SharingCapability are missing from input JSON",
+    "RequirementMet": false
+} if {
+    MissingConditions := [
+        count(SharepointSettings) == 0,
+        SharingCapabilitySetting == null
+    ]
+
+    some condition in MissingConditions
+    condition
 }
 #--
 
@@ -85,35 +114,43 @@ tests contains {
 # MS.SHAREPOINT.1.2v1
 #--
 
+ODBSharingCapabilitySetting := object.get(SharepointSettings, "ODBSharingCapability", null)
+
 # If ODBSharingCapability is set to Only People In Organization
 # OR Existing Guests, the policy should pass.
 tests contains {
     "PolicyId": "MS.SHAREPOINT.1.2v1",
     "Criticality": "Shall",
     "Commandlet": ["Get-SPOTenantRest"],
-    "ActualValue": [ODBSharingCapability],
+    "ActualValue": [ODBSharingCapabilitySetting],
     "ReportDetails": ReportDetailsBoolean(Status),
     "RequirementMet": Status
 } if {
-    input.OneDrive_PnP_Flag == false
-    ODBSharingCapability := Tenant.ODBSharingCapability
+    ODBSharingCapabilitySetting != null
+
     Conditions := [
-        ODBSharingCapability == ONLYPEOPLEINORG,
-        ODBSharingCapability == EXISTINGGUESTS
+        ODBSharingCapabilitySetting == ONLYPEOPLEINORG,
+        ODBSharingCapabilitySetting == EXISTINGGUESTS
     ]
+
     Status := count(FilterArray(Conditions, true)) == 1
 }
 
 tests contains {
-    "PolicyId": PolicyId,
-    "Criticality": "Shall/Not-Implemented",
-    "Commandlet": [],
-    "ActualValue": [],
-    "ReportDetails": NotCheckedDetails(PolicyId),
+    "PolicyId": "MS.SHAREPOINT.1.2v1",
+    "Criticality": "Shall",
+    "Commandlet": ["Get-SPOTenantRest"],
+    "ActualValue": "Setting Not Found in JSON",
+    "ReportDetails": "SPO_tenant or ODBSharingCapability are missing from input JSON",
     "RequirementMet": false
 } if {
-    PolicyId := "MS.SHAREPOINT.1.2v1"
-    input.OneDrive_PnP_Flag == true
+    MissingConditions := [
+        count(SharepointSettings) == 0,
+        ODBSharingCapabilitySetting == null
+    ]
+
+    some condition in MissingConditions
+    condition
 }
 #--
 
@@ -124,6 +161,8 @@ tests contains {
 # SharingDomainRestrictionMode == 0 Unchecked
 # SharingDomainRestrictionMode == 1 Checked
 # SharingAllowedDomainList == "domains" Domain list
+
+SharingDomainRestrictionModeSetting := object.get(SharepointSettings, "SharingDomainRestrictionMode", null)
 
 # At this time we are unable to test for approved security groups
 # because we have yet to find the setting to check
@@ -140,28 +179,50 @@ tests contains {
     "Criticality": "Shall",
     "Commandlet": ["Get-SPOTenantRest"],
     "ActualValue": [
-        Tenant.SharingDomainRestrictionMode,
-        SharingCapability
+        SharingDomainRestrictionModeSetting,
+        SharingCapabilitySetting
     ],
     "ReportDetails": ReportDetailsBooleanWarning(Status, NOTESTRING),
     "RequirementMet": Status
 } if {
-    SharingCapability != ONLYPEOPLEINORG
-    Status := Tenant.SharingDomainRestrictionMode == 1
+    SharingDomainRestrictionModeSetting != null
+    SharingCapabilitySetting != null
+
+    SharingCapabilitySetting != ONLYPEOPLEINORG
+    Status := SharingDomainRestrictionModeSetting == 1
 }
 
 # Test for N/A case where sharing is set to Only people in your organization
 tests contains {
-    "PolicyId": PolicyId,
+    "PolicyId": "MS.SHAREPOINT.1.3v1",
     "Criticality": "Shall",
     "Commandlet": ["Get-SPOTenantRest"],
     "ActualValue": [],
-    "ReportDetails": CheckedSkippedDetails(PolicyId, Reason),
+    "ReportDetails": CheckedSkippedDetails("MS.SHAREPOINT.1.3v1", Reason),
     "RequirementMet": true
 } if {
-    SharingCapability == ONLYPEOPLEINORG
-    PolicyId := "MS.SHAREPOINT.1.3v1"
+    SharingDomainRestrictionModeSetting != null
+    SharingCapabilitySetting != null
+    SharingCapabilitySetting == ONLYPEOPLEINORG
     Reason := NAString(SliderSettings(0), true)
+}
+
+tests contains {
+    "PolicyId": "MS.SHAREPOINT.1.3v1",
+    "Criticality": "Shall",
+    "Commandlet": ["Get-SPOTenantRest"],
+    "ActualValue": "Setting Not Found in JSON",
+    "ReportDetails": "SPO_tenant or SharingDomainRestrictionMode or SharingCapability are missing from input JSON",
+    "RequirementMet": false
+} if {
+    MissingConditions := [
+        count(SharepointSettings) == 0,
+        SharingCapabilitySetting == null,
+        SharingDomainRestrictionModeSetting == null
+    ]
+
+    some condition in MissingConditions
+    condition
 }
 #--
 
@@ -173,6 +234,8 @@ tests contains {
 # MS.SHAREPOINT.2.1v1
 #--
 
+DefaultSharingLinkTypeSetting := object.get(SharepointSettings, "DefaultSharingLinkType", null)
+
 # DefaultSharingLinkType == 1 for Specific People
 # DefaultSharingLinkType == 2 for Only people in your organization
 # Default Sharing Link should be set to specific people
@@ -180,17 +243,38 @@ tests contains {
     "PolicyId": "MS.SHAREPOINT.2.1v1",
     "Criticality": "Shall",
     "Commandlet": ["Get-SPOTenantRest"],
-    "ActualValue": [Tenant.DefaultSharingLinkType],
+    "ActualValue": [DefaultSharingLinkTypeSetting],
     "ReportDetails": ReportDetailsBoolean(Status),
     "RequirementMet": Status
 } if {
-    Status := Tenant.DefaultSharingLinkType == 1
+    DefaultSharingLinkTypeSetting != null
+
+    Status := DefaultSharingLinkTypeSetting == 1
+}
+
+tests contains {
+    "PolicyId": "MS.SHAREPOINT.2.1v1",
+    "Criticality": "Shall",
+    "Commandlet": ["Get-SPOTenantRest"],
+    "ActualValue": "Setting Not Found in JSON",
+    "ReportDetails": "SPO_tenant or DefaultSharingLinkType are missing from input JSON",
+    "RequirementMet": false
+} if {
+    MissingConditions := [
+        count(SharepointSettings) == 0,
+        DefaultSharingLinkTypeSetting == null
+    ]
+
+    some condition in MissingConditions
+    condition
 }
 #--
 
 #
 # MS.SHAREPOINT.2.2v1
 #--
+
+DefaultLinkPermissionSetting := object.get(SharepointSettings, "DefaultLinkPermission", null)
 
 # DefaultLinkPermission == 1 view
 # DefaultLinkPermission == 2 edit
@@ -200,11 +284,30 @@ tests contains {
     "PolicyId": "MS.SHAREPOINT.2.2v1",
     "Criticality": "Shall",
     "Commandlet": ["Get-SPOTenantRest"],
-    "ActualValue": [Tenant.DefaultLinkPermission],
+    "ActualValue": [DefaultLinkPermissionSetting],
     "ReportDetails": ReportDetailsBoolean(Status),
     "RequirementMet": Status
 } if {
-    Status := Tenant.DefaultLinkPermission == 1
+    DefaultLinkPermissionSetting != null
+
+    Status := DefaultLinkPermissionSetting == 1
+}
+
+tests contains {
+    "PolicyId": "MS.SHAREPOINT.2.2v1",
+    "Criticality": "Shall",
+    "Commandlet": ["Get-SPOTenantRest"],
+    "ActualValue": "Setting Not Found in JSON",
+    "ReportDetails": "SPO_tenant or DefaultLinkPermission are missing from input JSON",
+    "RequirementMet": false
+} if {
+    MissingConditions := [
+        count(SharepointSettings) == 0,
+        DefaultLinkPermissionSetting == null
+    ]
+
+    some condition in MissingConditions
+    condition
 }
 #--
 
@@ -215,6 +318,8 @@ tests contains {
 #
 # MS.SHAREPOINT.3.1v1
 #--
+
+RequireAnonymousLinksExpireInDaysSetting := object.get(SharepointSettings, "RequireAnonymousLinksExpireInDays", null)
 
 ErrStr := concat(" ", [
     "Requirement not met:",
@@ -229,31 +334,53 @@ tests contains {
     "Commandlet": ["Get-SPOTenantRest"],
     "ActualValue": [
         SharingCapability,
-        Tenant.RequireAnonymousLinksExpireInDays
+        RequireAnonymousLinksExpireInDaysSetting
     ],
     "ReportDetails": ReportDetailsString(Status, ErrStr),
     "RequirementMet": Status
 } if {
-    SharingCapability == ANYONE
+    SharingCapabilitySetting != null
+    SharingCapabilitySetting == ANYONE
+
+    RequireAnonymousLinksExpireInDaysSetting != null
     Conditions := [
-        Tenant.RequireAnonymousLinksExpireInDays >= 1,
-        Tenant.RequireAnonymousLinksExpireInDays <= 30
+        RequireAnonymousLinksExpireInDaysSetting >= 1,
+        RequireAnonymousLinksExpireInDaysSetting <= 30
     ]
     Status := count(FilterArray(Conditions, true)) == 2
 }
 
 # Test for N/A case where sharing is set to New and existing guests, Existing guests, or Only people in your organization.
 tests contains {
-    "PolicyId": PolicyId,
+    "PolicyId": "MS.SHAREPOINT.3.1v1",
     "Criticality": "Shall",
     "Commandlet": ["Get-SPOTenantRest"],
     "ActualValue": [],
-    "ReportDetails": CheckedSkippedDetails(PolicyId, Reason),
+    "ReportDetails": CheckedSkippedDetails("MS.SHAREPOINT.3.1v1", Reason),
     "RequirementMet": true
 } if {
-    PolicyId := "MS.SHAREPOINT.3.1v1"
-    SharingCapability != ANYONE
+    SharingCapabilitySetting != null
+    SharingCapabilitySetting != ANYONE
+    RequireAnonymousLinksExpireInDaysSetting != null
     Reason := NAString(SliderSettings(2), false)
+}
+
+tests contains {
+    "PolicyId": "MS.SHAREPOINT.3.1v1",
+    "Criticality": "Shall",
+    "Commandlet": ["Get-SPOTenantRest"],
+    "ActualValue": "Setting Not Found in JSON",
+    "ReportDetails": "SPO_tenant or RequireAnonymousLinksExpireInDays or SharingCapability are missing from input JSON",
+    "RequirementMet": false
+} if {
+    MissingConditions := [
+        count(SharepointSettings) == 0,
+        SharingCapabilitySetting == null,
+        RequireAnonymousLinksExpireInDaysSetting == null
+    ]
+
+    some condition in MissingConditions
+    condition
 }
 #--
 

--- a/PowerShell/ScubaGear/Rego/SharepointConfig.rego
+++ b/PowerShell/ScubaGear/Rego/SharepointConfig.rego
@@ -92,7 +92,6 @@ tests contains {
     "RequirementMet": false
 } if {
     MissingConditions := [
-        # count(SharepointSettings) == 0,
         count(SPOTenant) == 0,
         SharingCapabilitySetting == null
     ]
@@ -139,7 +138,6 @@ tests contains {
     "RequirementMet": false
 } if {
     MissingConditions := [
-        # count(SharepointSettings) == 0,
         count(SPOTenant) == 0,
         ODBSharingCapabilitySetting == null
     ]
@@ -212,7 +210,6 @@ tests contains {
     "RequirementMet": false
 } if {
     MissingConditions := [
-        # count(SharepointSettings) == 0,
         count(SPOTenant) == 0,
         SharingCapabilitySetting == null,
         SharingDomainRestrictionModeSetting == null

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Get-ServicePrincipalParams.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Get-ServicePrincipalParams.Tests.ps1
@@ -28,21 +28,21 @@ Describe -Tag 'Orchestrator' -Name 'Get-ServicePrincipalParams' {
                     AppID = '34289UFAHWFALL'
                 }
                 {Get-ServicePrincipalParams -ScubaConfig $ScubaConfig} |
-                    Should -Throw  'Missing parameters required for authentication with Service Principal Auth; Run Get-Help Invoke-Scuba for details on correct arguments'
+                    Should -Throw  'When authenticating with Service Principal authentication, the following command line parameters must be provided: -AppID, -CertificateThumbprint and -Organization.'
             }
             It "Only Thumbprint Only"{
                 $ScubaConfig = [PSCustomObject]@{
                     CertificateThumbprint = 'WPOEALFN425A'
                 }
                 {Get-ServicePrincipalParams -ScubaConfig $ScubaConfig} |
-                    Should -Throw  'Missing parameters required for authentication with Service Principal Auth; Run Get-Help Invoke-Scuba for details on correct arguments'
+                    Should -Throw  'When authenticating with Service Principal authentication, the following command line parameters must be provided: -AppID, -CertificateThumbprint and -Organization.'
             }
             It "Only Organization Only"{
                 $ScubaConfig = [PSCustomObject]@{
                     Organization = 'example.onmicrosoft.com'
                 }
                 {Get-ServicePrincipalParams -ScubaConfig $ScubaConfig} |
-                    Should -Throw  'Missing parameters required for authentication with Service Principal Auth; Run Get-Help Invoke-Scuba for details on correct arguments'
+                    Should -Throw  'When authenticating with Service Principal authentication, the following command line parameters must be provided: -AppID, -CertificateThumbprint and -Organization.'
             }
         }
         Context "No Service Principal provided"{

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-Scuba.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-Scuba.Tests.ps1
@@ -32,7 +32,7 @@ InModuleScope Orchestrator {
             Mock -CommandName Copy-Item {}
             Mock -ModuleName Orchestrator Initialize-ScubaLogging {}
             Mock -ModuleName Orchestrator Write-ScubaLog {}
-            Mock -ModuleName Orchestrator Get-ScubaRunDetails {}
+            Mock -ModuleName Orchestrator Write-ScubaRunDetails {}
         }
         Context 'When checking the conformance of commercial tenants' {
             BeforeAll {

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-ScubaCached.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-ScubaCached.Tests.ps1
@@ -29,7 +29,7 @@ InModuleScope Orchestrator {
             Mock -CommandName New-Item {}
             Mock -ModuleName Orchestrator Initialize-ScubaLogging {}
             Mock -ModuleName Orchestrator Write-ScubaLog {}
-            Mock -ModuleName Orchestrator Get-ScubaRunDetails {}
+            Mock -ModuleName Orchestrator Write-ScubaRunDetails {}
             Mock -CommandName Get-Content { "" }
             Mock -CommandName Get-Member { $true }
             Mock -CommandName New-Guid { "00000000-0000-0000-0000-000000000000" }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-ScubaConfig.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-ScubaConfig.Tests.ps1
@@ -128,7 +128,7 @@ InModuleScope Orchestrator {
         Mock -CommandName Copy-Item {}
         Mock -ModuleName Orchestrator Initialize-ScubaLogging {}
         Mock -ModuleName Orchestrator Write-ScubaLog {}
-        Mock -ModuleName Orchestrator Get-ScubaRunDetails {}
+        Mock -ModuleName Orchestrator Write-ScubaRunDetails {}
     }
 
     Context  "Parameter override test"{

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/ScubaLogging.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/ScubaLogging.Tests.ps1
@@ -438,7 +438,7 @@ InModuleScope ScubaLogging {
             }
         }
 
-        Context "Get-ScubaRunDetails - ConfiguredOPAPath Parameter" {
+        Context "Write-ScubaRunDetails - ConfiguredOPAPath Parameter" {
 
             BeforeEach {
                 Initialize-ScubaLogging -LogPath $script:TestLogPath -LogLevel "Debug" -DisableAutoReport
@@ -452,7 +452,7 @@ InModuleScope ScubaLogging {
                 $fakeOpa = Join-Path $script:TestLogPath "opa_windows_amd64.exe"
                 Set-Content $fakeOpa "fake" -Encoding UTF8
 
-                Get-ScubaRunDetails -ConfiguredOPAPath $fakeOpa
+                Write-ScubaRunDetails -ConfiguredOPAPath $fakeOpa
 
                 $logContent = Get-Content $Script:ScubaLogPath -Raw
                 $logContent | Should -Match "OPA Executable at configured path"
@@ -464,7 +464,7 @@ InModuleScope ScubaLogging {
                 New-Item -ItemType Directory $opaDir -Force | Out-Null
                 Set-Content (Join-Path $opaDir "opa_windows_amd64.exe") "fake" -Encoding UTF8
 
-                Get-ScubaRunDetails -ConfiguredOPAPath $opaDir
+                Write-ScubaRunDetails -ConfiguredOPAPath $opaDir
 
                 $logContent = Get-Content $Script:ScubaLogPath -Raw
                 $logContent | Should -Match "OPA Executable at configured path"
@@ -475,7 +475,7 @@ InModuleScope ScubaLogging {
                 $emptyDir = Join-Path $script:TestLogPath "emptydir-$(Get-Date -Format 'fff')"
                 New-Item -ItemType Directory $emptyDir -Force | Out-Null
 
-                Get-ScubaRunDetails -ConfiguredOPAPath $emptyDir
+                Write-ScubaRunDetails -ConfiguredOPAPath $emptyDir
 
                 $logContent = Get-Content $Script:ScubaLogPath -Raw
                 $logContent | Should -Match "OPA Executable NOT found at configured path"
@@ -486,7 +486,7 @@ InModuleScope ScubaLogging {
             It "Should log Warning 'OPA Executable NOT found at configured path' when path does not exist" {
                 $nonExistent = Join-Path $script:TestLogPath "doesnotexist\opa.exe"
 
-                Get-ScubaRunDetails -ConfiguredOPAPath $nonExistent
+                Write-ScubaRunDetails -ConfiguredOPAPath $nonExistent
 
                 $logContent = Get-Content $Script:ScubaLogPath -Raw
                 $logContent | Should -Match "OPA Executable NOT found at configured path"
@@ -495,7 +495,7 @@ InModuleScope ScubaLogging {
             }
 
             It "Should skip ConfiguredOPAPath check when parameter is not provided" {
-                Get-ScubaRunDetails
+                Write-ScubaRunDetails
 
                 $logContent = Get-Content $Script:ScubaLogPath -Raw
                 $logContent | Should -Not -Match "OPA Executable at configured path"
@@ -503,7 +503,7 @@ InModuleScope ScubaLogging {
             }
         }
 
-        Context "Get-ScubaRunDetails - Network Connectivity Uses Port 443" {
+        Context "Write-ScubaRunDetails - Network Connectivity Uses Port 443" {
 
             BeforeEach {
                 Initialize-ScubaLogging -LogPath $script:TestLogPath -LogLevel "Debug" -DisableAutoReport
@@ -514,7 +514,7 @@ InModuleScope ScubaLogging {
             It "Should call Test-NetConnection with Port 443 not ICMP" {
                 Mock Test-NetConnection { return $true }
 
-                Get-ScubaRunDetails
+                Write-ScubaRunDetails
 
                 Should -Invoke Test-NetConnection -ParameterFilter { $Port -eq 443 } -Times 1
             }
@@ -522,7 +522,7 @@ InModuleScope ScubaLogging {
             It "Should log InternetConnected true when HTTPS port 443 check succeeds" {
                 Mock Test-NetConnection { return $true }
 
-                Get-ScubaRunDetails
+                Write-ScubaRunDetails
 
                 $logContent = Get-Content $Script:ScubaLogPath -Raw
                 $logContent | Should -Match '"InternetConnected":true'
@@ -531,7 +531,7 @@ InModuleScope ScubaLogging {
             It "Should log InternetConnected false and InternetError when HTTPS check throws" {
                 Mock Test-NetConnection { throw "Connection refused" }
 
-                Get-ScubaRunDetails
+                Write-ScubaRunDetails
 
                 $logContent = Get-Content $Script:ScubaLogPath -Raw
                 $logContent | Should -Match '"InternetConnected":false'

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_01_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_01_test.rego
@@ -40,6 +40,56 @@ test_SharingCapability_Incorrect_V2 if {
 
     TestResult("MS.SHAREPOINT.1.1v1", Output, FAIL, false) == true
 }
+
+### Testing the "Missing the specific setting that this policy expects" scenarios
+###
+test_SharingCapability_SharepointSettings_Missing if {
+    Output := sharepoint.tests with input as []
+
+    MissingError := "SPO_tenant or SharingCapability are missing from input JSON"
+    TestResult("MS.SHAREPOINT.1.1v1", Output, MissingError, false) == true
+}
+
+test_SharingCapability_SharepointSettings_EmptyArray if {
+    Output := sharepoint.tests with input.SPO_tenant as []
+
+    MissingError := "SPO_tenant or SharingCapability are missing from input JSON"
+    TestResult("MS.SHAREPOINT.1.1v1", Output, MissingError, false) == true
+}
+
+test_SharingCapability_Missing if {
+    Tenant := json.patch(SPOTenant, [{"op": "remove", "path": "SharingCapability"}])
+    Output := sharepoint.tests with input.SPO_tenant as [Tenant]
+
+    MissingError := "SPO_tenant or SharingCapability are missing from input JSON"
+    TestResult("MS.SHAREPOINT.1.1v1", Output, MissingError, false) == true
+}
+
+### Delete below this
+# test_SharingCapability_Empty if {
+#     # Tenant := json.patch(SPOTenant, [{"op": "add", "path": "SharingCapability", "value": 2}])
+# SPOTenant := {
+#     "SharingCapability": 0,
+#     "ODBSharingCapability": 0,
+#     "SharingDomainRestrictionMode": 0,
+#     "DefaultSharingLinkType": 1,
+#     "DefaultLinkPermission": 1,
+#     "RequireAnonymousLinksExpireInDays": 30,
+#     "FileAnonymousLinkType": 1,
+#     "FolderAnonymousLinkType": 1,
+#     "EmailAttestationRequired": true,
+#     "EmailAttestationReAuthDays": 30
+# }
+
+#     Output := sharepoint.tests with input.SPO_tenant as [SPOTenant]
+#     # Output := sharepoint.tests with input.SPO_tenant as []
+
+#     # count(Output) == 1
+# # sprintf("DEBUG test_SharingCapability_Empty Output: %v", [Output])
+# print("DEBUG test_SharingCapability_Empty Output: ", [Output])
+
+#     TestResult("MS.SHAREPOINT.1.1v1", Output, FAIL, false) == true
+# }
 #--
 
 #
@@ -47,7 +97,6 @@ test_SharingCapability_Incorrect_V2 if {
 #--
 test_ODBSharingCapability_Correct_V1 if {
     Output := sharepoint.tests with input.SPO_tenant as [SPOTenant]
-                                with input.OneDrive_PnP_Flag as false
 
     TestResult("MS.SHAREPOINT.1.2v1", Output, PASS, true) == true
 }
@@ -56,27 +105,14 @@ test_ODBSharingCapability_Correct_V2 if {
     Tenant := json.patch(SPOTenant, [{"op": "add", "path": "ODBSharingCapability", "value": 3}])
 
     Output := sharepoint.tests with input.SPO_tenant as [Tenant]
-                                with input.OneDrive_PnP_Flag as false
 
     TestResult("MS.SHAREPOINT.1.2v1", Output, PASS, true) == true
-}
-
-test_UsingServicePrincipal if {
-    PolicyId := "MS.SHAREPOINT.1.2v1"
-
-    Tenant := json.patch(SPOTenant, [{"op": "add", "path": "ODBSharingCapability", "value": 3}])
-
-    Output := sharepoint.tests with input.SPO_tenant as [Tenant]
-                                with input.OneDrive_PnP_Flag as true
-
-    TestResult(PolicyId, Output, NotCheckedDetails(PolicyId), false) == true
 }
 
 test_ODBSharingCapability_Incorrect_V1 if {
     Tenant := json.patch(SPOTenant, [{"op": "add", "path": "ODBSharingCapability", "value": 1}])
 
     Output := sharepoint.tests with input.SPO_tenant as [Tenant]
-                                with input.OneDrive_PnP_Flag as false
 
     TestResult("MS.SHAREPOINT.1.2v1", Output, FAIL, false) == true
 }
@@ -85,9 +121,32 @@ test_ODBSharingCapability_Incorrect_V2 if {
     Tenant := json.patch(SPOTenant, [{"op": "add", "path": "ODBSharingCapability", "value": 2}])
 
     Output := sharepoint.tests with input.SPO_tenant as [Tenant]
-                                with input.OneDrive_PnP_Flag as false
 
     TestResult("MS.SHAREPOINT.1.2v1", Output, FAIL, false) == true
+}
+
+### Testing the "Missing the specific setting that this policy expects" scenarios
+###
+test_ODBSharingCapability_SharepointSettings_Missing if {
+    Output := sharepoint.tests with input as []
+
+    MissingError := "SPO_tenant or ODBSharingCapability are missing from input JSON"
+    TestResult("MS.SHAREPOINT.1.2v1", Output, MissingError, false) == true
+}
+
+test_ODBSharingCapability_SharepointSettings_EmptyArray if {
+    Output := sharepoint.tests with input.SPO_tenant as []
+
+    MissingError := "SPO_tenant or ODBSharingCapability are missing from input JSON"
+    TestResult("MS.SHAREPOINT.1.2v1", Output, MissingError, false) == true
+}
+
+test_ODBSharingCapability_Missing if {
+    Tenant := json.patch(SPOTenant, [{"op": "remove", "path": "ODBSharingCapability"}])
+    Output := sharepoint.tests with input.SPO_tenant as [Tenant]
+
+    MissingError := "SPO_tenant or ODBSharingCapability are missing from input JSON"
+    TestResult("MS.SHAREPOINT.1.2v1", Output, MissingError, false) == true
 }
 #--
 
@@ -189,5 +248,46 @@ test_SharingDomainRestrictionMode_SharingCapability_Anyone_Incorrect if {
         "see the baseline policy for instructions on a manual check."
     ])
     TestResult("MS.SHAREPOINT.1.3v1", Output, ReportDetailString, false) == true
+}
+
+### Testing the "Missing the specific setting that this policy expects" scenarios
+###
+test_SharingDomainRestrictionMode_SharepointSettings_Missing if {
+    Output := sharepoint.tests with input as []
+
+    MissingError := "SPO_tenant or SharingDomainRestrictionMode or SharingCapability are missing from input JSON"
+    TestResult("MS.SHAREPOINT.1.3v1", Output, MissingError, false) == true
+}
+
+test_SharingDomainRestrictionMode_SharepointSettings_EmptyArray if {
+    Output := sharepoint.tests with input.SPO_tenant as []
+
+    MissingError := "SPO_tenant or SharingDomainRestrictionMode or SharingCapability are missing from input JSON"
+    TestResult("MS.SHAREPOINT.1.3v1", Output, MissingError, false) == true
+}
+
+test_SharingDomainRestrictionMode_Missing if {
+    Tenant := json.patch(SPOTenant, [{"op": "remove", "path": "SharingDomainRestrictionMode"}])
+    Output := sharepoint.tests with input.SPO_tenant as [Tenant]
+
+    MissingError := "SPO_tenant or SharingDomainRestrictionMode or SharingCapability are missing from input JSON"
+    TestResult("MS.SHAREPOINT.1.3v1", Output, MissingError, false) == true
+}
+
+test_SharingDomainRestrictionMode_SharingCapability_Missing if {
+    Tenant := json.patch(SPOTenant, [{"op": "remove", "path": "SharingCapability"}])
+    Output := sharepoint.tests with input.SPO_tenant as [Tenant]
+
+    MissingError := "SPO_tenant or SharingDomainRestrictionMode or SharingCapability are missing from input JSON"
+    TestResult("MS.SHAREPOINT.1.3v1", Output, MissingError, false) == true
+}
+
+test_SharingDomainRestrictionMode_Both_Missing if {
+    Tenant := json.patch(SPOTenant, [{"op": "remove", "path": "SharingDomainRestrictionMode"},
+                                    {"op": "remove", "path": "SharingCapability"}])
+    Output := sharepoint.tests with input.SPO_tenant as [Tenant]
+
+    MissingError := "SPO_tenant or SharingDomainRestrictionMode or SharingCapability are missing from input JSON"
+    TestResult("MS.SHAREPOINT.1.3v1", Output, MissingError, false) == true
 }
 #--

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_01_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_01_test.rego
@@ -1,7 +1,6 @@
 package sharepoint_test
 import rego.v1
 import data.sharepoint
-import data.utils.report.NotCheckedDetails
 import data.utils.report.CheckedSkippedDetails
 import data.utils.key.TestResult
 import data.utils.key.FAIL

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_01_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_01_test.rego
@@ -64,32 +64,6 @@ test_SharingCapability_Missing if {
     MissingError := "SPO_tenant or SharingCapability are missing from input JSON"
     TestResult("MS.SHAREPOINT.1.1v1", Output, MissingError, false) == true
 }
-
-### Delete below this
-# test_SharingCapability_Empty if {
-#     # Tenant := json.patch(SPOTenant, [{"op": "add", "path": "SharingCapability", "value": 2}])
-# SPOTenant := {
-#     "SharingCapability": 0,
-#     "ODBSharingCapability": 0,
-#     "SharingDomainRestrictionMode": 0,
-#     "DefaultSharingLinkType": 1,
-#     "DefaultLinkPermission": 1,
-#     "RequireAnonymousLinksExpireInDays": 30,
-#     "FileAnonymousLinkType": 1,
-#     "FolderAnonymousLinkType": 1,
-#     "EmailAttestationRequired": true,
-#     "EmailAttestationReAuthDays": 30
-# }
-
-#     Output := sharepoint.tests with input.SPO_tenant as [SPOTenant]
-#     # Output := sharepoint.tests with input.SPO_tenant as []
-
-#     # count(Output) == 1
-# # sprintf("DEBUG test_SharingCapability_Empty Output: %v", [Output])
-# print("DEBUG test_SharingCapability_Empty Output: ", [Output])
-
-#     TestResult("MS.SHAREPOINT.1.1v1", Output, FAIL, false) == true
-# }
 #--
 
 #

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_02_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_02_test.rego
@@ -22,6 +22,30 @@ test_DefaultSharingLinkType_Incorrect if {
 
     TestResult("MS.SHAREPOINT.2.1v1", Output, FAIL, false) == true
 }
+
+### Testing the "Missing the specific setting that this policy expects" scenarios
+###
+test_DefaultSharingLinkType_SharepointSettings_Missing if {
+    Output := sharepoint.tests with input as []
+
+    MissingError := "SPO_tenant or DefaultSharingLinkType are missing from input JSON"
+    TestResult("MS.SHAREPOINT.2.1v1", Output, MissingError, false) == true
+}
+
+test_DefaultSharingLinkType_SharepointSettings_EmptyArray if {
+    Output := sharepoint.tests with input.SPO_tenant as []
+
+    MissingError := "SPO_tenant or DefaultSharingLinkType are missing from input JSON"
+    TestResult("MS.SHAREPOINT.2.1v1", Output, MissingError, false) == true
+}
+
+test_DefaultSharingLinkType_Missing if {
+    Tenant := json.patch(SPOTenant, [{"op": "remove", "path": "DefaultSharingLinkType"}])
+    Output := sharepoint.tests with input.SPO_tenant as [Tenant]
+
+    MissingError := "SPO_tenant or DefaultSharingLinkType are missing from input JSON"
+    TestResult("MS.SHAREPOINT.2.1v1", Output, MissingError, false) == true
+}
 #--
 
 #
@@ -39,5 +63,29 @@ test_DefaultLinkPermission_Incorrect if {
     Output := sharepoint.tests with input.SPO_tenant as [Tenant]
 
     TestResult("MS.SHAREPOINT.2.2v1", Output, FAIL, false) == true
+}
+
+### Testing the "Missing the specific setting that this policy expects" scenarios
+###
+test_DefaultLinkPermission_SharepointSettings_Missing if {
+    Output := sharepoint.tests with input as []
+
+    MissingError := "SPO_tenant or DefaultLinkPermission are missing from input JSON"
+    TestResult("MS.SHAREPOINT.2.2v1", Output, MissingError, false) == true
+}
+
+test_DefaultLinkPermission_SharepointSettings_EmptyArray if {
+    Output := sharepoint.tests with input.SPO_tenant as []
+
+    MissingError := "SPO_tenant or DefaultLinkPermission are missing from input JSON"
+    TestResult("MS.SHAREPOINT.2.2v1", Output, MissingError, false) == true
+}
+
+test_DefaultLinkPermission_Missing if {
+    Tenant := json.patch(SPOTenant, [{"op": "remove", "path": "DefaultLinkPermission"}])
+    Output := sharepoint.tests with input.SPO_tenant as [Tenant]
+
+    MissingError := "SPO_tenant or DefaultLinkPermission are missing from input JSON"
+    TestResult("MS.SHAREPOINT.2.2v1", Output, MissingError, false) == true
 }
 #--

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_03_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_03_test.rego
@@ -403,6 +403,56 @@ test_File_Folder_AnonymousLinkType_SharingCapability_NewExistingGuests_NotApplic
     TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), true) == true
 }
 
+### Testing the "Missing the specific setting that this policy expects" scenarios
+###
+test_File_Folder_AnonymousLinkType_SharepointSettings_Missing if {
+    Output := sharepoint.tests with input as []
+
+    MissingError := "SPO_tenant or FileAnonymousLinkType or FolderAnonymousLinkType or SharingCapability are missing from input JSON"
+    TestResult("MS.SHAREPOINT.3.2v1", Output, MissingError, false) == true
+}
+
+test_File_Folder_AnonymousLinkType_SharepointSettings_EmptyArray if {
+    Output := sharepoint.tests with input.SPO_tenant as []
+
+    MissingError := "SPO_tenant or FileAnonymousLinkType or FolderAnonymousLinkType or SharingCapability are missing from input JSON"
+    TestResult("MS.SHAREPOINT.3.2v1", Output, MissingError, false) == true
+}
+
+test_FileAnonymousLinkType_Missing if {
+    Tenant := json.patch(SPOTenant, [{"op": "remove", "path": "FileAnonymousLinkType"}])
+    Output := sharepoint.tests with input.SPO_tenant as [Tenant]
+
+    MissingError := "SPO_tenant or FileAnonymousLinkType or FolderAnonymousLinkType or SharingCapability are missing from input JSON"
+    TestResult("MS.SHAREPOINT.3.2v1", Output, MissingError, false) == true
+}
+
+test_FolderAnonymousLinkType_Missing if {
+    Tenant := json.patch(SPOTenant, [{"op": "remove", "path": "FolderAnonymousLinkType"}])
+    Output := sharepoint.tests with input.SPO_tenant as [Tenant]
+
+    MissingError := "SPO_tenant or FileAnonymousLinkType or FolderAnonymousLinkType or SharingCapability are missing from input JSON"
+    TestResult("MS.SHAREPOINT.3.2v1", Output, MissingError, false) == true
+}
+
+test_File_Folder_AnonymousLinkType_SharingCapability_Missing if {
+    Tenant := json.patch(SPOTenant, [{"op": "remove", "path": "SharingCapability"}])
+    Output := sharepoint.tests with input.SPO_tenant as [Tenant]
+
+    MissingError := "SPO_tenant or FileAnonymousLinkType or FolderAnonymousLinkType or SharingCapability are missing from input JSON"
+    TestResult("MS.SHAREPOINT.3.2v1", Output, MissingError, false) == true
+}
+
+test_File_Folder_AnonymousLinkType_Both_Missing if {
+    Tenant := json.patch(SPOTenant, [{"op": "remove", "path": "FileAnonymousLinkType"},
+                                    {"op": "remove", "path": "FolderAnonymousLinkType"}])
+    Output := sharepoint.tests with input.SPO_tenant as [Tenant]
+
+    MissingError := "SPO_tenant or FileAnonymousLinkType or FolderAnonymousLinkType or SharingCapability are missing from input JSON"
+    TestResult("MS.SHAREPOINT.3.2v1", Output, MissingError, false) == true
+}
+#--
+
 #
 # Policy MS.SHAREPOINT.3.3v2
 #--
@@ -428,8 +478,8 @@ test_EmailAttestationReAuthDays_SharingCapability_OnlyPeopleInOrg_NotApplicable 
 }
 
 ###########################################
-# EmailAttestationReAuthDays = 30         #
-# Expected: PASS                          #
+# EmailAttestationReAuthDays = 30  (default) #
+# Expected: PASS                             #
 ###########################################
 
 test_EmailAttestationReAuthDays_SharingCapability_NewExistingGuests_Correct if {
@@ -618,5 +668,55 @@ test_EmailAttestationRequired_SharingCapability_ExistingGuests_Incorrect if {
 
     ReportDetailsString := "Requirement not met: Expiration time for 'People who use a verification code' NOT enabled"
     TestResult("MS.SHAREPOINT.3.3v2", Output, ReportDetailsString, false) == true
+}
+
+### Testing the "Missing the specific setting that this policy expects" scenarios
+###
+test_EmailAttestation_SharepointSettings_Missing if {
+    Output := sharepoint.tests with input as []
+
+    MissingError := "SPO_tenant or EmailAttestationRequired or EmailAttestationReAuthDays or SharingCapability are missing from input JSON"
+    TestResult("MS.SHAREPOINT.3.3v2", Output, MissingError, false) == true
+}
+
+test_EmailAttestation_SharepointSettings_EmptyArray if {
+    Output := sharepoint.tests with input.SPO_tenant as []
+
+    MissingError := "SPO_tenant or EmailAttestationRequired or EmailAttestationReAuthDays or SharingCapability are missing from input JSON"
+    TestResult("MS.SHAREPOINT.3.3v2", Output, MissingError, false) == true
+}
+
+test_EmailAttestationRequired_Missing if {
+    Tenant := json.patch(SPOTenant, [{"op": "remove", "path": "EmailAttestationRequired"}])
+    Output := sharepoint.tests with input.SPO_tenant as [Tenant]
+
+    MissingError := "SPO_tenant or EmailAttestationRequired or EmailAttestationReAuthDays or SharingCapability are missing from input JSON"
+    TestResult("MS.SHAREPOINT.3.3v2", Output, MissingError, false) == true
+}
+
+test_EmailAttestationReAuthDays_Missing if {
+    Tenant := json.patch(SPOTenant, [{"op": "remove", "path": "EmailAttestationReAuthDays"}])
+    Output := sharepoint.tests with input.SPO_tenant as [Tenant]
+
+    MissingError := "SPO_tenant or EmailAttestationRequired or EmailAttestationReAuthDays or SharingCapability are missing from input JSON"
+    TestResult("MS.SHAREPOINT.3.3v2", Output, MissingError, false) == true
+}
+
+test_EmailAttestation_SharingCapability_Missing if {
+    Tenant := json.patch(SPOTenant, [{"op": "remove", "path": "SharingCapability"}])
+    Output := sharepoint.tests with input.SPO_tenant as [Tenant]
+
+    MissingError := "SPO_tenant or EmailAttestationRequired or EmailAttestationReAuthDays or SharingCapability are missing from input JSON"
+    TestResult("MS.SHAREPOINT.3.3v2", Output, MissingError, false) == true
+}
+
+test_EmailAttestation_Both_Missing if {
+    Tenant := json.patch(SPOTenant, [{"op": "remove", "path": "EmailAttestationRequired"},
+                                    {"op": "remove", "path": "EmailAttestationReAuthDays"},
+                                    {"op": "remove", "path": "SharingCapability"}])
+    Output := sharepoint.tests with input.SPO_tenant as [Tenant]
+
+    MissingError := "SPO_tenant or EmailAttestationRequired or EmailAttestationReAuthDays or SharingCapability are missing from input JSON"
+    TestResult("MS.SHAREPOINT.3.3v2", Output, MissingError, false) == true
 }
 #--

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_03_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/Sharepoint/SharepointConfig_03_test.rego
@@ -177,6 +177,47 @@ test_SharingCapability_NewExistingGuests_NotApplicable_V2 if {
     ])
     TestResult(PolicyId, Output, CheckedSkippedDetails(PolicyId, ReportDetailsString), true) == true
 }
+
+### Testing the "Missing the specific setting that this policy expects" scenarios
+###
+test_RequireAnonymousLinksExpireInDays_SharepointSettings_Missing if {
+    Output := sharepoint.tests with input as []
+
+    MissingError := "SPO_tenant or RequireAnonymousLinksExpireInDays or SharingCapability are missing from input JSON"
+    TestResult("MS.SHAREPOINT.3.1v1", Output, MissingError, false) == true
+}
+
+test_RequireAnonymousLinksExpireInDays_SharepointSettings_EmptyArray if {
+    Output := sharepoint.tests with input.SPO_tenant as []
+
+    MissingError := "SPO_tenant or RequireAnonymousLinksExpireInDays or SharingCapability are missing from input JSON"
+    TestResult("MS.SHAREPOINT.3.1v1", Output, MissingError, false) == true
+}
+
+test_RequireAnonymousLinksExpireInDays_Missing if {
+    Tenant := json.patch(SPOTenant, [{"op": "remove", "path": "RequireAnonymousLinksExpireInDays"}])
+    Output := sharepoint.tests with input.SPO_tenant as [Tenant]
+
+    MissingError := "SPO_tenant or RequireAnonymousLinksExpireInDays or SharingCapability are missing from input JSON"
+    TestResult("MS.SHAREPOINT.3.1v1", Output, MissingError, false) == true
+}
+
+test_RequireAnonymousLinksExpireInDays_SharingCapability_Missing if {
+    Tenant := json.patch(SPOTenant, [{"op": "remove", "path": "SharingCapability"}])
+    Output := sharepoint.tests with input.SPO_tenant as [Tenant]
+
+    MissingError := "SPO_tenant or RequireAnonymousLinksExpireInDays or SharingCapability are missing from input JSON"
+    TestResult("MS.SHAREPOINT.3.1v1", Output, MissingError, false) == true
+}
+
+test_RequireAnonymousLinksExpireInDays_SharingDomainRestrictionMode_Both_Missing if {
+    Tenant := json.patch(SPOTenant, [{"op": "remove", "path": "RequireAnonymousLinksExpireInDays"},
+                                    {"op": "remove", "path": "SharingCapability"}])
+    Output := sharepoint.tests with input.SPO_tenant as [Tenant]
+
+    MissingError := "SPO_tenant or RequireAnonymousLinksExpireInDays or SharingCapability are missing from input JSON"
+    TestResult("MS.SHAREPOINT.3.1v1", Output, MissingError, false) == true
+}
 #--
 
 #
@@ -245,7 +286,7 @@ test_File_Folder_AnonymousLinkType_UsingServicePrincipal_Correct if {
 
     # Set PnP flag to true denoting use of service principal
     Output := sharepoint.tests with input.SPO_tenant as [Tenant]
-        with input.OneDrive_PnP_Flag as true
+
     TestResult("MS.SHAREPOINT.3.2v1", Output, PASS, true) == true
 }
 
@@ -261,7 +302,6 @@ test_File_Folder_AnonymousLinkType_UsingServicePrincipal_Incorrect if {
     
     # Set PnP flag to true denoting use of service principal 
     Output := sharepoint.tests with input.SPO_tenant as [Tenant]
-        with input.OneDrive_PnP_Flag as true
 
     ReportDetailsString := concat(": ", [
         FAIL,
@@ -282,7 +322,6 @@ test_File_AnonymousLinkType_UsingServicePrincipal_Incorrect if {
     
     # Set PnP flag to true denoting use of service principal
     Output := sharepoint.tests with input.SPO_tenant as [Tenant]
-        with input.OneDrive_PnP_Flag as true
 
     # FAIL = Requirement not met
     # ReportDetailsString = "Requirement not met: both files and folders are not limited to view for Anyone"
@@ -305,7 +344,6 @@ test_Folder_AnonymousLinkType_UsingServicePrincipal_Incorrect if {
     
     # Set PnP flag to true denoting use of service principal
     Output := sharepoint.tests with input.SPO_tenant as [Tenant]
-        with input.OneDrive_PnP_Flag as true
 
     ReportDetailsString := concat(": ", [
         FAIL,


### PR DESCRIPTION

## 🗣 Description ##

This PR rectifies these core problems:

**Problem 1** - When **TryCommand was detecting an error executing a cmdlet or REST API, ScubaGear was treating that as a terminating condition emanating from the provider execution**, which is incorrect according to how TryCommand was designed. The providers were designed to treat each cmdlet or REST API call as an isolated incident and produce a "An error occurred running XYZ cmdlets" in the ScubaGear HTML report for the respective policies that require the data associated with those APIs. Due to a recent enhancement I added to the providers to trace the detailed execution steps and times, this functionality was inadvertently affected. I rectified the problem by adding a new parameter named -LogErrors $false to Trace-ScubaFunction which signals that the caller will handle errors by itself and this effectively prevents TryCommand from stopping the execution of ScubaGear as expected. I made this change in various places inside ExportAADProvider where Trace-ScubaFunction is used as well.

**Problem 2** - I also changed places where my previous enhancement calls Write-ScubaLog to pass -Level "Info" instead of "Warning". **When "Warning" is passed, the ScubaLogging module treats the error as terminating, which again breaks the design paradigm that the providers handle errors by themselves and should not stop ScubaGear from proceeding to execute other providers**. For example, if the AAD provider has some errors fetching some API data, that should not stop the AAD provider from fetching data for other APIs and that should not stop ScubaGear from executing other providers like SharePoint or Teams, etc. from "doing their thing".

**Problem 3** - When working on the recent Power BI pull request to implement those policy checks, I became aware that ScubaGear has a defect in the way that the Rego rulesets are designed. The defect is that the **Rego code does not properly handle scenarios where the required JSON object / field is either completely missing or is an empty array**. For example, regarding SharePoint, if the SharingCapability field is missing from the input JSON because there was an error fetching the SharePoint settings, the Rego rulesets did not work as expected and in many instances produced no output at all for the rulesets that reference SharingCapability. This is a major defect and I will log a separate issue to fix the Rego associated with other products (currently only SharePoint and Power BI are fully resilient against this Rego design defect). In this PR I concentrated on fixing the SharePoint Rego using the same methodology that I recently implemented for the Power BI Rego. The updated SharePoint Rego code will always produce an output policy evaluation even if the input fields are missing and the Rego policies will produce a RequirementMet = false when this occurs, which is the correct result.

**Problem 4** - InvokeScubaCached was not calling Import-Resources to load the helper modules like Connect, ScubaLogging, etc. early enough so it would error the first time that you call it.

closes #2164 
closes #2170 
closes #2180 

## 🧪 Testing ##

Detailed testing instructions are captured in a separate comment inside the PR.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed.

  Use `Update branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [x] Resolved all merge conflicts on branch.
- [x] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the PR assignee to complete. -->
- [x] Feature branch deleted after merge to clean up repository.
- [x] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
- [x] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
