### PR TITLE
Dynamically determine M365Environment during non-interactive authentication

### DIFF
--- a/PowerShell/ScubaGear/Modules/Connection/Connection.psm1
+++ b/PowerShell/ScubaGear/Modules/Connection/Connection.psm1
@@ -427,6 +427,41 @@ function Disconnect-SCuBATenant {
 
 }
 
+function Get-ServicePrincipalParams {
+    <#
+    .Description
+    Returns a valid a hastable of parameters for authentication via
+    Service Principal. Throws an error if there are none.
+    .Functionality
+    Internal
+    #>
+    [CmdletBinding()]
+    param(
+    [Parameter(Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [object]
+    $ScubaConfig
+    )
+
+    $ServicePrincipalParams = @{}
+
+    $CheckThumbprintParams = ($ScubaConfig.CertificateThumbprint) `
+    -and ($ScubaConfig.AppID) -and ($ScubaConfig.Organization)
+
+    if ($CheckThumbprintParams) {
+        $CertThumbprintParams = @{
+            CertificateThumbprint = $ScubaConfig.CertificateThumbprint;
+            AppID = $ScubaConfig.AppID;
+            Organization = $ScubaConfig.Organization;
+        }
+        $ServicePrincipalParams += @{CertThumbprintParams = $CertThumbprintParams}
+    }
+    else {
+        throw "Missing parameters required for authentication with Service Principal Auth; Run Get-Help Invoke-Scuba for details on correct arguments"
+    }
+    $ServicePrincipalParams
+}
+
 function Get-M365EnvironmentByDomain {
     <#
     .SYNOPSIS
@@ -472,5 +507,6 @@ function Get-M365EnvironmentByDomain {
 Export-ModuleMember -Function @(
     'Connect-Tenant',
     'Disconnect-SCuBATenant',
+    'Get-ServicePrincipalParams',
     'Get-M365EnvironmentByDomain'
 )

--- a/PowerShell/ScubaGear/Modules/Connection/Connection.psm1
+++ b/PowerShell/ScubaGear/Modules/Connection/Connection.psm1
@@ -457,7 +457,7 @@ function Get-ServicePrincipalParams {
         $ServicePrincipalParams += @{CertThumbprintParams = $CertThumbprintParams}
     }
     else {
-        throw "Missing parameters required for authentication with Service Principal Auth; Run Get-Help Invoke-Scuba for details on correct arguments"
+        throw "When authenticating with Service Principal authentication, the following command line parameters must be provided: -AppID, -CertificateThumbprint and -Organization."
     }
     $ServicePrincipalParams
 }

--- a/PowerShell/ScubaGear/Modules/Connection/Connection.psm1
+++ b/PowerShell/ScubaGear/Modules/Connection/Connection.psm1
@@ -427,7 +427,50 @@ function Disconnect-SCuBATenant {
 
 }
 
+function Get-M365EnvironmentByDomain {
+    <#
+    .SYNOPSIS
+        Determines the M365 environment based on the tenant domain.
+
+    .DESCRIPTION
+        Determines the M365 environment based on the tenant domain.
+
+    .PARAMETER TenantDomain
+        The domain of the tenant for which to determine the environment.
+
+    .EXAMPLE
+        $M365Environment = Get-M365EnvironmentByDomain -TenantDomain "contoso.onmicrosoft.com"
+
+    .FUNCTIONALITY
+        Internal
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'Interactive')]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$TenantDomain
+    )
+
+    $MetadataUri = "https://login.microsoftonline.com/$TenantDomain/.well-known/openid-configuration"
+
+    $Metadata = Invoke-RestMethod -Uri $MetadataUri -Method Get -ErrorAction Stop
+
+    $TenantRegionSubScope = $Metadata.tenant_region_sub_scope
+
+    $M365Environment = switch ($TenantRegionSubScope) {
+        "DODCON" { "gcchigh" }
+        "GCC"    { "gcc" }
+        "DOD"    { "dod" }
+        $null    { "commercial" }
+        default  {
+            throw "Unknown tenant_region_sub_scope value: '$TenantRegionSubScope'"
+        }
+    }
+
+    return $M365Environment
+}
+
 Export-ModuleMember -Function @(
-   'Connect-Tenant',
-   'Disconnect-SCuBATenant'
+    'Connect-Tenant',
+    'Disconnect-SCuBATenant',
+    'Get-M365EnvironmentByDomain'
 )

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -2297,7 +2297,7 @@ function Invoke-SCuBACached {
                 # logging product authentication start with details on which products are being authenticated, the environment, and whether service principal auth is being used
                 Write-ScubaLog -Message "Starting product authentication" -Level "Info" -Source "ScubaCached" -Data @{
                     ProductNames = ($ProductNames -join ', ')
-                    M365Environment = $M365Environment
+                    M365Environment = $TempScubaConfig.M365Environment
                     UsesServicePrincipal = ($null -ne $TempScubaConfig.AppID)
                 }
 
@@ -2339,7 +2339,7 @@ function Invoke-SCuBACached {
                 }
 
                 Write-ScubaLog -Message "Retrieving tenant details" -Level "Info" -Source "ScubaCached"
-                $TenantDetails = Get-TenantDetail -ProductNames $ProductNames -M365Environment $M365Environment
+                $TenantDetails = Get-TenantDetail -ProductNames $ProductNames -M365Environment $TempScubaConfig.M365Environment
 
                 # A new GUID needs to be generated if the provider is run
                 $Guid = New-Guid -ErrorAction 'Stop'

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -482,7 +482,7 @@ function Invoke-SCuBA {
             Write-ScubaLog -Message "ScubaGear logging initialized" -Level "Info" -Source "InvokeScuba" -Data @{
                 Version = $ModuleVersion
                 ProductNames = ($ProductNames -join ', ')
-                Environment = $M365Environment
+                UserPassedEnvironment = $M365Environment
                 OutputFolder = $OutFolderPath
                 LogFolder = $ScubaLogFolder
                 TranscriptEnabled = $Transcript
@@ -527,11 +527,19 @@ function Invoke-SCuBA {
             $Script:ScubaLoggingEnabled = $false
         }
 
+        # If user is authenticating with service principal, automatically detect the M365Environment using Microsoft's openid-configuration API
+        # This overrides any user provided command line value for M365Environment and the default value of "commercial"
+        $ServicePrincipalParams = $null
+        if ($ScubaConfig.CertificateThumbprint) {
+            $ServicePrincipalParams = Get-ServicePrincipalParams -ScubaConfig $ScubaConfig
+            $ScubaConfig.M365Environment = Get-M365EnvironmentByDomain -TenantDomain $ServicePrincipalParams.CertThumbprintParams.Organization
+        }
+
         # Product Authentication - parameters consolidated into ScubaConfig
         Write-ScubaLog -Message "Starting product authentication..." -Level "Info" -Source "InvokeScuba" -Data @{
             ProductNames = ($ScubaConfig.ProductNames -join ', ')
             M365Environment = $ScubaConfig.M365Environment
-            UsesServicePrincipal = (-not [string]::IsNullOrEmpty($ScubaConfig.AppID)) #$null -ne $ScubaConfig.AppID)
+            UsesServicePrincipal = (-not [string]::IsNullOrEmpty($ScubaConfig.AppID))
         }
 
         $ConnectionResult = Invoke-Connection -ScubaConfig $ScubaConfig
@@ -1906,7 +1914,7 @@ function Import-Resources {
 
         @('Connection', 'RunRego', 'CreateReport', 'ScubaConfig', 'Support', 'Utility') | ForEach-Object {
             $ModulePath = Join-Path -Path $PSScriptRoot -ChildPath $_ -ErrorAction 'Stop'
-            Write-Debug "Importing $_ module"
+            Write-Debug "Importing $_ module $ModulePath"
             Import-Module -Name $ModulePath
         }
     }

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -21,8 +21,8 @@ function Invoke-SCuBA {
     This parameter is used to authenticate to the different commercial/government environments.
     Valid values include "commercial", "gcc", "gcchigh", or "dod".
     - For M365 tenants with E3/E5 licenses enter the value **"commercial"**.
-    - For M365 Government Commercial Cloud tenants with G3/G5 licenses enter the value **"gcc"**.
-    - For M365 Government Commercial Cloud High tenants enter the value **"gcchigh"**.
+    - For M365 Government Community Cloud tenants with G3/G5 licenses enter the value **"gcc"**.
+    - For M365 Government Community Cloud High tenants enter the value **"gcchigh"**.
     - For M365 Department of Defense tenants enter the value **"dod"**.
     Default value is 'commercial'.
     .Parameter OPAPath
@@ -127,7 +127,7 @@ function Invoke-SCuBA {
     'dod' teams endpoint.
     .Example
     Invoke-SCuBA -ProductNames aad,exo -M365Environment gcc -OPAPath . -OutPath . -DisconnectOnExit
-    Run the tool against Azure Active Directory and Exchange Online security
+    Run the tool against Entra Id and Exchange Online security
     baselines, disconnecting connections for those products when complete.
     .Example
     Invoke-SCuBA -ProductNames * -CertificateThumbprint <insert-thumbprint> -AppID <insert-appid> -Organization "tenant.onmicrosoft.com"
@@ -1982,8 +1982,8 @@ function Invoke-SCuBACached {
     This parameter is used to authenticate to the different commercial/government environments.
     Valid values include "commercial", "gcc", "gcchigh", or "dod".
     For M365 tenants with E3/E5 licenses enter the value **"commercial"**.
-    For M365 Government Commercial Cloud tenants with G3/G5 licenses enter the value **"gcc"**.
-    For M365 Government Commercial Cloud High tenants enter the value **"gcchigh"**.
+    For M365 Government community cloud tenants with G3/G5 licenses enter the value **"gcc"**.
+    For M365 Government community cloud High tenants enter the value **"gcchigh"**.
     For M365 Department of Defense tenants enter the value **"dod"**.
     Default is 'commercial'.
     .Parameter OPAPath

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -529,10 +529,10 @@ function Invoke-SCuBA {
 
         # If user is authenticating with service principal, automatically detect the M365Environment using Microsoft's openid-configuration API
         # This overrides any user provided command line value for M365Environment and the default value of "commercial"
-        $ServicePrincipalParams = $null
-        if ($ScubaConfig.CertificateThumbprint) {
-            $ServicePrincipalParams = Get-ServicePrincipalParams -ScubaConfig $ScubaConfig
-            $ScubaConfig.M365Environment = Get-M365EnvironmentByDomain -TenantDomain $ServicePrincipalParams.CertThumbprintParams.Organization
+        if ($ScubaConfig.CertificateThumbprint -or $ScubaConfig.AppID) {
+            # Get-ServicePrincipalParams will validate that CertificateThumbprint, AppID, and Organization are all provided
+            $null = Get-ServicePrincipalParams -ScubaConfig $ScubaConfig
+            $ScubaConfig.M365Environment = Get-M365EnvironmentByDomain -TenantDomain $ScubaConfig.Organization
         }
 
         # Product Authentication - parameters consolidated into ScubaConfig
@@ -2241,7 +2241,7 @@ function Invoke-SCuBACached {
                 Write-ScubaLog -Message "ScubaGear logging initialized (Cached Mode)" -Level "Info" -Source "ScubaCached" -Data @{
                     Version = $ModuleVersion
                     ProductNames = ($ProductNames -join ', ')
-                    Environment = $M365Environment
+                    UserPassedEnvironment = $M365Environment
                     OutputFolder = $OutFolderPath
                     LogFolder = $ScubaLogFolder
                     ExportProvider = $ExportProvider
@@ -2305,6 +2305,14 @@ function Invoke-SCuBACached {
                 'OutCsvFileName' = $OutCsvFileName;
                 'OutActionPlanFileName' = $OutActionPlanFileName;
                 'NumberOfUUIDCharactersToTruncate' = $NumberOfUUIDCharactersToTruncate
+            }
+
+            # If user is authenticating with service principal, automatically detect the M365Environment using Microsoft's openid-configuration API
+            # This overrides any user provided command line value for M365Environment and the default value of "commercial"
+            if ($TempScubaConfig.CertificateThumbprint -or $TempScubaConfig.AppID) {
+                # Get-ServicePrincipalParams will validate that CertificateThumbprint, AppID, and Organization are all provided
+                $null = Get-ServicePrincipalParams -ScubaConfig $TempScubaConfig
+                $TempScubaConfig.M365Environment = Get-M365EnvironmentByDomain -TenantDomain $TempScubaConfig.Organization
             }
 
             try {

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -1846,41 +1846,6 @@ function Compare-ProductList {
     }
 }
 
-function Get-ServicePrincipalParams {
-    <#
-    .Description
-    Returns a valid a hastable of parameters for authentication via
-    Service Principal. Throws an error if there are none.
-    .Functionality
-    Internal
-    #>
-    [CmdletBinding()]
-    param(
-    [Parameter(Mandatory=$true)]
-    [ValidateNotNullOrEmpty()]
-    [object]
-    $ScubaConfig
-    )
-
-    $ServicePrincipalParams = @{}
-
-    $CheckThumbprintParams = ($ScubaConfig.CertificateThumbprint) `
-    -and ($ScubaConfig.AppID) -and ($ScubaConfig.Organization)
-
-    if ($CheckThumbprintParams) {
-        $CertThumbprintParams = @{
-            CertificateThumbprint = $ScubaConfig.CertificateThumbprint;
-            AppID = $ScubaConfig.AppID;
-            Organization = $ScubaConfig.Organization;
-        }
-        $ServicePrincipalParams += @{CertThumbprintParams = $CertThumbprintParams}
-    }
-    else {
-        throw "When authenticating with Service Principal authentication, the following command line parameters must be provided: -AppID, -CertificateThumbprint and -Organization."
-    }
-    $ServicePrincipalParams
-}
-
 function Import-Resources {
     <#
     .Description

--- a/PowerShell/ScubaGear/Modules/Support/Support.psm1
+++ b/PowerShell/ScubaGear/Modules/Support/Support.psm1
@@ -675,8 +675,8 @@ function New-SCuBAConfig {
     This parameter is used to authenticate to the different commercial/government environments.
     Valid values include "commercial", "gcc", "gcchigh", or "dod".
     - For M365 tenants with E3/E5 licenses enter the value **"commercial"**.
-    - For M365 Government Commercial Cloud tenants with G3/G5 licenses enter the value **"gcc"**.
-    - For M365 Government Commercial Cloud High tenants enter the value **"gcchigh"**.
+    - For M365 Government community cloud tenants with G3/G5 licenses enter the value **"gcc"**.
+    - For M365 Government community cloud High tenants enter the value **"gcchigh"**.
     - For M365 Department of Defense tenants enter the value **"dod"**.
     Default value is 'commercial'.
     .Parameter OPAPath

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Connection/Get-ServicePrincipalParams.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Connection/Get-ServicePrincipalParams.Tests.ps1
@@ -1,8 +1,8 @@
-$OrchestratorPath = '../../../../Modules/Orchestrator.psm1'
-Import-Module (Join-Path -Path $PSScriptRoot -ChildPath $OrchestratorPath) -Function 'Get-ServicePrincipalParams'
+$ConnectionModulePath = '../../../../Modules/Connection/Connection.psm1'
+Import-Module (Join-Path -Path $PSScriptRoot -ChildPath $ConnectionModulePath) -Function 'Get-ServicePrincipalParams'
 
-Describe -Tag 'Orchestrator' -Name 'Get-ServicePrincipalParams' {
-    InModuleScope Orchestrator {
+Describe -Tag 'Connection' -Name 'Get-ServicePrincipalParams' {
+    InModuleScope Connection {
         Context "Service Principal provided"{
             BeforeAll{
                 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'ScubaConfig')]
@@ -56,5 +56,5 @@ Describe -Tag 'Orchestrator' -Name 'Get-ServicePrincipalParams' {
 }
 
 AfterAll {
-    Remove-Module Orchestrator -ErrorAction SilentlyContinue
+    Remove-Module Connection -ErrorAction SilentlyContinue
 }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Connect-Tenant.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Connect-Tenant.Tests.ps1
@@ -13,6 +13,8 @@ InModuleScope Orchestrator {
                 }
                 function Connect-Tenant { throw 'this will be mocked' }
                 Mock -ModuleName Orchestrator Connect-Tenant { @() }
+                function Get-ServicePrincipalParams { throw 'this will be mocked' }
+                Mock -ModuleName Orchestrator Get-ServicePrincipalParams { @() }
             }
 
             It 'connects to aad (single product)' {

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-Connection.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-Connection.Tests.ps1
@@ -23,7 +23,7 @@ InModuleScope Orchestrator {
         }
         It 'Has AppId - Service Principal Auth'{
                 Mock -ModuleName Orchestrator Connect-Tenant {$null}
-                Mock -ModuleName Orchestrator Get-ServicePrincipalParams { @{CertThumbprintParams = @{AppID="a"; CertificateThumbprint="b"; Organization="c"}} }
+                Mock -ModuleName Connection Get-ServicePrincipalParams { @{CertThumbprintParams = @{AppID="a"; CertificateThumbprint="b"; Organization="c"}} }
                 $ScubaConfig = [PSCustomObject]@{
                     ProductNames = @('aad')
                     M365Environment = 'commercial'

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-Connection.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-Connection.Tests.ps1
@@ -6,6 +6,8 @@ InModuleScope Orchestrator {
         BeforeAll {
             function Connect-Tenant {throw 'this will be mocked'}
             Mock -ModuleName Orchestrator Connect-Tenant {$null}
+            function Get-ServicePrincipalParams {throw 'this will be mocked'}
+            Mock -ModuleName Orchestrator Get-ServicePrincipalParams { @{CertThumbprintParams = @{AppID="a"; CertificateThumbprint="b"; Organization="c"}} }
         }
         It 'Basic connection without AppID'{
                 $ScubaConfig = [PSCustomObject]@{
@@ -22,8 +24,8 @@ InModuleScope Orchestrator {
                 {Invoke-Connection -ScubaConfig $ScubaConfig} | Should -Not -Throw
         }
         It 'Has AppId - Service Principal Auth'{
-                Mock -ModuleName Orchestrator Connect-Tenant {$null}
-                Mock -ModuleName Connection Get-ServicePrincipalParams { @{CertThumbprintParams = @{AppID="a"; CertificateThumbprint="b"; Organization="c"}} }
+                # Mock -ModuleName Orchestrator Connect-Tenant {$null}
+                # Mock -ModuleName Orchestrator Get-ServicePrincipalParams { @{CertThumbprintParams = @{AppID="a"; CertificateThumbprint="b"; Organization="c"}} }
                 $ScubaConfig = [PSCustomObject]@{
                     ProductNames = @('aad')
                     M365Environment = 'commercial'

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-Connection.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-Connection.Tests.ps1
@@ -24,8 +24,6 @@ InModuleScope Orchestrator {
                 {Invoke-Connection -ScubaConfig $ScubaConfig} | Should -Not -Throw
         }
         It 'Has AppId - Service Principal Auth'{
-                # Mock -ModuleName Orchestrator Connect-Tenant {$null}
-                # Mock -ModuleName Orchestrator Get-ServicePrincipalParams { @{CertThumbprintParams = @{AppID="a"; CertificateThumbprint="b"; Organization="c"}} }
                 $ScubaConfig = [PSCustomObject]@{
                     ProductNames = @('aad')
                     M365Environment = 'commercial'

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-Scuba.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-Scuba.Tests.ps1
@@ -60,6 +60,9 @@ InModuleScope Orchestrator {
 
             function Get-M365EnvironmentByDomain {throw 'this will be mocked'}
             Mock -ModuleName Orchestrator Get-M365EnvironmentByDomain {}
+
+            function Get-ServicePrincipalParams {throw 'this will be mocked'}
+            Mock -ModuleName Orchestrator Get-ServicePrincipalParams { @{CertThumbprintParams = @{AppID="a"; CertificateThumbprint="b"; Organization="c"}} }
         }
         Context 'When checking the conformance of commercial tenants' {
             BeforeAll {

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-Scuba.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-Scuba.Tests.ps1
@@ -30,9 +30,36 @@ InModuleScope Orchestrator {
 
             Mock -CommandName New-Item {}
             Mock -CommandName Copy-Item {}
+            function Initialize-ScubaLogging {throw 'this will be mocked'}
             Mock -ModuleName Orchestrator Initialize-ScubaLogging {}
+
+            function Write-ScubaLog {throw 'this will be mocked'}
             Mock -ModuleName Orchestrator Write-ScubaLog {}
+
+            function Write-ScubaRunDetails {throw 'this will be mocked'}
             Mock -ModuleName Orchestrator Write-ScubaRunDetails {}
+
+            function Trace-ScubaFunction {
+                [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '')]
+                param(
+                    [string] $FunctionName,
+                    [hashtable] $Parameters,
+                    [switch] $LogReturnValue,
+                    [scriptblock] $ScriptBlock
+                )
+
+                throw 'this will be mocked'
+            }
+            Mock -ModuleName Orchestrator Trace-ScubaFunction {
+                $scriptBlockToInvoke = $args |
+                    Where-Object { $_ -is [scriptblock] } |
+                    Select-Object -First 1
+
+                & $scriptBlockToInvoke
+            }
+
+            function Get-M365EnvironmentByDomain {throw 'this will be mocked'}
+            Mock -ModuleName Orchestrator Get-M365EnvironmentByDomain {}
         }
         Context 'When checking the conformance of commercial tenants' {
             BeforeAll {
@@ -43,46 +70,52 @@ InModuleScope Orchestrator {
                 }
             }
             It 'Do it quietly (Do not automatically show report)' {
-                {Invoke-Scuba -Quiet} | Should -Not -Throw
+                {Invoke-Scuba -Quiet -SilenceBODWarnings} | Should -Not -Throw
                 Should -Invoke -CommandName Invoke-ReportCreation -Exactly -Times 1 -ParameterFilter {$Quiet -eq $true}
             }
             It 'Show report' {
-                {Invoke-Scuba} | Should -Not -Throw
+                {Invoke-Scuba -SilenceBODWarnings} | Should -Not -Throw
                 Should -Invoke -CommandName Invoke-ReportCreation -Exactly -Times 1 -ParameterFilter {$Quiet -eq $false}
             }
             It 'Given -ProductNames aad should not throw' {
                 $SplatParams += @{
                     ProductNames = @("aad")
+                    SilenceBODWarnings = $true
                 }
                 {Invoke-Scuba @SplatParams} | Should -Not -Throw
             }
             It 'Given -ProductNames securitysuite should not throw' {
                 $SplatParams += @{
                     ProductNames = @("securitysuite")
+                    SilenceBODWarnings = $true
                 }
                 {Invoke-Scuba @SplatParams} | Should -Not -Throw
             }
             It 'Given -ProductNames exo should not throw' {
                 $SplatParams += @{
                     ProductNames = @("exo")
+                    SilenceBODWarnings = $true
                 }
                 {Invoke-Scuba @SplatParams} | Should -Not -Throw
             }
             It 'Given -ProductNames powerplatform should not throw' {
                 $SplatParams += @{
                     ProductNames = @("powerplatform")
+                    SilenceBODWarnings = $true
                 }
                 {Invoke-Scuba @SplatParams} | Should -Not -Throw
             }
             It 'Given -ProductNames teams should not throw' {
                 $SplatParams += @{
                     ProductNames = @("teams")
+                    SilenceBODWarnings = $true
                 }
                 {Invoke-Scuba @SplatParams} | Should -Not -Throw
             }
             It 'Given -ProductNames * should not throw' {
                 $SplatParams += @{
                     ProductNames = @("*")
+                    SilenceBODWarnings = $true
                 }
                 {Invoke-Scuba @SplatParams} | Should -Not -Throw
             }
@@ -90,11 +123,12 @@ InModuleScope Orchestrator {
                 $SplatParams += @{
                     ProductNames = @("*")
                     DisconnectOnExit = $true
+                    SilenceBODWarnings = $true
                 }
                 {Invoke-Scuba @SplatParams} | Should -Not -Throw
             }
             It 'Should only run each baseline once if provider names contains duplicates' {
-                {Invoke-Scuba -ProductNames aad,aad} | Should -Not -Throw
+                {Invoke-Scuba -ProductNames aad,aad -SilenceBODWarnings} | Should -Not -Throw
                 # After refactor, -ProductNames are consolidated into ScubaConfig and duplicates removed
                 # Validate only a single invocation and that consolidated ProductNames contains exactly one 'aad'
                 Should -Invoke Invoke-ReportCreation -ParameterFilter {$ScubaConfig.ProductNames -eq 'aad'}

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-ScubaConfig.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-ScubaConfig.Tests.ps1
@@ -126,9 +126,39 @@ InModuleScope Orchestrator {
         }
         Mock -CommandName New-Item {}
         Mock -CommandName Copy-Item {}
-        Mock -ModuleName Orchestrator Initialize-ScubaLogging {}
+        function Write-ScubaLog {throw 'this will be mocked'}
         Mock -ModuleName Orchestrator Write-ScubaLog {}
+        function Write-ScubaRunDetails {throw 'this will be mocked'}
         Mock -ModuleName Orchestrator Write-ScubaRunDetails {}
+
+        function Initialize-ScubaLogging {throw 'this will be mocked'}
+        Mock -ModuleName Orchestrator Initialize-ScubaLogging {}
+        function Get-M365EnvironmentByDomain {throw 'this will be mocked'}
+        Mock -ModuleName Orchestrator Get-M365EnvironmentByDomain {
+            return "commercial"
+        }
+
+        function Get-ServicePrincipalParams {throw 'this will be mocked'}
+        Mock -ModuleName Orchestrator Get-ServicePrincipalParams { @{CertThumbprintParams = @{AppID="a"; CertificateThumbprint="b"; Organization="c"}} }
+
+        function Trace-ScubaFunction {
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '')]
+            param(
+                [string] $FunctionName,
+                [hashtable] $Parameters,
+                [switch] $LogReturnValue,
+                [scriptblock] $ScriptBlock
+            )
+
+            throw 'this will be mocked'
+        }
+        Mock -ModuleName Orchestrator Trace-ScubaFunction {
+            $scriptBlockToInvoke = $args |
+                Where-Object { $_ -is [scriptblock] } |
+                Select-Object -First 1
+
+            & $scriptBlockToInvoke
+        }
     }
 
     Context  "Parameter override test"{
@@ -155,7 +185,7 @@ InModuleScope Orchestrator {
                         CertificateThumbprint='1234567890ABCDEF1234567890ABCDEF12345678'
                     }
                 }
-                Invoke-SCuBA -ConfigFilePath (Join-Path -Path $PSScriptRoot -ChildPath "orchestrator_config_test.yaml")
+                Invoke-SCuBA -ConfigFilePath (Join-Path -Path $PSScriptRoot -ChildPath "orchestrator_config_test.yaml") -SilenceBODWarnings
             }
 
             It "Verify parameter ""<parameter>"" with value ""<value>""" -ForEach @(
@@ -199,7 +229,7 @@ InModuleScope Orchestrator {
                 }
                 Invoke-SCuBA `
                   -ProductNames "*" `
-                  -ConfigFilePath (Join-Path -Path $PSScriptRoot -ChildPath "orchestrator_config_test.yaml")
+                  -ConfigFilePath (Join-Path -Path $PSScriptRoot -ChildPath "orchestrator_config_test.yaml") -SilenceBODWarnings
             }
 
             It "Verify parameter, ProductNames, with wildcard CLI override"{
@@ -228,7 +258,7 @@ InModuleScope Orchestrator {
                     }
                 }
                 Invoke-SCuBA `
-                  -ConfigFilePath (Join-Path -Path $PSScriptRoot -ChildPath "product_wildcard_config_test.yaml")
+                  -ConfigFilePath (Join-Path -Path $PSScriptRoot -ChildPath "product_wildcard_config_test.yaml") -SilenceBODWarnings
             }
 
             It "Verify parameter, ProductNames, reflects all products"{

--- a/Testing/Functional/Products/Products.Tests.ps1
+++ b/Testing/Functional/Products/Products.Tests.ps1
@@ -104,7 +104,9 @@ BeforeDiscovery {
 
     $ScubaModulePath = Join-Path -Path $PSScriptRoot -ChildPath "../../../PowerShell/ScubaGear/Modules"
     $ScubaModule = Join-Path -Path $ScubaModulePath -ChildPath "../ScubaGear.psd1"
+    $ConnectionModule = Join-Path -Path $ScubaModulePath -ChildPath "Connection/Connection.psm1"
     Import-Module $ScubaModule
+    Import-Module $ConnectionModule
 
     if ($Variant) {
         $TestPlanFileName = "TestPlans/$ProductName.$Variant.testplan.yaml"
@@ -120,13 +122,13 @@ BeforeDiscovery {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'Tests', Justification = 'Variable is used in ScriptBlock')]
     $Tests = $TestPlan.Tests
 
-    InModuleScope Connection -Parameters @{
-        ProductName = $ProductName
-        M365Environment = $M365Environment
-        Thumbprint = $Thumbprint
-        AppId = $AppId
-        TenantDomain = $TenantDomain
-    }{
+    # InModuleScope Connection -Parameters @{
+    #     ProductName = $ProductName
+    #     M365Environment = $M365Environment
+    #     Thumbprint = $Thumbprint
+    #     AppId = $AppId
+    #     TenantDomain = $TenantDomain
+    # }{
         if ($ProductName -eq "securitysuite"){
             $ProductNames = @($ProductName, "exo")
         }
@@ -135,18 +137,27 @@ BeforeDiscovery {
         }
 
         if (-Not [string]::IsNullOrEmpty($AppId)){
-        $ServicePrincipalParams = @{CertThumbprintParams = @{
-            CertificateThumbprint = $Thumbprint;
-            AppID = $AppId;
-            Organization = $TenantDomain;
-        }}
-        Connect-Tenant -ProductNames $ProductNames -M365Environment $M365Environment -ServicePrincipalParams $ServicePrincipalParams
+            $TempScubaConfig = New-Object -Type PSObject -Property @{
+                'AppID' = $AppID;
+                'CertificateThumbprint' = $Thumbprint;
+                'Organization' = $TenantDomain;
+            }
+            # Get-ServicePrincipalParams will validate that CertificateThumbprint, AppID, and Organization are all provided
+            $null = Get-ServicePrincipalParams -ScubaConfig $TempScubaConfig
+            $M365Environment = Get-M365EnvironmentByDomain -TenantDomain $TenantDomain
+
+            $ServicePrincipalParams = @{CertThumbprintParams = @{
+                CertificateThumbprint = $Thumbprint;
+                AppID = $AppId;
+                Organization = $TenantDomain;
+            }}
+            Connect-Tenant -ProductNames $ProductNames -M365Environment $M365Environment -ServicePrincipalParams $ServicePrincipalParams
         }
         else {
-        Write-Debug "Manual Connect to Tenant"
-        Connect-Tenant -ProductNames $ProductNames -M365Environment $M365Environment
+            Write-Debug "Manual Connect to Tenant"
+            Connect-Tenant -ProductNames $ProductNames -M365Environment $M365Environment
         }
-    }
+    # }
 }
 
 BeforeAll {
@@ -297,7 +308,7 @@ BeforeAll {
   function RunScuba() {
         if (-not [string]::IsNullOrEmpty($Thumbprint))
         {
-            Invoke-SCuBA -CertificateThumbPrint $Thumbprint -AppId $AppId -Organization $TenantDomain -Productnames $ProductName -OutPath . -M365Environment $M365Environment -Quiet -KeepIndividualJSON -SilenceBODWarnings
+            Invoke-SCuBA -CertificateThumbPrint $Thumbprint -AppId $AppId -Organization $TenantDomain -Productnames $ProductName -OutPath . -Quiet -KeepIndividualJSON -SilenceBODWarnings
         }
         else {
             Invoke-SCuBA -Login $false -Productnames $ProductName -OutPath . -M365Environment $M365Environment -Quiet -KeepIndividualJSON -SilenceBODWarnings

--- a/Testing/Functional/Products/Products.Tests.ps1
+++ b/Testing/Functional/Products/Products.Tests.ps1
@@ -18,8 +18,8 @@
     This parameter is used to authenticate to the different commercial/government environments.
     Valid values include "commercial", "gcc", "gcchigh", or "dod".
     - For M365 tenants with E3/E5 licenses enter the value **"commercial"**.
-    - For M365 Government Commercial Cloud tenants with G3/G5 licenses enter the value **"gcc"**.
-    - For M365 Government Commercial Cloud High tenants enter the value **"gcchigh"**.
+    - For M365 Government community cloud tenants with G3/G5 licenses enter the value **"gcc"**.
+    - For M365 Government community cloud High tenants enter the value **"gcchigh"**.
     - For M365 Department of Defense tenants enter the value **"dod"**.
     Default value is 'commercial'.
     .EXAMPLE

--- a/Testing/Functional/Products/Products.Tests.ps1
+++ b/Testing/Functional/Products/Products.Tests.ps1
@@ -122,42 +122,34 @@ BeforeDiscovery {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'Tests', Justification = 'Variable is used in ScriptBlock')]
     $Tests = $TestPlan.Tests
 
-    # InModuleScope Connection -Parameters @{
-    #     ProductName = $ProductName
-    #     M365Environment = $M365Environment
-    #     Thumbprint = $Thumbprint
-    #     AppId = $AppId
-    #     TenantDomain = $TenantDomain
-    # }{
-        if ($ProductName -eq "securitysuite"){
-            $ProductNames = @($ProductName, "exo")
-        }
-        else {
-            $ProductNames = @($ProductName)
-        }
+    if ($ProductName -eq "securitysuite"){
+        $ProductNames = @($ProductName, "exo")
+    }
+    else {
+        $ProductNames = @($ProductName)
+    }
 
-        if (-Not [string]::IsNullOrEmpty($AppId)){
-            $TempScubaConfig = New-Object -Type PSObject -Property @{
-                'AppID' = $AppID;
-                'CertificateThumbprint' = $Thumbprint;
-                'Organization' = $TenantDomain;
-            }
-            # Get-ServicePrincipalParams will validate that CertificateThumbprint, AppID, and Organization are all provided
-            $null = Get-ServicePrincipalParams -ScubaConfig $TempScubaConfig
-            $M365Environment = Get-M365EnvironmentByDomain -TenantDomain $TenantDomain
+    if (-Not [string]::IsNullOrEmpty($AppId)){
+        $TempScubaConfig = New-Object -Type PSObject -Property @{
+            'AppID' = $AppID;
+            'CertificateThumbprint' = $Thumbprint;
+            'Organization' = $TenantDomain;
+        }
+        # Get-ServicePrincipalParams will validate that CertificateThumbprint, AppID, and Organization are all provided
+        $null = Get-ServicePrincipalParams -ScubaConfig $TempScubaConfig
+        $M365Environment = Get-M365EnvironmentByDomain -TenantDomain $TenantDomain
 
-            $ServicePrincipalParams = @{CertThumbprintParams = @{
-                CertificateThumbprint = $Thumbprint;
-                AppID = $AppId;
-                Organization = $TenantDomain;
-            }}
-            Connect-Tenant -ProductNames $ProductNames -M365Environment $M365Environment -ServicePrincipalParams $ServicePrincipalParams
-        }
-        else {
-            Write-Debug "Manual Connect to Tenant"
-            Connect-Tenant -ProductNames $ProductNames -M365Environment $M365Environment
-        }
-    # }
+        $ServicePrincipalParams = @{CertThumbprintParams = @{
+            CertificateThumbprint = $Thumbprint;
+            AppID = $AppId;
+            Organization = $TenantDomain;
+        }}
+        Connect-Tenant -ProductNames $ProductNames -M365Environment $M365Environment -ServicePrincipalParams $ServicePrincipalParams
+    }
+    else {
+        Write-Debug "Manual Connect to Tenant"
+        Connect-Tenant -ProductNames $ProductNames -M365Environment $M365Environment
+    }
 }
 
 BeforeAll {

--- a/docs/configuration/parameters.md
+++ b/docs/configuration/parameters.md
@@ -24,8 +24,7 @@ Here is an example using `-AppID`:
 Invoke-SCuBA -ProductNames teams `
   -CertificateThumbprint fedcba9876543210fedcba9876543210fedcba98 `
   -AppID abcdef0123456789abcde01234566789 `
-  -Organization contoso.onmicrosoft.com `
-  -M365Environment gcc
+  -Organization contoso.onmicrosoft.com
 ```
 
 > **Note**: AppID, CertificateThumbprint, and Organization are part of a parameter set used for authentication; if one is specified, all three must be specified.
@@ -48,8 +47,7 @@ Here is an example using `-CertificateThumbprint`:
 Invoke-SCuBA -ProductNames teams `
   -CertificateThumbprint fedcba9876543210fedcba9876543210fedcba98 `
   -AppID abcdef0123456789abcde01234566789 `
-  -Organization contoso.onmicrosoft.com `
-  -M365Environment gcc
+  -Organization contoso.onmicrosoft.com
 ```
 
 > **Note**: AppID, CertificateThumbprint, and Organization are part of a parameter set used for authentication; if one is specified, all three must be specified.
@@ -154,7 +152,7 @@ Invoke-SCuBA -ProductNames teams `
 
 ## M365Environment
 
-**M365Environment** is used to authenticate to the various M365 commercial/government environments.
+**M365Environment** is used to authenticate to the various M365 commercial/government environments. It is not required when authenticating using non-interactive (service principal) authentication.
 
 | Parameter   | Value        |
 |-------------|--------------|
@@ -163,10 +161,10 @@ Invoke-SCuBA -ProductNames teams `
 | Default     | `commercial` |
 | Config File | Yes          |
 
-> **Note**: This parameter is required if authenticating to Power Platform. It is also required if executing the tool against GCC High or DoD tenants.
+> **Note**: This parameter is required if authenticating to a GCC, GCC High or DoD tenants.
 
 ```powershell
-# Assess a government commercial account
+# Assess a government community cloud (gcc) tenant
 Invoke-SCuBA -ProductNames teams `
   -M365Environment gcc
 ```
@@ -176,8 +174,8 @@ The list of acceptable values are:
 | Tenant                          | Value      |
 |---------------------------------|------------|
 | Non-government tenants          | commercial |
-| Government cloud tenants        | gcc        |
-| Government cloud tenants (high) | gcchigh    |
+| Government community cloud        | gcc        |
+| Government community cloud (high) | gcchigh    |
 | Department of Defense tenants   | dod        |
 
 
@@ -229,7 +227,7 @@ Invoke-SCuBA -ProductNames teams `
 
 ## Organization
 
-**Organization** is the organization that's used in non-interactive mode authentication.  It is of the form `contoso.onmicrosoft.com`.
+**Organization** is the initial domain assigned when the tenant was created and is of the form `contoso.onmicrosoft.com`.
 
 | Parameter   | Value  |
 |-------------|--------|
@@ -245,8 +243,7 @@ Here is an example using Organization:
 Invoke-SCuBA -ProductNames teams `
   -CertificateThumbprint fedcba9876543210fedcba9876543210fedcba98 `
   -AppID abcdef0123456789abcde01234566789 `
-  -Organization contoso.onmicrosoft.com `
-  -M365Environment gcc
+  -Organization contoso.onmicrosoft.com
 ```
 
 > **Note**: AppID, CertificateThumbprint, and Organization are part of a parameter set used for authentication; if one is specified, all three must be specified.

--- a/docs/execution/execution.md
+++ b/docs/execution/execution.md
@@ -80,16 +80,14 @@ More information about the resulting reports can be found on the [reports](repor
 
 ## Non-interactive Mode
 
-Non-interactive mode means that the credentials that are required by the underlying Microsoft libraries are supplied via command-line parameters or the config file. It uses an Entra ID [service principal](../prerequisites/noninteractive.md) and a certificate thumbprint, thus enabling ScubaGear to be used in automated processes, such as pipelines and scheduled jobs. 
+Non-interactive mode means that the credentials that are required to authenticate are supplied via command-line parameters or the config file. It uses an Entra ID [service principal](../prerequisites/noninteractive.md) and a certificate thumbprint, thus enabling ScubaGear to be used in automated processes, such as pipelines and scheduled jobs. 
 
 ```powershell
 # Assess with service principal
-# Must pass M365Environment. Acceptable values are: commercial, gcc, gcchigh
 Invoke-SCuBA -ProductNames * `
   -CertificateThumbprint fedcba9876543210fedcba9876543210fedcba98 `
   -AppID abcdef0123456789abcde01234566789 `
-  -Organization contoso.onmicrosoft.com `
-  -M365Environment gcc
+  -Organization contoso.onmicrosoft.com
 ```
 
 ## Parameters

--- a/docs/prerequisites/noninteractive.md
+++ b/docs/prerequisites/noninteractive.md
@@ -116,11 +116,8 @@ In the **Power BI Admin portal**:
 After enabling the setting, confirm the SP can reach the API:
 
 ```powershell
-Invoke-SCuBA -ProductNames powerbi -AppID <app-id> -CertificateThumbprint <thumbprint> -Organization <tenant>.onmicrosoft.com -M365Environment gcc
+Invoke-SCuBA -ProductNames powerbi -AppID <app-id> -CertificateThumbprint <thumbprint> -Organization <tenant>.onmicrosoft.com
 ```
-
-> [!NOTE]
-> For GCC High tenants, use `-M365Environment gcchigh`. See [Power BI in GCC High](#power-bi-in-gcc-high) for additional details.
 
 ## Power Platform Registration
 
@@ -175,7 +172,3 @@ When running ScubaGear to assess Defender for Office 365 in a GCC High tenant, t
 ### SharePoint in GCC High
 
 When running ScubaGear to assess SharePoint Online in a GCC High tenant, the `Sites.FullControl.All` application permission must be added from the GCC High-unique `Office 365 SharePoint Online` API rather than the commercial-unique `SharePoint` API located in commercial/government community cloud tenants.
-
-### Power BI in GCC High
-
-When running ScubaGear to assess Power BI in a GCC High tenant, the same [Power BI Tenant Setting](#power-bi-tenant-setting) configuration applies — create an Entra security group containing the service principal and add it to the "Service principals can access read-only admin APIs" setting in the Power BI Admin portal. No API permissions need to be added to the App Registration. Use `-M365Environment gcchigh` when invoking ScubaGear.

--- a/docs/prerequisites/serviceprincipal-troubleshooting.md
+++ b/docs/prerequisites/serviceprincipal-troubleshooting.md
@@ -101,7 +101,7 @@ Yes, but you must export the certificate with private key and import it on each 
 Currently, New-ScubaGearServicePrincipal and New-ScubaGearAppCert create new certificates. To use an existing certificate, manually attach it through Entra Admin Center:
 1. Go to App registrations > Your app > Certificates & secrets
 2. Upload your certificate (.cer or .pem file)
-3. Use its thumbprint with Invoke-ScubaGear
+3. Use its thumbprint with Invoke-Scuba
 
 ---
 

--- a/docs/prerequisites/serviceprincipal-workflows.md
+++ b/docs/prerequisites/serviceprincipal-workflows.md
@@ -127,7 +127,6 @@ Verify the service principal can authenticate:
 Invoke-Scuba `
     -AppID $NewSP.AppID `
     -CertificateThumbprint $NewSP.CertThumbprint `
-    -M365Environment $NewSP.M365Environment `
     -ProductNames $NewSP.ProductNames `
     -Organization 'example.onmicrosoft.com'
 ```
@@ -256,10 +255,9 @@ Test ScubaGear execution with the new certificate:
 
 ```powershell
 # Test with new certificate
-Invoke-ScubaGear `
+Invoke-Scuba `
     -AppID "your-app-id-here" `
     -CertificateThumbprint $NewCert.Thumbprint `
-    -M365Environment commercial `
     -ProductNames 'aad'
 ```
 
@@ -367,4 +365,4 @@ Get-ScubaGearAppPermission -AppID $AppID -M365Environment commercial -ProductNam
 ## Next Steps
 
 - **Troubleshooting:** See [Service Principal Troubleshooting](serviceprincipal-troubleshooting.md) for common issues
-- **Configuration:** See [Parameters Reference](../configuration/parameters.md) for Invoke-ScubaGear parameters
+- **Configuration:** See [Parameters Reference](../configuration/parameters.md) for Invoke-Scuba parameters

--- a/docs/troubleshooting/power.md
+++ b/docs/troubleshooting/power.md
@@ -5,7 +5,7 @@ In order for ScubaGear to properly assess Power Platform, one of the following c
 - The tenant must include the `Power Apps for Office 365` license and the user running the tool must have the `Power Platform Administrator` role, or...
 - The user running the tool must have the `Global Administrator` role.
 
-In addition to those conditions, the correct [M365Environment parameter](../configuration/parameters.md#m365environment) value must be used with `Invoke-SCuBA`:
+In addition to those conditions, the correct [M365Environment parameter](../configuration/parameters.md#m365environment) value must be used with `Invoke-SCuBA` if authenticating interactively with user credentials:
 
 If any of these conditions are not met, an error will be thrown similar to the one shown below:
 


### PR DESCRIPTION
## 🗣 Description ##

This PR introduces a strategic enhancement that automatically determines the M365Environment (commercial, gcc, gcc high) using Microsoft's public openid-configuration API, when a user authenticates in non-interactive (service principal) mode (ie with a certificate). It also addresses a minor parameter validation inadequacy to ensure that ScubaGear alerts the user if they are missing a required command line parameter when authenticating with a certificate.

**Note**: I decided to hold off on automatically detecting the M365 environment when a user signs in with interactive auth until a later release because that is much trickier and may require major changes to how ScubaGear authenticates, which I didn't want to introduce leading up to the 2.0.0 release with Security Suite and other major changes already going on. There will be a separate issue for that.

closes #2147 
closes #2199

## 💭 Motivation and context ##

The key motivations for this enhancement are to:

- Minimize the number of parameters that a user must pass to ScubaGear (make it easier to use)
- By automatically detecting the M365Environment there is less of a chance that ScubaGear will crash if the user forgets to pass the parameter or passes a wrong value.

## 🧪 Testing ##

### Scenario 1 - Service principal without M365Environment

Authenticate with a service principal and do NOT pass the M365Environment variable. Test against all tenant types (commercial, gcc, gcc high). Make sure it automatically detects the correct environment by examining the "Starting product authentication" trace message.

<img width="1106" height="469" alt="missing M365Environment" src="https://github.com/user-attachments/assets/c979c27e-3d41-4c88-b62f-5b49b97e2e1e" />

### Scenario 2 - Service principal with Incorrect M365Environment

Authenticate with a service principal and pass a wrong M365Environment value (e.g. the tenant is commercial but you pass gcc). Make sure it automatically detects the correct environment by examining the "Starting product authentication" trace message.

<img width="1106" height="476" alt="incorrect M365Environment" src="https://github.com/user-attachments/assets/6a44740e-886c-460c-a960-bb4a16ff5c59" />

### Scenario 3 - Missing Organization parameter

Authenticate with a service principal but do not pass the -Organization parameter. Make sure ScubaGear stops execution to provide a missing parameters error message.

<img width="1106" height="270" alt="image" src="https://github.com/user-attachments/assets/bd7ecdb1-a113-4ce1-ac80-d61eef157561" />

### Scenario 4 - Missing AppId parameter

Authenticate with a service principal but do not pass the -AppId parameter. Make sure ScubaGear stops execution to provide a missing parameters error message.

<img width="1096" height="265" alt="image" src="https://github.com/user-attachments/assets/d0b7a5da-617c-4db4-b46a-a91924c86f60" />

### Scenario 5 - Missing CertificateThumbPrint parameter

Authenticate with a service principal but do not pass the -CertificateThumbPrint parameter. Make sure ScubaGear stops execution to provide a missing parameters error message.

<img width="1107" height="279" alt="image" src="https://github.com/user-attachments/assets/e8807eeb-7acf-4363-9b67-c4472f759890" />

### Scenario 6 - Same tests with Invoke-ScubaCached.

Repeat the same tests (1 through 5) as above, except test with Invoke-ScubaCached and pass -Login $true which forces the authentication flow. Below is an example without the M365Environment variable to test auto-detection.

<img width="1103" height="106" alt="image" src="https://github.com/user-attachments/assets/18a959fc-2d57-456e-a284-ac8c2dc001e0" />

### Scenario 7 - Executing functional tests without the M365Environment parameter.

```
$TestContainers = @()

$TestContainers += New-PesterContainer -Path "Testing/Functional/Products" -Data @{ Thumbprint = "1B0268B04B9F22EFA77A0EFF01930ADE279AC174"; TenantDomain = "GCCHIGHDOMAIN.onmicrosoft.us"; TenantDisplayName = "GCCHIGHDISPLAYNAME"; AppId = "1234a54de2c84bccb074639f39e35fa1"; ProductName = "powerplatform"; }

$PesterConfig = @{
	Run = @{
		Container = $TestContainers
	}
	Filter = @{

	}
	Output = @{
		Verbosity = 'Detailed'
	}
}

$Config = New-PesterConfiguration -Hashtable $PesterConfig 

Invoke-Pester -Configuration $Config
```

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All relevant functional tests passed.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] PR passed smoke test check.
- [x] Feature branch has been rebased against changes from parent branch, as needed.

  Use `Update branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [x] Resolved all merge conflicts on branch.
- [x] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the PR assignee to complete. -->
- [x] Feature branch deleted after merge to clean up repository.
- [x] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
- [x] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
