### PR TITLE
fix: add OrgName and OrgUnitName to top-level Metadata in ScubaResults.json

### DIFF
--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -1373,6 +1373,8 @@ function Merge-JsonOutput {
                 "ToolVersion" = $ModuleVersion;
                 "TimestampZulu" = $TimestampZulu;
                 "ReportUUID" = $Guid;
+                "OrgName" = $SettingsExportObject.scuba_config.OrgName;
+                "OrgUnitName" = $SettingsExportObject.scuba_config.OrgUnitName;
             }
 
 

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -1366,6 +1366,8 @@ function Merge-JsonOutput {
                 "TenantId" = $TenantDetails.TenantId;
                 "DisplayName" = $TenantDetails.DisplayName;
                 "DomainName" = $TenantDetails.DomainName;
+                "OrgName" = $SettingsExportObject.scuba_config.OrgName;
+                "OrgUnitName" = $SettingsExportObject.scuba_config.OrgUnitName;
                 "ProductSuite" = "Microsoft 365";
                 "ProductsAssessed" = $FullNames;
                 "ProductAbbreviationMapping" = $ProductAbbreviationMapping
@@ -1373,8 +1375,6 @@ function Merge-JsonOutput {
                 "ToolVersion" = $ModuleVersion;
                 "TimestampZulu" = $TimestampZulu;
                 "ReportUUID" = $Guid;
-                "OrgName" = $SettingsExportObject.scuba_config.OrgName;
-                "OrgUnitName" = $SettingsExportObject.scuba_config.OrgUnitName;
             }
 
 

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Merge-JsonOutput.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Merge-JsonOutput.Tests.ps1
@@ -13,6 +13,10 @@ InModuleScope Orchestrator {
                     "Results"        = @();
                     "timestamp_zulu" = "";
                     "report_uuid" = "00000000-0000-0000-0000-000000000000"
+                    "scuba_config"   = @{
+                        "OrgName"     = "Test Organization";
+                        "OrgUnitName" = "Test Unit";
+                    }
                 }
             }
             Mock -CommandName Add-Member {}
@@ -56,6 +60,63 @@ InModuleScope Orchestrator {
                 { Merge-JsonOutput @JsonParameters } | Should -Not -Throw
                 Should -Invoke -CommandName Remove-Item -Exactly -Times 3
                 $JsonParameters.ProductNames = @()
+            }
+        }
+        Context 'When OrgName and OrgUnitName are present in scuba_config' {
+            BeforeAll {
+                Mock -CommandName Join-Path { "." }
+                Mock -CommandName ConvertFrom-Json { @{
+                        "ReportSummary"  = @{"Date" = "" }
+                        "Results"        = @();
+                        "timestamp_zulu" = "";
+                        "report_uuid"    = "00000000-0000-0000-0000-000000000000"
+                        "scuba_config"   = @{
+                            "OrgName"     = "My Agency";
+                            "OrgUnitName" = "My Division";
+                        }
+                    }
+                }
+                Mock -CommandName ConvertTo-Json { param($InputObject) $InputObject | ConvertTo-Json -Depth 3 }
+                [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'MergeParams')]
+                $MergeParams = @{
+                    TenantDetails       = @{"DisplayName" = "displayName"; "TenantId" = "tenantId"; "DomainName" = "domainName" };
+                    ModuleVersion       = '1.0';
+                    OutFolderPath       = "./";
+                    OutProviderFileName = "ProviderSettingsExport";
+                    FullScubaResultsName = "ScubaResults.json";
+                    Guid                = "00000000-0000-0000-0000-000000000000";
+                    ProductNames        = @("aad");
+                }
+            }
+            It 'Does not throw when OrgName and OrgUnitName are set' {
+                { Merge-JsonOutput @MergeParams } | Should -Not -Throw
+            }
+        }
+        Context 'When OrgName and OrgUnitName are absent from scuba_config' {
+            BeforeAll {
+                Mock -CommandName Join-Path { "." }
+                Mock -CommandName ConvertFrom-Json { @{
+                        "ReportSummary"  = @{"Date" = "" }
+                        "Results"        = @();
+                        "timestamp_zulu" = "";
+                        "report_uuid"    = "00000000-0000-0000-0000-000000000000"
+                        "scuba_config"   = @{}
+                    }
+                }
+                Mock -CommandName ConvertTo-Json { param($InputObject) $InputObject | ConvertTo-Json -Depth 3 }
+                [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'MergeParams')]
+                $MergeParams = @{
+                    TenantDetails       = @{"DisplayName" = "displayName"; "TenantId" = "tenantId"; "DomainName" = "domainName" };
+                    ModuleVersion       = '1.0';
+                    OutFolderPath       = "./";
+                    OutProviderFileName = "ProviderSettingsExport";
+                    FullScubaResultsName = "ScubaResults.json";
+                    Guid                = "00000000-0000-0000-0000-000000000000";
+                    ProductNames        = @("aad");
+                }
+            }
+            It 'Does not throw when OrgName and OrgUnitName are null' {
+                { Merge-JsonOutput @MergeParams } | Should -Not -Throw
             }
         }
     }


### PR DESCRIPTION
Closes #2137

## Summary

Replicates `OrgName` and `OrgUnitName` from `Raw.scuba_config` into the top-level `Metadata` key of `ScubaResults_*.json`, so downstream analytics processes can identify a results file without traversing the `Raw` object.

**`Orchestrator.psm1` — `Merge-JsonOutput`**

Added two fields to the `$MetaData` object built at the start of result aggregation:

```powershell
"OrgName"     = $SettingsExportObject.scuba_config.OrgName;
"OrgUnitName" = $SettingsExportObject.scuba_config.OrgUnitName;
```

`$SettingsExportObject` is the already-loaded provider JSON, so no additional I/O is needed. Both keys are always present in `Metadata`; when `OrgName`/`OrgUnitName` are not set in the config file the values are `null`, matching the accepted design in the issue.

**`Merge-JsonOutput.Tests.ps1`**

- Updated the existing `ConvertFrom-Json` mock to include `scuba_config` with `OrgName`/`OrgUnitName`
- Added a context block for the case where both values are populated
- Added a context block for the case where `scuba_config` is empty (null values)

## Test plan

- [x] `Invoke-Pester PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Merge-JsonOutput.Tests.ps1`
- [x] Verify `ScubaResults_*.json` contains `Metadata.OrgName` and `Metadata.OrgUnitName` after a full run with `OrgName`/`OrgUnitName` set in config
- [x] Verify the keys are present but `null` when not set in config