### PR TITLE
Move EXO to REST Calls

### DIFF
--- a/PowerShell/ScubaGear/Modules/Connection/ConnectHelpers.psm1
+++ b/PowerShell/ScubaGear/Modules/Connection/ConnectHelpers.psm1
@@ -285,7 +285,7 @@ function Get-MsalAccessToken {
 
                 $TokenResult = $MsalApp.AcquireTokenInteractive([string[]]@($Scope)).
                     WithPrompt([Microsoft.Identity.Client.Prompt]::SelectAccount).
-                    WithUseEmbeddedWebView($true).
+                    WithUseEmbeddedWebView($false).
                     ExecuteAsync().GetAwaiter().GetResult()
             }
             return $TokenResult.AccessToken

--- a/PowerShell/ScubaGear/Modules/Connection/ConnectHelpers.psm1
+++ b/PowerShell/ScubaGear/Modules/Connection/ConnectHelpers.psm1
@@ -285,7 +285,7 @@ function Get-MsalAccessToken {
 
                 $TokenResult = $MsalApp.AcquireTokenInteractive([string[]]@($Scope)).
                     WithPrompt([Microsoft.Identity.Client.Prompt]::SelectAccount).
-                    WithUseEmbeddedWebView($false).
+                    WithUseEmbeddedWebView($true).
                     ExecuteAsync().GetAwaiter().GetResult()
             }
             return $TokenResult.AccessToken

--- a/PowerShell/ScubaGear/Modules/Connection/Connection.psm1
+++ b/PowerShell/ScubaGear/Modules/Connection/Connection.psm1
@@ -37,6 +37,7 @@
    Import-Module -Name $PSScriptRoot/../Providers/ProviderHelpers/PowerPlatformRestHelper.psm1 -Function Get-PowerPlatformBaseUrl, Get-PowerPlatformScope
    Import-Module -Name $PSScriptRoot/../Providers/ProviderHelpers/SPORestHelper.psm1 -Function Get-SPOAdminUrl
    Import-Module -Name $PSScriptRoot/../Providers/ProviderHelpers/PowerBIRestHelper.psm1 -Function Get-PowerBIBaseUrl, Get-PowerBIScope
+   Import-Module -Name $PSScriptRoot/../Providers/ProviderHelpers/EXORestHelper.psm1 -Function Get-ExchangeOnlineScope, Get-ExchangeOnlineApiEndpoint
 
    # Prevent duplicate sign ins
    $EXOAuthRequired = $true
@@ -55,12 +56,14 @@
 
    # Token data for REST-based products (populated during connection)
    $TokenData = @{
-       SPOAccessToken  = $null
-       SPOAdminUrl     = $null
-       PPAccessToken   = $null
-       PPBaseUrl       = $null
-       PBIAccessToken  = $null
-       PBIBaseUrl      = $null
+       SPOAccessToken     = $null
+       SPOAdminUrl        = $null
+       PPAccessToken      = $null
+       PPBaseUrl          = $null
+       PBIAccessToken     = $null
+       PBIBaseUrl         = $null
+       EXOAccessToken     = $null
+       EXOApiEndpoint     = $null
    }
 
    $N = 0
@@ -95,14 +98,56 @@
                }
                {($_ -eq "exo") -or ($_ -eq "securitysuite")} {
                    if ($EXOAuthRequired) {
-                       $EXOHelperParams = @{
-                           M365Environment = $M365Environment;
+                       if ($AADAuthRequired) {
+                           $LimitedGraphParams = @{
+                               'M365Environment' = $M365Environment;
+                               'ErrorAction' = 'Stop';
+                           }
+                           if ($ServicePrincipalParams) {
+                               $LimitedGraphParams += @{ServicePrincipalParams = $ServicePrincipalParams}
+                           }
+                           Connect-GraphHelper @LimitedGraphParams
+                           $AADAuthRequired = $false
                        }
-                       if ($ServicePrincipalParams) {
-                           $EXOHelperParams += @{ServicePrincipalParams = $ServicePrincipalParams}
+
+                       # Resolve tenant info if not already cached
+                       if ([string]::IsNullOrEmpty($TenantName)) {
+                           $OrgDetails = (Invoke-GraphDirectly -Commandlet Get-MgBetaOrganization -M365Environment $M365Environment).Value
+                           $InitialDomain = $OrgDetails.VerifiedDomains | Where-Object { $_.isInitial }
+                           $TenantName = $InitialDomain.Name
+                           $InitialDomainPrefix = $TenantName.split(".")[0]
                        }
-                       Write-Verbose "For the Security Suite baseline, Defender will require a sign in every single run regardless of what the LogIn parameter is set"
-                       Connect-EXOHelper @EXOHelperParams
+
+                       # Acquire Exchange Online access token
+                       $EXOScope = Get-ExchangeOnlineScope -M365Environment $M365Environment
+
+                       if ($ServicePrincipalParams.CertThumbprintParams) {
+                           $TokenData.EXOAccessToken = Get-MsalAccessToken `
+                               -Scope $EXOScope `
+                               -CertificateThumbprint $ServicePrincipalParams.CertThumbprintParams.CertificateThumbprint `
+                               -AppID $ServicePrincipalParams.CertThumbprintParams.AppID `
+                               -Tenant $ServicePrincipalParams.CertThumbprintParams.Organization `
+                               -M365Environment $M365Environment
+                       }
+                       else {
+                           # Microsoft Exchange Online Remote PowerShell well-known client ID
+                           $EXOClientId = "fb78d390-0c51-40cd-8e17-fdbfab77341b"
+                           $TokenData.EXOAccessToken = Get-MsalAccessToken `
+                               -Scope $EXOScope `
+                               -ClientId $EXOClientId `
+                               -Tenant $TenantName `
+                               -M365Environment $M365Environment
+                       }
+
+                       # Resolve the EXO API endpoint (handles redirects)
+                       $TenantId = (Invoke-GraphDirectly -Commandlet Get-MgBetaOrganization -M365Environment $M365Environment).Value.Id
+                       $TokenData.EXOApiEndpoint = Get-ExchangeOnlineApiEndpoint `
+                           -TenantId $TenantId `
+                           -TenantDomain $TenantName `
+                           -M365Environment $M365Environment `
+                           -AccessToken $TokenData.EXOAccessToken
+
+                       Write-Verbose "Exchange Online token and endpoint acquired successfully"
                        $EXOAuthRequired = $false
                    }
                }
@@ -348,6 +393,8 @@
        PPBaseUrl       = $TokenData.PPBaseUrl
        PBIAccessToken  = $TokenData.PBIAccessToken
        PBIBaseUrl      = $TokenData.PBIBaseUrl
+       EXOAccessToken  = $TokenData.EXOAccessToken
+       EXOApiEndpoint  = $TokenData.EXOApiEndpoint
    }
 }
 
@@ -408,7 +455,8 @@ function Disconnect-SCuBATenant {
                if($Product -eq "securitysuite") {
                    Disconnect-MgGraph -ErrorAction SilentlyContinue | Out-Null
                }
-               Disconnect-ExchangeOnline -Confirm:$false -ErrorAction SilentlyContinue -InformationAction SilentlyContinue | Out-Null
+               # EXO now uses REST API with on-demand token - no persistent connection to disconnect
+               Disconnect-MgGraph -ErrorAction SilentlyContinue | Out-Null
            }
            else {
                Write-Warning "Product $Product not recognized, skipping..."

--- a/PowerShell/ScubaGear/Modules/Connection/Connection.psm1
+++ b/PowerShell/ScubaGear/Modules/Connection/Connection.psm1
@@ -147,6 +147,15 @@
                            -M365Environment $M365Environment `
                            -AccessToken $TokenData.EXOAccessToken
 
+                       # Also establish an EXO module session so that EXO management cmdlets
+                       # (e.g. Set-TransportConfig, New-SharingPolicy) are available for
+                       # functional test setup/teardown and Defender baseline checks.
+                       $EXOHelperParams = @{ M365Environment = $M365Environment }
+                       if ($ServicePrincipalParams.CertThumbprintParams) {
+                           $EXOHelperParams += @{ ServicePrincipalParams = $ServicePrincipalParams }
+                       }
+                       Connect-EXOHelper @EXOHelperParams
+
                        Write-Verbose "Exchange Online token and endpoint acquired successfully"
                        $EXOAuthRequired = $false
                    }

--- a/PowerShell/ScubaGear/Modules/Connection/Connection.psm1
+++ b/PowerShell/ScubaGear/Modules/Connection/Connection.psm1
@@ -147,14 +147,15 @@
                            -M365Environment $M365Environment `
                            -AccessToken $TokenData.EXOAccessToken
 
-                       # Also establish an EXO module session so that EXO management cmdlets
-                       # (e.g. Set-TransportConfig, New-SharingPolicy) are available for
-                       # functional test setup/teardown and Defender baseline checks.
-                       $EXOHelperParams = @{ M365Environment = $M365Environment }
-                       if ($ServicePrincipalParams.CertThumbprintParams) {
-                           $EXOHelperParams += @{ ServicePrincipalParams = $ServicePrincipalParams }
+                       # EXO product checks use REST; only establish an EXO module session
+                       # when Security Suite is part of the requested product list.
+                       if ($ProductNames -contains "securitysuite") {
+                           $EXOHelperParams = @{ M365Environment = $M365Environment }
+                           if ($ServicePrincipalParams.CertThumbprintParams) {
+                               $EXOHelperParams += @{ ServicePrincipalParams = $ServicePrincipalParams }
+                           }
+                           Connect-EXOHelper @EXOHelperParams
                        }
-                       Connect-EXOHelper @EXOHelperParams
 
                        Write-Verbose "Exchange Online token and endpoint acquired successfully"
                        $EXOAuthRequired = $false

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -583,7 +583,7 @@ function Invoke-SCuBA {
             M365Environment = $ScubaConfig.M365Environment
         }
 
-        $TenantDetails = Get-TenantDetail -ProductNames $ScubaConfig.ProductNames -M365Environment $ScubaConfig.M365Environment
+        $TenantDetails = Get-TenantDetail -ProductNames $ScubaConfig.ProductNames -M365Environment $ScubaConfig.M365Environment -ConnectionResult $ConnectionResult
         Write-ScubaLog -Message "Tenant details retrieved successfully" -Level "Debug" -Source "InvokeScuba"
 
         # Generate a GUID to uniquely identify the output JSON
@@ -851,7 +851,13 @@ function Invoke-ProviderList {
                             $RetVal = Export-AADProvider -M365Environment $ScubaConfig.M365Environment | Select-Object -Last 1
                         }
                         "exo" {
-                            $RetVal = Export-EXOProvider -PreferredDnsResolvers $ScubaConfig.PreferredDnsResolvers -SkipDoH $ScubaConfig.SkipDoH | Select-Object -Last 1
+                            $EXOProviderParams = @{
+                                'PreferredDnsResolvers' = $ScubaConfig.PreferredDnsResolvers
+                                'SkipDoH'              = $ScubaConfig.SkipDoH
+                                'AccessToken'          = $ConnectionResult.EXOAccessToken
+                                'ApiEndpoint'          = $ConnectionResult.EXOApiEndpoint
+                            }
+                            $RetVal = Export-EXOProvider @EXOProviderParams | Select-Object -Last 1
                         }
                         "securitysuite" {
                             $RetVal = Export-SecuritySuiteProvider @ConnectTenantParams  | Select-Object -Last 1
@@ -1717,7 +1723,11 @@ function Get-TenantDetail {
         [ValidateSet("commercial", "gcc", "gcchigh", "dod", IgnoreCase = $false)]
         [ValidateNotNullOrEmpty()]
         [string]
-        $M365Environment
+        $M365Environment,
+
+        [Parameter(Mandatory = $false)]
+        [hashtable]
+        $ConnectionResult = @{}
     )
 
     # organized by best tenant details information
@@ -1737,10 +1747,14 @@ function Get-TenantDetail {
         Get-AADTenantDetail -M365Environment $M365Environment
     }
     elseif ($ProductNames.Contains("exo")) {
-        Get-EXOTenantDetail -M365Environment $M365Environment
+        Get-EXOTenantDetail -M365Environment $M365Environment `
+            -AccessToken $ConnectionResult.EXOAccessToken `
+            -ApiEndpoint $ConnectionResult.EXOApiEndpoint
     }
     elseif ($ProductNames.Contains("securitysuite")) {
-        Get-EXOTenantDetail -M365Environment $M365Environment
+        Get-EXOTenantDetail -M365Environment $M365Environment `
+            -AccessToken $ConnectionResult.EXOAccessToken `
+            -ApiEndpoint $ConnectionResult.EXOApiEndpoint
     }
     else {
         $TenantInfo = @{

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -1828,7 +1828,6 @@ function Compare-ProductList {
 
         [Parameter(Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
-        [ValidateSet("teams", "exo", "defender", "aad", "powerbi", "powerplatform", "sharepoint", '*', IgnoreCase = $false)]
         [ValidateSet("teams", "exo", "securitysuite", "aad", "powerplatform", "sharepoint", "powerbi", '*', IgnoreCase = $false)]
         [string[]]
         $ProductNames,

--- a/PowerShell/ScubaGear/Modules/Providers/ExportEXOProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportEXOProvider.psm1
@@ -2,7 +2,7 @@ function Export-EXOProvider {
     <#
     .Description
     Gets the Exchange Online (EXO) settings that are relevant
-    to the SCuBA EXO baselines using the EXO PowerShell Module
+    to the SCuBA EXO baselines using direct REST API calls.
     .Functionality
     Internal
     #>
@@ -18,25 +18,31 @@ function Export-EXOProvider {
         [Parameter(Mandatory = $true)]
         [ValidateSet($true, $false)]
         [boolean]
-        $SkipDoH
+        $SkipDoH,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $AccessToken,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $ApiEndpoint
     )
 
-    # Manually importing the module name here to bypass cmdlet name conflicts
-    # There are conflicting PowerShell Cmdlet names in EXO and Power Platform
-    Import-Module ExchangeOnlineManagement
-
-    Import-Module $PSScriptRoot/ProviderHelpers/CommandTracker.psm1
+    $HelperFolderPath = Join-Path -Path $PSScriptRoot -ChildPath "ProviderHelpers"
+    Import-Module (Join-Path -Path $HelperFolderPath -ChildPath "CommandTracker.psm1")
+    Import-Module (Join-Path -Path $HelperFolderPath -ChildPath "EXORestHelper.psm1")
     $Tracker = Get-CommandTracker
 
     <#
     MS.EXO.1.1v2
     #>
-    $RemoteDomains = ConvertTo-Json @($Tracker.TryCommand("Get-RemoteDomain"))
+    $RemoteDomains = ConvertTo-Json @($Tracker.TryCommand("Invoke-EXORestMethod", @{CmdletName = "Get-RemoteDomain"; ApiEndpoint = $ApiEndpoint; AccessToken = $AccessToken}))
 
     <#
     MS.EXO.2.2v3 SPF
     #>
-    $AcceptedDomains = $Tracker.TryCommand("Get-AcceptedDomain")
+    $AcceptedDomains = $Tracker.TryCommand("Invoke-EXORestMethod", @{CmdletName = "Get-AcceptedDomain"; ApiEndpoint = $ApiEndpoint; AccessToken = $AccessToken})
     $SPFRecords = ConvertTo-Json @($Tracker.TryCommand("Get-ScubaSpfRecord", @{
         "Domains"=$AcceptedDomains;
         "PreferredDnsResolvers"=$PreferredDnsResolvers;
@@ -46,7 +52,7 @@ function Export-EXOProvider {
     <#
     MS.EXO.3.1v1 DKIM
     #>
-    $DKIMConfig = ConvertTo-Json @($Tracker.TryCommand("Get-DkimSigningConfig"))
+    $DKIMConfig = ConvertTo-Json @($Tracker.TryCommand("Invoke-EXORestMethod", @{CmdletName = "Get-DkimSigningConfig"; ApiEndpoint = $ApiEndpoint; AccessToken = $AccessToken}))
     $DKIMRecords = ConvertTo-Json @($Tracker.TryCommand("Get-ScubaDkimRecord", @{
         "Domains"=$AcceptedDomains;
         "PreferredDnsResolvers"=$PreferredDnsResolvers;
@@ -65,17 +71,17 @@ function Export-EXOProvider {
     <#
     MS.EXO.5.1v1
     #>
-    $TransportConfig = ConvertTo-Json @($Tracker.TryCommand("Get-TransportConfig"))
+    $TransportConfig = ConvertTo-Json @($Tracker.TryCommand("Invoke-EXORestMethod", @{CmdletName = "Get-TransportConfig"; ApiEndpoint = $ApiEndpoint; AccessToken = $AccessToken}))
 
     <#
     MS.EXO.6.1v1
     #>
-    $SharingPolicy = ConvertTo-Json @($Tracker.TryCommand("Get-SharingPolicy"))
+    $SharingPolicy = ConvertTo-Json @($Tracker.TryCommand("Invoke-EXORestMethod", @{CmdletName = "Get-SharingPolicy"; ApiEndpoint = $ApiEndpoint; AccessToken = $AccessToken}))
 
     <#
     MS.EXO.7.1v1
     #>
-    $TransportRules = ConvertTo-Json @($Tracker.TryCommand("Get-TransportRule"))
+    $TransportRules = ConvertTo-Json @($Tracker.TryCommand("Invoke-EXORestMethod", @{CmdletName = "Get-TransportRule"; ApiEndpoint = $ApiEndpoint; AccessToken = $AccessToken}))
 
     <#
     MS.EXO.13.1v1
@@ -96,14 +102,14 @@ function Export-EXOProvider {
         "ActivityBasedAuthenticationTimeoutInterval",
         "BookingsEnabled"
     )
-    $Config = $Tracker.TryCommand("Get-OrganizationConfig") | Select-Object $OrgConfigProperties
+    $Config = $Tracker.TryCommand("Invoke-EXORestMethod", @{CmdletName = "Get-OrganizationConfig"; ApiEndpoint = $ApiEndpoint; AccessToken = $AccessToken}) | Select-Object $OrgConfigProperties
     $Config = ConvertTo-Json @($Config)
 
     # Hybrid / connector configuration
-    $InboundConnectors = ConvertTo-Json @($Tracker.TryCommand("Get-InboundConnector")) -Depth 4
-    $OutboundConnectors = ConvertTo-Json @($Tracker.TryCommand("Get-OutboundConnector")) -Depth 4
-    $IntraOrgConnectors = ConvertTo-Json @($Tracker.TryCommand("Get-IntraOrganizationConnector")) -Depth 4
-    $OrgRelationships = ConvertTo-Json @($Tracker.TryCommand("Get-OrganizationRelationship")) -Depth 4
+    $InboundConnectors = ConvertTo-Json @($Tracker.TryCommand("Invoke-EXORestMethod", @{CmdletName = "Get-InboundConnector"; ApiEndpoint = $ApiEndpoint; AccessToken = $AccessToken})) -Depth 4
+    $OutboundConnectors = ConvertTo-Json @($Tracker.TryCommand("Invoke-EXORestMethod", @{CmdletName = "Get-OutboundConnector"; ApiEndpoint = $ApiEndpoint; AccessToken = $AccessToken})) -Depth 4
+    $IntraOrgConnectors = ConvertTo-Json @($Tracker.TryCommand("Invoke-EXORestMethod", @{CmdletName = "Get-IntraOrganizationConnector"; ApiEndpoint = $ApiEndpoint; AccessToken = $AccessToken})) -Depth 4
+    $OrgRelationships = ConvertTo-Json @($Tracker.TryCommand("Invoke-EXORestMethod", @{CmdletName = "Get-OrganizationRelationship"; ApiEndpoint = $ApiEndpoint; AccessToken = $AccessToken})) -Depth 4
 
     # Convert accepted domains to JSON format AFTER its used in Get-ScubaSpfRecord, Get-ScubaDkimRecord, and Get-ScubaDmarcRecord methods.
     # We want to store the accepted domain values to check for the "IsCoexistenceDomain" property.
@@ -139,7 +145,7 @@ function Export-EXOProvider {
 function Get-EXOTenantDetail {
     <#
     .Description
-    Gets the tenant details using the EXO PowerShell Module
+    Gets the tenant details using the EXO REST API
     .Functionality
     Internal
     #>
@@ -149,11 +155,23 @@ function Get-EXOTenantDetail {
         [ValidateSet("commercial", "gcc", "gcchigh", "dod", IgnoreCase = $false)]
         [ValidateNotNullOrEmpty()]
         [string]
-        $M365Environment
+        $M365Environment,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $AccessToken,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $ApiEndpoint
     )
     try {
-        Import-Module ExchangeOnlineManagement
-        $OrgConfig = Get-OrganizationConfig -ErrorAction "Stop"
+        Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "ProviderHelpers/EXORestHelper.psm1")
+        $OrgConfig = Invoke-EXORestMethod -CmdletName "Get-OrganizationConfig" -ApiEndpoint $ApiEndpoint -AccessToken $AccessToken
+        # Handle array result from the API
+        if ($OrgConfig -is [array]) {
+            $OrgConfig = $OrgConfig[0]
+        }
         $DomainName = $OrgConfig.Name
         $TenantId = "Error retrieving Tenant ID"
         $Uri = "https://login.microsoftonline.com/$($DomainName)/.well-known/openid-configuration"

--- a/PowerShell/ScubaGear/Modules/Providers/ProviderHelpers/CommandTracker.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ProviderHelpers/CommandTracker.psm1
@@ -30,6 +30,8 @@ class CommandTracker {
         $TrackedCommand = $Command
         $Result = @()
 
+        # EXO REST calls are executed through a shared wrapper, but downstream report logic
+        # expects the underlying EXO cmdlet name when checking command dependencies.
         if ($Command -eq "Invoke-EXORestMethod" -and $CommandArgs.ContainsKey("CmdletName") -and -not [string]::IsNullOrWhiteSpace($CommandArgs.CmdletName)) {
             $TrackedCommand = $CommandArgs.CmdletName
         }

--- a/PowerShell/ScubaGear/Modules/Providers/ProviderHelpers/CommandTracker.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ProviderHelpers/CommandTracker.psm1
@@ -27,7 +27,12 @@ class CommandTracker {
         }
 
         $isGraphDirect = $false
+        $TrackedCommand = $Command
         $Result = @()
+
+        if ($Command -eq "Invoke-EXORestMethod" -and $CommandArgs.ContainsKey("CmdletName") -and -not [string]::IsNullOrWhiteSpace($CommandArgs.CmdletName)) {
+            $TrackedCommand = $CommandArgs.CmdletName
+        }
 
         # Pre-process command arguments
         if ($CommandArgs.ContainsKey("GraphDirect")) {
@@ -64,7 +69,7 @@ class CommandTracker {
                 }
             }
 
-            $this.SuccessfulCommands += $Command
+            $this.SuccessfulCommands += $TrackedCommand
         }
         catch {
             if (-not $SuppressWarning) {
@@ -78,7 +83,7 @@ class CommandTracker {
                 StackTrace = $_.ScriptStackTrace
             }
 
-            $this.UnSuccessfulCommands += $Command
+            $this.UnSuccessfulCommands += $TrackedCommand
             $Result = @()
         }
 

--- a/PowerShell/ScubaGear/Modules/Providers/ProviderHelpers/CommandTracker.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ProviderHelpers/CommandTracker.psm1
@@ -2,6 +2,7 @@ Import-Module -Name $PSScriptRoot/../ExportEXOProvider.psm1 -Function Get-ScubaS
 Import-Module -Name $PSScriptRoot/../ExportAADProvider.psm1 -Function Get-PrivilegedRole, Get-PrivilegedUser
 Import-Module -Name $PSScriptRoot/AADRiskyPermissionsHelper.psm1 -Function Get-ApplicationsWithRiskyPermissions, Get-ServicePrincipalsWithRiskyPermissions, Format-RiskyApplications, Format-RiskyThirdPartyServicePrincipals, Get-ServicePrincipalsWithRiskyDelegatedPermissionClassifications
 Import-Module -Name $PSScriptRoot/AADHybridExchangeHelper.psm1 -Function Get-LegacyExchangeServicePrincipal, Get-DedicatedExchangeHybridApplications
+Import-Module -Name $PSScriptRoot/EXORestHelper.psm1 -Function Invoke-EXORestMethod
 Import-Module -Name $PSScriptRoot/PowerPlatformRestHelper.psm1 -Function Get-PowerPlatformTenantSettingsRest, Get-PowerPlatformEnvironmentsRest, Get-PowerPlatformDlpPoliciesRest, Get-PowerPlatformTenantIsolationRest
 Import-Module -Name $PSScriptRoot/SPORestHelper.psm1 -Function Get-SPOTenantRest
 Import-Module -Name $PSScriptRoot/../../Utility/Utility.psm1 -Function Invoke-GraphDirectly, ConvertFrom-GraphHashtable

--- a/PowerShell/ScubaGear/Modules/Providers/ProviderHelpers/EXORestHelper.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ProviderHelpers/EXORestHelper.psm1
@@ -81,27 +81,57 @@ function Get-ExchangeOnlineApiEndpoint {
         "X-AnchorMailbox" = "UPN:SystemMailbox{bb558c35-97f1-4cb9-8ff7-d53741dc928c}@$TenantDomain"
     }
 
+    $DefaultInvokeEndpoint = "$AdminApiFrontDoorBaseUri/adminapi/beta/$TenantId/InvokeCommand"
+
+    $Handler = $null
+    $HttpClient = $null
+    $Request = $null
+    $Response = $null
+
     try {
         $FrontDoorEndpoint = "$AdminApiFrontDoorBaseUri/AdminApi/v1.0/$TenantId/EXOModuleFile"
-        $Response = Invoke-WebRequest `
-            -Uri $FrontDoorEndpoint `
-            -Method Get `
-            -MaximumRedirection 0 `
-            -UseBasicParsing `
-            -Headers $Headers `
-            -ErrorAction SilentlyContinue
+        $Handler = [System.Net.Http.HttpClientHandler]::new()
+        $Handler.AllowAutoRedirect = $false
+        $HttpClient = [System.Net.Http.HttpClient]::new($Handler)
+        $Request = [System.Net.Http.HttpRequestMessage]::new([System.Net.Http.HttpMethod]::Get, $FrontDoorEndpoint)
 
-        if ($Response.StatusCode -eq 302) {
-            $RedirectUri = [Uri]$Response.Headers["Location"]
+        foreach ($Header in $Headers.GetEnumerator()) {
+            $null = $Request.Headers.TryAddWithoutValidation($Header.Key, $Header.Value)
+        }
+
+        $Response = $HttpClient.SendAsync(
+            $Request,
+            [System.Net.Http.HttpCompletionOption]::ResponseHeadersRead
+        ).GetAwaiter().GetResult()
+
+        if ((([int]$Response.StatusCode) -ge 300) -and (([int]$Response.StatusCode) -lt 400) -and $Response.Headers.Location) {
+            $RedirectUri = $Response.Headers.Location
+            if (-not $RedirectUri.IsAbsoluteUri) {
+                $RedirectUri = [Uri]::new([Uri]$AdminApiFrontDoorBaseUri, $RedirectUri)
+            }
             $Prefix = $RedirectUri.Host.Split('.')[0]
             return "https://$Prefix$BackendSuffix/adminapi/beta/$TenantId/InvokeCommand"
         }
         else {
-            return "$AdminApiFrontDoorBaseUri/adminapi/beta/$TenantId/InvokeCommand"
+            return $DefaultInvokeEndpoint
         }
     }
     catch {
         throw "Failed to resolve Exchange Online API endpoint: $($_.Exception.Message)"
+    }
+    finally {
+        if ($Response) {
+            $Response.Dispose()
+        }
+        if ($Request) {
+            $Request.Dispose()
+        }
+        if ($HttpClient) {
+            $HttpClient.Dispose()
+        }
+        if ($Handler) {
+            $Handler.Dispose()
+        }
     }
 }
 

--- a/PowerShell/ScubaGear/Modules/Providers/ProviderHelpers/EXORestHelper.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ProviderHelpers/EXORestHelper.psm1
@@ -1,0 +1,170 @@
+Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "../../Utility/Utility.psm1") -Function Invoke-ScubaRestMethod
+
+function Get-ExchangeOnlineScope {
+    <#
+    .SYNOPSIS
+        Returns the OAuth2 scope for Exchange Online based on M365 environment.
+    .PARAMETER M365Environment
+        The M365 environment (commercial, gcc, gcchigh, dod).
+    .FUNCTIONALITY
+        Internal
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("commercial", "gcc", "gcchigh", "dod")]
+        [string]$M365Environment
+    )
+
+    $Scope = switch ($M365Environment.ToLower()) {
+        "commercial" { "https://outlook.office365.com/.default" }
+        "gcc"        { "https://outlook.office365.com/.default" }
+        "gcchigh"    { "https://outlook.office365.us/.default" }
+        "dod"        { "https://outlook-dod.office365.us/.default" }
+    }
+
+    return $Scope
+}
+
+function Get-ExchangeOnlineApiEndpoint {
+    <#
+    .SYNOPSIS
+        Dynamically resolves the Exchange Online Admin API endpoint URI.
+    .DESCRIPTION
+        Calls the Exchange Online front-door endpoint to determine the actual backend
+        API endpoint. Some tenants get redirected to a tenant-specific subdomain.
+        Returns a URI in the format:
+        https://<prefix>.outlook.office365.com/adminapi/beta/<TenantId>/InvokeCommand
+    .PARAMETER TenantId
+        The Azure AD tenant ID.
+    .PARAMETER TenantDomain
+        The tenant domain (e.g., contoso.onmicrosoft.com).
+    .PARAMETER M365Environment
+        The M365 environment (commercial, gcc, gcchigh, dod).
+    .PARAMETER AccessToken
+        The OAuth2 access token for Exchange Online.
+    .FUNCTIONALITY
+        Internal
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$TenantId,
+
+        [Parameter(Mandatory = $true)]
+        [string]$TenantDomain,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("commercial", "gcc", "gcchigh", "dod")]
+        [string]$M365Environment,
+
+        [Parameter(Mandatory = $true)]
+        [string]$AccessToken
+    )
+
+    $AdminApiFrontDoorBaseUri = switch ($M365Environment.ToLower()) {
+        "commercial" { "https://outlook.office365.com" }
+        "gcc"        { "https://outlook.office365.com" }
+        "gcchigh"    { "https://outlook.office365.us" }
+        "dod"        { "https://outlook-dod.office365.us" }
+    }
+
+    $BackendSuffix = switch ($M365Environment.ToLower()) {
+        "commercial" { ".outlook.office365.com" }
+        "gcc"        { ".outlook.office365.com" }
+        "gcchigh"    { ".outlook.office365.us" }
+        "dod"        { ".outlook-dod.office365.us" }
+    }
+
+    $Headers = @{
+        "Authorization"   = "Bearer $AccessToken"
+        "X-AnchorMailbox" = "UPN:SystemMailbox{bb558c35-97f1-4cb9-8ff7-d53741dc928c}@$TenantDomain"
+    }
+
+    try {
+        $FrontDoorEndpoint = "$AdminApiFrontDoorBaseUri/AdminApi/v1.0/$TenantId/EXOModuleFile"
+        $Response = Invoke-WebRequest `
+            -Uri $FrontDoorEndpoint `
+            -Method Get `
+            -MaximumRedirection 0 `
+            -UseBasicParsing `
+            -Headers $Headers `
+            -ErrorAction SilentlyContinue
+
+        if ($Response.StatusCode -eq 302) {
+            $RedirectUri = [Uri]$Response.Headers["Location"]
+            $Prefix = $RedirectUri.Host.Split('.')[0]
+            return "https://$Prefix$BackendSuffix/adminapi/beta/$TenantId/InvokeCommand"
+        }
+        else {
+            return "$AdminApiFrontDoorBaseUri/adminapi/beta/$TenantId/InvokeCommand"
+        }
+    }
+    catch {
+        throw "Failed to resolve Exchange Online API endpoint: $($_.Exception.Message)"
+    }
+}
+
+function Invoke-EXORestMethod {
+    <#
+    .SYNOPSIS
+        Invokes an Exchange Online cmdlet via the Admin REST API.
+    .DESCRIPTION
+        Calls the Exchange Online AdminApi InvokeCommand endpoint with the specified
+        cmdlet name. The backend API expects the cmdlet name as a parameter in the
+        request body and returns the results as JSON.
+    .PARAMETER CmdletName
+        The Exchange Online cmdlet to invoke (e.g., "Get-RemoteDomain", "Get-OrganizationConfig").
+    .PARAMETER ApiEndpoint
+        The fully-qualified InvokeCommand endpoint URI.
+    .PARAMETER AccessToken
+        The OAuth2 access token for Exchange Online.
+    .PARAMETER Parameters
+        Optional hashtable of parameters to pass to the cmdlet.
+    .FUNCTIONALITY
+        Internal
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$CmdletName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ApiEndpoint,
+
+        [Parameter(Mandatory = $true)]
+        [string]$AccessToken,
+
+        [Parameter(Mandatory = $false)]
+        [hashtable]$Parameters = @{}
+    )
+
+    $Headers = @{
+        "Authorization"     = "Bearer $AccessToken"
+        "Prefer"            = "odata.maxpagesize=1000"
+        "X-ResponseFormat"  = "json"
+        "client-request-id" = [guid]::NewGuid().ToString()
+        "User-Agent"        = "ScubaGear"
+    }
+
+    $Body = @{
+        CmdletInput = @{
+            CmdletName = $CmdletName
+            Parameters = $Parameters
+        }
+    } | ConvertTo-Json -Depth 5
+
+    try {
+        $Response = Invoke-RestMethod -Method POST -Uri $ApiEndpoint -Headers $Headers -Body $Body -ContentType "application/json"
+        return $Response.value
+    }
+    catch {
+        throw "Exchange Online API call '$CmdletName' failed: $($_.Exception.Message)"
+    }
+}
+
+Export-ModuleMember -Function @(
+    'Get-ExchangeOnlineScope',
+    'Get-ExchangeOnlineApiEndpoint',
+    'Invoke-EXORestMethod'
+)

--- a/PowerShell/ScubaGear/RequiredVersions.ps1
+++ b/PowerShell/ScubaGear/RequiredVersions.ps1
@@ -31,5 +31,3 @@ $ModuleList = @(
 )
 
 
-
-

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Connection/Connect-Tenant.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Connection/Connect-Tenant.Tests.ps1
@@ -35,6 +35,8 @@ InModuleScope Connection {
             }
             function Get-MsalAccessToken {throw 'this will be mocked'}
             Mock Get-MsalAccessToken -MockWith { return "mock-access-token" }
+            function Connect-EXOHelper {throw 'this will be mocked'}
+            Mock Connect-EXOHelper -MockWith {}
             Mock -CommandName Write-Progress {
             }
         }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Connection/Connect-Tenant.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Connection/Connect-Tenant.Tests.ps1
@@ -41,12 +41,12 @@ InModuleScope Connection {
             }
         }
         Context 'With Endpoint:  <Endpoint>; ProductNames: <ProductNames>' -ForEach @(
-            @{ProductNames = "aad"; Services = @('Connect-GraphHelper')}
-            @{ProductNames = "securitysuite"; Services = @('Get-MsalAccessToken')}
-            @{ProductNames = "exo"; Services = @('Get-MsalAccessToken')}
-            @{ProductNames = "powerplatform"; Services = @('Connect-GraphHelper')}
-            @{ProductNames = "sharepoint"; Services = @('Connect-GraphHelper')}  # SharePoint uses REST API, only needs Graph for tenant info
-            @{ProductNames = "teams"; Services = @('Connect-MicrosoftTeams')}
+            @{ProductNames = "aad"; Services = @('Connect-GraphHelper'); EXOHelperCalls = 0}
+            @{ProductNames = "securitysuite"; Services = @('Get-MsalAccessToken'); EXOHelperCalls = 1}
+            @{ProductNames = "exo"; Services = @('Get-MsalAccessToken'); EXOHelperCalls = 0}
+            @{ProductNames = "powerplatform"; Services = @('Connect-GraphHelper'); EXOHelperCalls = 0}
+            @{ProductNames = "sharepoint"; Services = @('Connect-GraphHelper'); EXOHelperCalls = 0}  # SharePoint uses REST API, only needs Graph for tenant info
+            @{ProductNames = "teams"; Services = @('Connect-MicrosoftTeams'); EXOHelperCalls = 0}
             @{
                 ProductNames = "aad", "securitysuite", "exo", "powerplatform", "sharepoint", "teams"
                 Services = @(
@@ -54,6 +54,7 @@ InModuleScope Connection {
                     'Get-MsalAccessToken',
                     'Connect-MicrosoftTeams'
                 )
+                EXOHelperCalls = 1
             }
 
         ){
@@ -75,6 +76,7 @@ InModuleScope Connection {
                 foreach ($Service in $Services){
                     Should -Invoke -CommandName $Service -Times 1 -Because "only want to authenticate to needed service once"
                 }
+                Should -Invoke -CommandName 'Connect-EXOHelper' -Times $EXOHelperCalls
             }
 
         }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Connection/Connect-Tenant.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Connection/Connect-Tenant.Tests.ps1
@@ -15,8 +15,10 @@ InModuleScope Connection {
             # SharePoint now uses REST API - no PnP/SPO connection needed
             function Connect-MicrosoftTeams{throw 'this will be mocked'}
             Mock Connect-MicrosoftTeams -MockWith {}
-            function Connect-EXOHelper {throw 'this will be mocked'}
-            Mock -ModuleName Connection Connect-EXOHelper -MockWith {}
+            function Get-ExchangeOnlineApiEndpoint {throw 'this will be mocked'}
+            Mock Get-ExchangeOnlineApiEndpoint -MockWith { return "https://mock.outlook.office365.com/adminapi/beta/TenantId/InvokeCommand" }
+            function Get-ExchangeOnlineScope {throw 'this will be mocked'}
+            Mock Get-ExchangeOnlineScope -MockWith { return "https://outlook.office365.com/.default" }
             function Invoke-GraphDirectly {throw 'this will be mocked'}
             Mock Invoke-GraphDirectly -MockWith {
                 return [pscustomobject]@{
@@ -38,8 +40,8 @@ InModuleScope Connection {
         }
         Context 'With Endpoint:  <Endpoint>; ProductNames: <ProductNames>' -ForEach @(
             @{ProductNames = "aad"; Services = @('Connect-GraphHelper')}
-            @{ProductNames = "securitysuite"; Services = @('Connect-EXOHelper')}
-            @{ProductNames = "exo"; Services = @('Connect-EXOHelper')}
+            @{ProductNames = "securitysuite"; Services = @('Get-MsalAccessToken')}
+            @{ProductNames = "exo"; Services = @('Get-MsalAccessToken')}
             @{ProductNames = "powerplatform"; Services = @('Connect-GraphHelper')}
             @{ProductNames = "sharepoint"; Services = @('Connect-GraphHelper')}  # SharePoint uses REST API, only needs Graph for tenant info
             @{ProductNames = "teams"; Services = @('Connect-MicrosoftTeams')}
@@ -47,7 +49,7 @@ InModuleScope Connection {
                 ProductNames = "aad", "securitysuite", "exo", "powerplatform", "sharepoint", "teams"
                 Services = @(
                     'Connect-GraphHelper',
-                    'Connect-EXOHelper',
+                    'Get-MsalAccessToken',
                     'Connect-MicrosoftTeams'
                 )
             }
@@ -69,7 +71,7 @@ InModuleScope Connection {
                 }
                 Connect-Tenant -ProductNames $ProductNames -M365Environment $Endpoint -ServicePrincipalParams $ServicePrincipalParams
                 foreach ($Service in $Services){
-                    Should -Invoke -CommandName $Service -Exactly -Times 1 -Because "only want to authenticate to needed service once"
+                    Should -Invoke -CommandName $Service -Times 1 -Because "only want to authenticate to needed service once"
                 }
             }
 

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Connection/Disconnect-SCuBATenant.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Connection/Disconnect-SCuBATenant.Tests.ps1
@@ -8,8 +8,7 @@ InModuleScope Connection {
         BeforeAll {
             function Disconnect-MgGraph {throw 'this will be mocked'}
             Mock -ModuleName Connection Disconnect-MgGraph {}
-            function Disconnect-ExchangeOnline {throw 'this will be mocked'}
-            Mock -ModuleName Connection Disconnect-ExchangeOnline {}
+            # EXO now uses REST API - no ExchangeOnline module disconnect needed
             # SharePoint uses REST API - no SPO module disconnect needed
             function Remove-PowerAppsAccount {throw 'this will be mocked'}
             Mock  -ModuleName Connection Remove-PowerAppsAccount {}
@@ -23,7 +22,8 @@ InModuleScope Connection {
         }
         It 'Disconnects from Exchange Online' {
             Disconnect-SCuBATenant -ProductNames 'exo'
-            Should -Invoke -ModuleName Connection -CommandName Disconnect-ExchangeOnline -Times 1 -Exactly
+            # EXO now uses REST API - disconnect only cleans up Graph session
+            Should -Invoke -ModuleName Connection -CommandName Disconnect-MgGraph -Times 1 -Exactly
         }
         It 'Disconnects from Security Suite (Exchange Online and Security & Compliance)' {
             {Disconnect-SCuBATenant -ProductNames 'securitysuite'} | Should -Not -Throw

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/EXOProvider/Export-EXOProvider.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/EXOProvider/Export-EXOProvider.Tests.ps1
@@ -19,19 +19,11 @@ InModuleScope -ModuleName ExportEXOProvider {
                     # This is where you decide where you mock functions called by CommandTracker :)
                     try {
                         switch ($Command) {
-                            "Get-RemoteDomain" {
-                                $this.SuccessfulCommands += $Command
-                                return [pscustomobject]@{}
-                            }
-                            "Get-AcceptedDomain" {
+                            "Invoke-EXORestMethod" {
                                 $this.SuccessfulCommands += $Command
                                 return [pscustomobject]@{}
                             }
                             "Get-ScubaSpfRecord" {
-                                $this.SuccessfulCommands += $Command
-                                return [pscustomobject]@{}
-                            }
-                            "Get-DkimSigningConfig" {
                                 $this.SuccessfulCommands += $Command
                                 return [pscustomobject]@{}
                             }
@@ -40,42 +32,6 @@ InModuleScope -ModuleName ExportEXOProvider {
                                 return [pscustomobject]@{}
                             }
                             "Get-ScubaDmarcRecord" {
-                                $this.SuccessfulCommands += $Command
-                                return [pscustomobject]@{}
-                            }
-                            "Get-TransportConfig" {
-                                $this.SuccessfulCommands += $Command
-                                return [pscustomobject]@{}
-                            }
-                            "Get-SharingPolicy" {
-                                $this.SuccessfulCommands += $Command
-                                return [pscustomobject]@{}
-                            }
-                            "Get-TransportRule" {
-                                $this.SuccessfulCommands += $Command
-                                return [pscustomobject]@{}
-                            }
-                            "Get-HostedConnectionFilterPolicy" {
-                                $this.SuccessfulCommands += $Command
-                                return [pscustomobject]@{}
-                            }
-                            "Get-OrganizationConfig" {
-                                $this.SuccessfulCommands += $Command
-                                return [pscustomobject]@{}
-                            }
-                            "Get-InboundConnector" {
-                                $this.SuccessfulCommands += $Command
-                                return [pscustomobject]@{}
-                            }
-                            "Get-OutboundConnector" {
-                                $this.SuccessfulCommands += $Command
-                                return [pscustomobject]@{}
-                            }
-                            "Get-IntraOrganizationConnector" {
-                                $this.SuccessfulCommands += $Command
-                                return [pscustomobject]@{}
-                            }
-                            "Get-OrganizationRelationship" {
                                 $this.SuccessfulCommands += $Command
                                 return [pscustomobject]@{}
                             }
@@ -138,7 +94,7 @@ InModuleScope -ModuleName ExportEXOProvider {
             }
         }
         It "When called, returns valid JSON" {
-            $Json = Export-EXOProvider -PreferredDnsResolvers @() -SkipDoH $false
+            $Json = Export-EXOProvider -PreferredDnsResolvers @() -SkipDoH $false -AccessToken "mock-token" -ApiEndpoint "https://mock.endpoint/InvokeCommand"
             $ValidJson = Test-SCuBAValidProviderJson -Json $Json | Select-Object -Last 1
             $ValidJson | Should -Be $true
         }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/EXOProvider/Get-EXOTenantDetail.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/EXOProvider/Get-EXOTenantDetail.Tests.ps1
@@ -5,9 +5,9 @@ InModuleScope ExportEXOProvider {
     Describe "Get-EXOTenantDetail" {
         BeforeAll {
             # empty stub required for mocked cmdlets called directly in the provider
-            function Get-OrganizationConfig {}
+            function Invoke-EXORestMethod {}
 
-            Mock -ModuleName ExportEXOProvider Get-OrganizationConfig {
+            Mock -ModuleName ExportEXOProvider Invoke-EXORestMethod {
                 return [pscustomobject]@{
                     Name = "name";
                     DisplayName = "DisplayName";
@@ -34,22 +34,22 @@ InModuleScope ExportEXOProvider {
             }
         }
         It "When called with -M365Environment 'commercial', returns valid JSON" {
-            $Json = Get-EXOTenantDetail -M365Environment "commercial"
+            $Json = Get-EXOTenantDetail -M365Environment "commercial" -AccessToken "mock-token" -ApiEndpoint "https://mock.endpoint/InvokeCommand"
             $ValidJson = Test-SCuBAValidJson -Json $Json | Select-Object -Last 1
             $ValidJson | Should -Be $true
         }
         It "When called with -M365Environment 'gcc', returns valid JSON" {
-            $Json = Get-EXOTenantDetail -M365Environment "gcc"
+            $Json = Get-EXOTenantDetail -M365Environment "gcc" -AccessToken "mock-token" -ApiEndpoint "https://mock.endpoint/InvokeCommand"
             $ValidJson = Test-SCuBAValidJson -Json $Json | Select-Object -Last 1
             $ValidJson | Should -Be $true
         }
         It "When called with -M365Environment 'gcchigh', returns valid JSON" {
-            $Json = Get-EXOTenantDetail -M365Environment "gcchigh"
+            $Json = Get-EXOTenantDetail -M365Environment "gcchigh" -AccessToken "mock-token" -ApiEndpoint "https://mock.endpoint/InvokeCommand"
             $ValidJson = Test-SCuBAValidJson -Json $Json | Select-Object -Last 1
             $ValidJson | Should -Be $true
         }
         It "When called with -M365Environment 'dod', returns valid JSON" {
-            $Json = Get-EXOTenantDetail -M365Environment "dod"
+            $Json = Get-EXOTenantDetail -M365Environment "dod" -AccessToken "mock-token" -ApiEndpoint "https://mock.endpoint/InvokeCommand"
             $ValidJson = Test-SCuBAValidJson -Json $Json | Select-Object -Last 1
             $ValidJson | Should -Be $true
         }

--- a/Testing/Functional/Products/FunctionalTestUtils.ps1
+++ b/Testing/Functional/Products/FunctionalTestUtils.ps1
@@ -454,8 +454,8 @@ function Set-ExoEnabledSharingPoliciesDomain {
   }
 
   # The Domains property may be returned as an array by EXO REST; check both forms.
-  # Use a long window (300 s) because GCC replica propagation can take several minutes.
-  Wait-FunctionalExoCondition -MaxAttempts 30 -DelaySeconds 10 -Condition {
+  # Use a long window (600 s) because GCC replica propagation can take several minutes.
+  Wait-FunctionalExoCondition -MaxAttempts 60 -DelaySeconds 10 -Condition {
     @(Get-SharingPolicy |
       Where-Object {
         (ConvertTo-FunctionalExoBoolean -Value $_.Enabled) -eq $true -and

--- a/Testing/Functional/Products/FunctionalTestUtils.ps1
+++ b/Testing/Functional/Products/FunctionalTestUtils.ps1
@@ -41,12 +41,17 @@ function Resolve-FunctionalExoIdentity {
     return $null
   }
 
-  # Prefer Name over Identity: the REST canonical identity path (e.g. "tenant\PolicyName")
-  # is often rejected by mutating cmdlets, while Name is consistently accepted.
+  # Prefer Guid: accepted by all EXO REST mutating endpoints in every cloud.
+  # Name alone causes 404 in commercial tenants (e.g. "FederatedSharing" rejected).
+  if (-not [string]::IsNullOrWhiteSpace([string]$InputObject.Guid)) {
+    return [string]$InputObject.Guid
+  }
+  if (-not [string]::IsNullOrWhiteSpace([string]$InputObject.ExchangeObjectId)) {
+    return [string]$InputObject.ExchangeObjectId
+  }
   if (-not [string]::IsNullOrWhiteSpace([string]$InputObject.Name)) {
     return [string]$InputObject.Name
   }
-
   if (-not [string]::IsNullOrWhiteSpace([string]$InputObject.Identity)) {
     return [string]$InputObject.Identity
   }
@@ -369,6 +374,11 @@ function Set-ExoRemoteDomainAutoForwardEnabled {
         }).Count -gt 0
     } -FailureMessage "Failed to observe at least one remote domain with AutoForwardEnabled=true after update."
   }
+
+  # Allow time for the write to propagate to all EXO backend replicas before
+  # ScubaGear's independent REST session reads tenant state. Without this,
+  # ScubaGear may read a replica that hasn't received the update yet.
+  Start-Sleep -Seconds 60
 }
 
 function Set-ExoTransportConfigSmtpClientAuthenticationDisabled {
@@ -433,7 +443,8 @@ function Set-ExoEnabledSharingPoliciesDomain {
   $Targets | Set-SharingPolicy -Domains $Domains
 
   # The Domains property may be returned as an array by EXO REST; check both forms.
-  Wait-FunctionalExoCondition -Condition {
+  # Use a long window (300 s) because GCC replica propagation can take several minutes.
+  Wait-FunctionalExoCondition -MaxAttempts 30 -DelaySeconds 10 -Condition {
     @(Get-SharingPolicy |
       Where-Object {
         (ConvertTo-FunctionalExoBoolean -Value $_.Enabled) -eq $true -and
@@ -505,10 +516,17 @@ function Set-ExoOrganizationAuditDisabled {
   }
   catch {
     # Some tenants (GCC/GCCH) lock the audit policy and reject this change
-    # via service-principal REST calls. Log a warning and continue so the
-    # test can still evaluate the tenant's current (immutable) state rather
-    # than crashing the entire test run.
+    # via service-principal REST calls. Log a warning and verify actual state.
     Write-Warning "Set-ExoOrganizationAuditDisabled: Could not set AuditDisabled=$AuditDisabled - $($_.Exception.Message). The tenant may not permit this change."
+  }
+
+  # Verify the actual state matches the desired state regardless of whether the
+  # call succeeded or was silently rejected. If not, throw so the test reports
+  # a clear environment-restriction error rather than a misleading assertion failure.
+  $ActualConfig = Invoke-FunctionalExoCommand -CmdletName 'Get-OrganizationConfig' | Select-Object -First 1
+  $ActualValue = ConvertTo-FunctionalExoBoolean -Value $ActualConfig.AuditDisabled
+  if ($ActualValue -ne $AuditDisabled) {
+    throw "Set-ExoOrganizationAuditDisabled: Tenant AuditDisabled is '$ActualValue' but '$AuditDisabled' was requested. Tenant policy prohibits this change - this test cannot complete in this environment."
   }
 }
 

--- a/Testing/Functional/Products/FunctionalTestUtils.ps1
+++ b/Testing/Functional/Products/FunctionalTestUtils.ps1
@@ -52,6 +52,60 @@ function Resolve-FunctionalExoIdentity {
   return $null
 }
 
+function ConvertTo-FunctionalExoBoolean {
+  param(
+    [Parameter(Mandatory = $false)]
+    [AllowNull()]
+    [object]$Value
+  )
+
+  if ($null -eq $Value) {
+    return $null
+  }
+
+  if ($Value -is [bool]) {
+    return [bool]$Value
+  }
+
+  $AsString = [string]$Value
+  if ([string]::IsNullOrWhiteSpace($AsString)) {
+    return $null
+  }
+
+  $Parsed = $false
+  if ([bool]::TryParse($AsString, [ref]$Parsed)) {
+    return $Parsed
+  }
+
+  return $null
+}
+
+function Wait-FunctionalExoCondition {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [scriptblock]$Condition,
+    [Parameter(Mandatory = $false)]
+    [int]$MaxAttempts = 10,
+    [Parameter(Mandatory = $false)]
+    [int]$DelaySeconds = 2,
+    [Parameter(Mandatory = $false)]
+    [string]$FailureMessage = 'Condition was not met in the expected time window.'
+  )
+
+  for ($Attempt = 1; $Attempt -le $MaxAttempts; $Attempt++) {
+    if (& $Condition) {
+      return
+    }
+
+    if ($Attempt -lt $MaxAttempts) {
+      Start-Sleep -Seconds $DelaySeconds
+    }
+  }
+
+  throw $FailureMessage
+}
+
 function Get-RemoteDomain {
   [CmdletBinding()]
   param()
@@ -95,6 +149,13 @@ function Set-TransportConfig {
   Invoke-FunctionalExoCommand -CmdletName 'Set-TransportConfig' -Parameters @{
     SmtpClientAuthenticationDisabled = $SmtpClientAuthenticationDisabled
   } | Out-Null
+}
+
+function Get-TransportConfig {
+  [CmdletBinding()]
+  param()
+
+  return Invoke-FunctionalExoCommand -CmdletName 'Get-TransportConfig'
 }
 
 function Get-SharingPolicy {
@@ -280,9 +341,18 @@ function Set-ExoRemoteDomainAutoForwardEnabled {
     [bool]$DesiredValue
   )
 
-  Get-RemoteDomain |
-    Where-Object { $_.AutoForwardEnabled -eq $CurrentValue } |
-    Set-RemoteDomain -AutoForwardEnabled $DesiredValue
+  $Targets = @(Get-RemoteDomain |
+      Where-Object { (ConvertTo-FunctionalExoBoolean -Value $_.AutoForwardEnabled) -eq $CurrentValue })
+
+  if ($Targets.Count -gt 0) {
+    $Targets | Set-RemoteDomain -AutoForwardEnabled $DesiredValue
+  }
+
+  Wait-FunctionalExoCondition -Condition {
+    @(Get-RemoteDomain | Where-Object {
+        (ConvertTo-FunctionalExoBoolean -Value $_.AutoForwardEnabled) -eq $DesiredValue
+      }).Count -gt 0
+  } -FailureMessage "Failed to observe remote domains with AutoForwardEnabled=$DesiredValue after update."
 }
 
 function Set-ExoTransportConfigSmtpClientAuthenticationDisabled {
@@ -293,6 +363,12 @@ function Set-ExoTransportConfigSmtpClientAuthenticationDisabled {
   )
 
   Set-TransportConfig -SmtpClientAuthenticationDisabled $SmtpClientAuthenticationDisabled
+
+  Wait-FunctionalExoCondition -Condition {
+    $Config = Get-TransportConfig | Select-Object -First 1
+    $CurrentValue = ConvertTo-FunctionalExoBoolean -Value $Config.SmtpClientAuthenticationDisabled
+    $CurrentValue -eq $SmtpClientAuthenticationDisabled
+  } -FailureMessage "Failed to observe SmtpClientAuthenticationDisabled=$SmtpClientAuthenticationDisabled after update."
 }
 
 function New-ExoSharingPolicy {
@@ -324,9 +400,22 @@ function Set-ExoEnabledSharingPoliciesDomain {
     [string]$Domains
   )
 
-  Get-SharingPolicy |
-    Where-Object { $_.Enabled -eq $true } |
-    Set-SharingPolicy -Domains $Domains
+  $Targets = @(Get-SharingPolicy |
+      Where-Object { (ConvertTo-FunctionalExoBoolean -Value $_.Enabled) -eq $true })
+
+  if ($Targets.Count -eq 0) {
+    throw 'Set-ExoEnabledSharingPoliciesDomain did not find any enabled sharing policies to update.'
+  }
+
+  $Targets | Set-SharingPolicy -Domains $Domains
+
+  Wait-FunctionalExoCondition -Condition {
+    @(Get-SharingPolicy |
+      Where-Object {
+        (ConvertTo-FunctionalExoBoolean -Value $_.Enabled) -eq $true -and
+        [string]$_.Domains -eq $Domains
+      }).Count -gt 0
+  } -FailureMessage "Failed to observe enabled sharing policies updated to Domains='$Domains'."
 }
 
 function Disable-ExoExternalSenderWarningRules {
@@ -334,7 +423,11 @@ function Disable-ExoExternalSenderWarningRules {
   param()
 
   Get-TransportRule |
-    Where-Object { $_.State -eq 'Enabled' -and $_.Mode -eq 'Enforce' -and $_.FromScope -eq 'NotInOrganization' } |
+    Where-Object {
+      [string]$_.State -eq 'Enabled' -and
+      [string]$_.Mode -eq 'Enforce' -and
+      [string]$_.FromScope -eq 'NotInOrganization'
+    } |
     Disable-TransportRule
 }
 
@@ -343,7 +436,11 @@ function Enable-ExoExternalSenderWarningRules {
   param()
 
   Get-TransportRule |
-    Where-Object { $_.State -eq 'Disabled' -and $_.Mode -eq 'Enforce' -and $_.FromScope -eq 'NotInOrganization' } |
+    Where-Object {
+      [string]$_.State -eq 'Disabled' -and
+      [string]$_.Mode -eq 'Enforce' -and
+      [string]$_.FromScope -eq 'NotInOrganization'
+    } |
     Enable-TransportRule
 }
 

--- a/Testing/Functional/Products/FunctionalTestUtils.ps1
+++ b/Testing/Functional/Products/FunctionalTestUtils.ps1
@@ -190,32 +190,6 @@ function New-SharingPolicy {
   }
 }
 
-function Set-SharingPolicy {
-  [CmdletBinding()]
-  param(
-    [Parameter(ValueFromPipeline = $true)]
-    [AllowNull()]
-    [object]$InputObject,
-    [Parameter(Mandatory = $false)]
-    [AllowNull()]
-    [string]$Identity,
-    [Parameter(Mandatory = $true)]
-    [string]$Domains
-  )
-
-  process {
-    $ResolvedIdentity = Resolve-FunctionalExoIdentity -InputObject $InputObject -Identity $Identity
-    if ([string]::IsNullOrWhiteSpace($ResolvedIdentity)) {
-      throw 'Set-SharingPolicy requires an Identity or piped object with Identity.'
-    }
-
-    Invoke-FunctionalExoCommand -CmdletName 'Set-SharingPolicy' -Parameters @{
-      Identity = $ResolvedIdentity
-      Domains = $Domains
-    } | Out-Null
-  }
-}
-
 function Remove-SharingPolicy {
   [CmdletBinding()]
   param(
@@ -424,47 +398,6 @@ function Remove-ExoSharingPolicy {
   )
 
   Remove-SharingPolicy -Identity $Identity
-}
-
-function Set-ExoEnabledSharingPoliciesDomain {
-  [CmdletBinding()]
-  param(
-    [Parameter(Mandatory = $true)]
-    [string]$Domains
-  )
-
-  $Targets = @(Get-SharingPolicy |
-      Where-Object { (ConvertTo-FunctionalExoBoolean -Value $_.Enabled) -eq $true })
-
-  if ($Targets.Count -eq 0) {
-    throw 'Set-ExoEnabledSharingPoliciesDomain did not find any enabled sharing policies to update.'
-  }
-
-  # Use foreach+try/catch instead of pipeline so that a stale ghost policy left
-  # behind by the previous test's Remove postcondition does not abort the entire
-  # update. A failed Set on a deleted policy is logged and skipped; valid policies
-  # still get updated.
-  foreach ($Target in $Targets) {
-    try {
-      Set-SharingPolicy -InputObject $Target -Domains $Domains
-    }
-    catch {
-      Write-Warning "Set-ExoEnabledSharingPoliciesDomain: Could not update policy '$([string]$Target.Name)' - $($_.Exception.Message). Skipping."
-    }
-  }
-
-  # The Domains property may be returned as an array by EXO REST; check both forms.
-  # Use a long window (600 s) because GCC replica propagation can take several minutes.
-  Wait-FunctionalExoCondition -MaxAttempts 60 -DelaySeconds 10 -Condition {
-    @(Get-SharingPolicy |
-      Where-Object {
-        (ConvertTo-FunctionalExoBoolean -Value $_.Enabled) -eq $true -and
-        (
-          ($_.Domains -is [array] -and $_.Domains -contains $Domains) -or
-          ([string]$_.Domains -eq $Domains)
-        )
-      }).Count -gt 0
-  } -FailureMessage "Failed to observe enabled sharing policies updated to Domains='$Domains'."
 }
 
 function Disable-ExoExternalSenderWarningRules {

--- a/Testing/Functional/Products/FunctionalTestUtils.ps1
+++ b/Testing/Functional/Products/FunctionalTestUtils.ps1
@@ -41,12 +41,14 @@ function Resolve-FunctionalExoIdentity {
     return $null
   }
 
-  if (-not [string]::IsNullOrWhiteSpace([string]$InputObject.Identity)) {
-    return [string]$InputObject.Identity
-  }
-
+  # Prefer Name over Identity: the REST canonical identity path (e.g. "tenant\PolicyName")
+  # is often rejected by mutating cmdlets, while Name is consistently accepted.
   if (-not [string]::IsNullOrWhiteSpace([string]$InputObject.Name)) {
     return [string]$InputObject.Name
+  }
+
+  if (-not [string]::IsNullOrWhiteSpace([string]$InputObject.Identity)) {
+    return [string]$InputObject.Identity
   }
 
   return $null
@@ -174,9 +176,12 @@ function New-SharingPolicy {
     [string]$Domains
   )
 
+  # Explicitly enable the policy on creation; the EXO REST endpoint does not
+  # guarantee Enabled=$true by default, and Rego only evaluates enabled policies.
   return Invoke-FunctionalExoCommand -CmdletName 'New-SharingPolicy' -Parameters @{
-    Name = $Name
+    Name    = $Name
     Domains = $Domains
+    Enabled = $true
   }
 }
 
@@ -348,11 +353,22 @@ function Set-ExoRemoteDomainAutoForwardEnabled {
     $Targets | Set-RemoteDomain -AutoForwardEnabled $DesiredValue
   }
 
-  Wait-FunctionalExoCondition -Condition {
-    @(Get-RemoteDomain | Where-Object {
-        (ConvertTo-FunctionalExoBoolean -Value $_.AutoForwardEnabled) -eq $DesiredValue
-      }).Count -gt 0
-  } -FailureMessage "Failed to observe remote domains with AutoForwardEnabled=$DesiredValue after update."
+  # Direction-aware convergence check:
+  #   Compliant   ($false) => ALL domains must have AutoForwardEnabled=false (zero with true)
+  #   Non-compliant ($true) => AT LEAST ONE domain must have AutoForwardEnabled=true
+  if ($DesiredValue -eq $false) {
+    Wait-FunctionalExoCondition -Condition {
+      @(Get-RemoteDomain | Where-Object {
+          (ConvertTo-FunctionalExoBoolean -Value $_.AutoForwardEnabled) -eq $true
+        }).Count -eq 0
+    } -FailureMessage "Failed to observe all remote domains with AutoForwardEnabled=false after update."
+  } else {
+    Wait-FunctionalExoCondition -Condition {
+      @(Get-RemoteDomain | Where-Object {
+          (ConvertTo-FunctionalExoBoolean -Value $_.AutoForwardEnabled) -eq $true
+        }).Count -gt 0
+    } -FailureMessage "Failed to observe at least one remote domain with AutoForwardEnabled=true after update."
+  }
 }
 
 function Set-ExoTransportConfigSmtpClientAuthenticationDisabled {
@@ -381,6 +397,13 @@ function New-ExoSharingPolicy {
   )
 
   New-SharingPolicy -Name $Name -Domains $Domains | Out-Null
+
+  # Wait for the policy to become visible so ScubaGear's provider call sees it.
+  Wait-FunctionalExoCondition -Condition {
+    @(Get-SharingPolicy | Where-Object {
+        [string]$_.Name -eq $Name -or [string]$_.Identity -eq $Name
+      }).Count -gt 0
+  } -FailureMessage "Failed to observe new sharing policy '$Name' after creation."
 }
 
 function Remove-ExoSharingPolicy {
@@ -409,11 +432,15 @@ function Set-ExoEnabledSharingPoliciesDomain {
 
   $Targets | Set-SharingPolicy -Domains $Domains
 
+  # The Domains property may be returned as an array by EXO REST; check both forms.
   Wait-FunctionalExoCondition -Condition {
     @(Get-SharingPolicy |
       Where-Object {
         (ConvertTo-FunctionalExoBoolean -Value $_.Enabled) -eq $true -and
-        [string]$_.Domains -eq $Domains
+        (
+          ($_.Domains -is [array] -and $_.Domains -contains $Domains) -or
+          ([string]$_.Domains -eq $Domains)
+        )
       }).Count -gt 0
   } -FailureMessage "Failed to observe enabled sharing policies updated to Domains='$Domains'."
 }
@@ -473,7 +500,16 @@ function Set-ExoOrganizationAuditDisabled {
     [bool]$AuditDisabled
   )
 
-  Set-OrganizationConfig -AuditDisabled $AuditDisabled
+  try {
+    Set-OrganizationConfig -AuditDisabled $AuditDisabled
+  }
+  catch {
+    # Some tenants (GCC/GCCH) lock the audit policy and reject this change
+    # via service-principal REST calls. Log a warning and continue so the
+    # test can still evaluate the tenant's current (immutable) state rather
+    # than crashing the entire test run.
+    Write-Warning "Set-ExoOrganizationAuditDisabled: Could not set AuditDisabled=$AuditDisabled - $($_.Exception.Message). The tenant may not permit this change."
+  }
 }
 
 # -----------------------------------------------------------------------

--- a/Testing/Functional/Products/FunctionalTestUtils.ps1
+++ b/Testing/Functional/Products/FunctionalTestUtils.ps1
@@ -2,6 +2,384 @@ $UtilityModulePath = Join-Path -Path $PSScriptRoot -ChildPath "../../../PowerShe
 Import-Module $UtilityModulePath -Function Get-Utf8NoBom, Set-Utf8NoBom
 
 # -----------------------------------------------------------------------
+# Exchange Online REST wrappers for functional test pre/postconditions.
+# These replace ExchangeOnlineManagement cmdlets in EXO test plans.
+# $script:EXOApiEndpoint and $script:EXOAccessToken must be set by
+# Products.Tests.ps1 BeforeAll before these functions are called.
+# -----------------------------------------------------------------------
+function Invoke-FunctionalExoCommand {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$CmdletName,
+    [Parameter(Mandatory = $false)]
+    [hashtable]$Parameters = @{}
+  )
+
+  return Invoke-EXORestMethod `
+    -CmdletName $CmdletName `
+    -ApiEndpoint $script:EXOApiEndpoint `
+    -AccessToken $script:EXOAccessToken `
+    -Parameters $Parameters
+}
+
+function Resolve-FunctionalExoIdentity {
+  param(
+    [Parameter(Mandatory = $false)]
+    [AllowNull()]
+    [object]$InputObject,
+    [Parameter(Mandatory = $false)]
+    [AllowNull()]
+    [string]$Identity
+  )
+
+  if (-not [string]::IsNullOrWhiteSpace($Identity)) {
+    return $Identity
+  }
+
+  if ($null -eq $InputObject) {
+    return $null
+  }
+
+  if (-not [string]::IsNullOrWhiteSpace([string]$InputObject.Identity)) {
+    return [string]$InputObject.Identity
+  }
+
+  if (-not [string]::IsNullOrWhiteSpace([string]$InputObject.Name)) {
+    return [string]$InputObject.Name
+  }
+
+  return $null
+}
+
+function Get-RemoteDomain {
+  [CmdletBinding()]
+  param()
+
+  return Invoke-FunctionalExoCommand -CmdletName 'Get-RemoteDomain'
+}
+
+function Set-RemoteDomain {
+  [CmdletBinding()]
+  param(
+    [Parameter(ValueFromPipeline = $true)]
+    [AllowNull()]
+    [object]$InputObject,
+    [Parameter(Mandatory = $false)]
+    [AllowNull()]
+    [string]$Identity,
+    [Parameter(Mandatory = $true)]
+    [bool]$AutoForwardEnabled
+  )
+
+  process {
+    $ResolvedIdentity = Resolve-FunctionalExoIdentity -InputObject $InputObject -Identity $Identity
+    if ([string]::IsNullOrWhiteSpace($ResolvedIdentity)) {
+      throw 'Set-RemoteDomain requires an Identity or piped object with Identity.'
+    }
+
+    Invoke-FunctionalExoCommand -CmdletName 'Set-RemoteDomain' -Parameters @{
+      Identity = $ResolvedIdentity
+      AutoForwardEnabled = $AutoForwardEnabled
+    } | Out-Null
+  }
+}
+
+function Set-TransportConfig {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [bool]$SmtpClientAuthenticationDisabled
+  )
+
+  Invoke-FunctionalExoCommand -CmdletName 'Set-TransportConfig' -Parameters @{
+    SmtpClientAuthenticationDisabled = $SmtpClientAuthenticationDisabled
+  } | Out-Null
+}
+
+function Get-SharingPolicy {
+  [CmdletBinding()]
+  param()
+
+  return Invoke-FunctionalExoCommand -CmdletName 'Get-SharingPolicy'
+}
+
+function New-SharingPolicy {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name,
+    [Parameter(Mandatory = $true)]
+    [string]$Domains
+  )
+
+  return Invoke-FunctionalExoCommand -CmdletName 'New-SharingPolicy' -Parameters @{
+    Name = $Name
+    Domains = $Domains
+  }
+}
+
+function Set-SharingPolicy {
+  [CmdletBinding()]
+  param(
+    [Parameter(ValueFromPipeline = $true)]
+    [AllowNull()]
+    [object]$InputObject,
+    [Parameter(Mandatory = $false)]
+    [AllowNull()]
+    [string]$Identity,
+    [Parameter(Mandatory = $true)]
+    [string]$Domains
+  )
+
+  process {
+    $ResolvedIdentity = Resolve-FunctionalExoIdentity -InputObject $InputObject -Identity $Identity
+    if ([string]::IsNullOrWhiteSpace($ResolvedIdentity)) {
+      throw 'Set-SharingPolicy requires an Identity or piped object with Identity.'
+    }
+
+    Invoke-FunctionalExoCommand -CmdletName 'Set-SharingPolicy' -Parameters @{
+      Identity = $ResolvedIdentity
+      Domains = $Domains
+    } | Out-Null
+  }
+}
+
+function Remove-SharingPolicy {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Identity
+  )
+
+  Invoke-FunctionalExoCommand -CmdletName 'Remove-SharingPolicy' -Parameters @{
+    Identity = $Identity
+  } | Out-Null
+}
+
+function Get-TransportRule {
+  [CmdletBinding()]
+  param()
+
+  return Invoke-FunctionalExoCommand -CmdletName 'Get-TransportRule'
+}
+
+function Disable-TransportRule {
+  [CmdletBinding()]
+  param(
+    [Parameter(ValueFromPipeline = $true)]
+    [AllowNull()]
+    [object]$InputObject,
+    [Parameter(Mandatory = $false)]
+    [AllowNull()]
+    [string]$Identity
+  )
+
+  process {
+    $ResolvedIdentity = Resolve-FunctionalExoIdentity -InputObject $InputObject -Identity $Identity
+    if ([string]::IsNullOrWhiteSpace($ResolvedIdentity)) {
+      throw 'Disable-TransportRule requires an Identity or piped object with Identity.'
+    }
+
+    Invoke-FunctionalExoCommand -CmdletName 'Disable-TransportRule' -Parameters @{
+      Identity = $ResolvedIdentity
+    } | Out-Null
+  }
+}
+
+function Enable-TransportRule {
+  [CmdletBinding()]
+  param(
+    [Parameter(ValueFromPipeline = $true)]
+    [AllowNull()]
+    [object]$InputObject,
+    [Parameter(Mandatory = $false)]
+    [AllowNull()]
+    [string]$Identity
+  )
+
+  process {
+    $ResolvedIdentity = Resolve-FunctionalExoIdentity -InputObject $InputObject -Identity $Identity
+    if ([string]::IsNullOrWhiteSpace($ResolvedIdentity)) {
+      throw 'Enable-TransportRule requires an Identity or piped object with Identity.'
+    }
+
+    Invoke-FunctionalExoCommand -CmdletName 'Enable-TransportRule' -Parameters @{
+      Identity = $ResolvedIdentity
+    } | Out-Null
+  }
+}
+
+function New-TransportRule {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [string]$Name,
+    [Parameter(Mandatory = $false)]
+    [AllowNull()]
+    [string]$FromScope,
+    [Parameter(Mandatory = $false)]
+    [AllowNull()]
+    [string]$PrependSubject
+  )
+
+  $Params = @{
+    Name = $Name
+  }
+  if (-not [string]::IsNullOrWhiteSpace($FromScope)) {
+    $Params.FromScope = $FromScope
+  }
+  if ($null -ne $PrependSubject) {
+    $Params.PrependSubject = $PrependSubject
+  }
+
+  return Invoke-FunctionalExoCommand -CmdletName 'New-TransportRule' -Parameters $Params
+}
+
+function Remove-TransportRule {
+  [CmdletBinding()]
+  param(
+    [Parameter(ValueFromPipeline = $true)]
+    [AllowNull()]
+    [object]$InputObject,
+    [Parameter(Mandatory = $false)]
+    [AllowNull()]
+    [string]$Identity
+  )
+
+  process {
+    $ResolvedIdentity = Resolve-FunctionalExoIdentity -InputObject $InputObject -Identity $Identity
+    if ([string]::IsNullOrWhiteSpace($ResolvedIdentity)) {
+      throw 'Remove-TransportRule requires an Identity or piped object with Identity.'
+    }
+
+    Invoke-FunctionalExoCommand -CmdletName 'Remove-TransportRule' -Parameters @{
+      Identity = $ResolvedIdentity
+    } | Out-Null
+  }
+}
+
+function Set-OrganizationConfig {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [bool]$AuditDisabled
+  )
+
+  Invoke-FunctionalExoCommand -CmdletName 'Set-OrganizationConfig' -Parameters @{
+    AuditDisabled = $AuditDisabled
+  } | Out-Null
+}
+
+function Set-ExoRemoteDomainAutoForwardEnabled {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [bool]$CurrentValue,
+    [Parameter(Mandatory = $true)]
+    [bool]$DesiredValue
+  )
+
+  Get-RemoteDomain |
+    Where-Object { $_.AutoForwardEnabled -eq $CurrentValue } |
+    Set-RemoteDomain -AutoForwardEnabled $DesiredValue
+}
+
+function Set-ExoTransportConfigSmtpClientAuthenticationDisabled {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [bool]$SmtpClientAuthenticationDisabled
+  )
+
+  Set-TransportConfig -SmtpClientAuthenticationDisabled $SmtpClientAuthenticationDisabled
+}
+
+function New-ExoSharingPolicy {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name,
+    [Parameter(Mandatory = $true)]
+    [string]$Domains
+  )
+
+  New-SharingPolicy -Name $Name -Domains $Domains | Out-Null
+}
+
+function Remove-ExoSharingPolicy {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Identity
+  )
+
+  Remove-SharingPolicy -Identity $Identity
+}
+
+function Set-ExoEnabledSharingPoliciesDomain {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Domains
+  )
+
+  Get-SharingPolicy |
+    Where-Object { $_.Enabled -eq $true } |
+    Set-SharingPolicy -Domains $Domains
+}
+
+function Disable-ExoExternalSenderWarningRules {
+  [CmdletBinding()]
+  param()
+
+  Get-TransportRule |
+    Where-Object { $_.State -eq 'Enabled' -and $_.Mode -eq 'Enforce' -and $_.FromScope -eq 'NotInOrganization' } |
+    Disable-TransportRule
+}
+
+function Enable-ExoExternalSenderWarningRules {
+  [CmdletBinding()]
+  param()
+
+  Get-TransportRule |
+    Where-Object { $_.State -eq 'Disabled' -and $_.Mode -eq 'Enforce' -and $_.FromScope -eq 'NotInOrganization' } |
+    Enable-TransportRule
+}
+
+function New-ExoExternalSenderWarningRule {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $false)]
+    [string]$Name = 'FunctionalTest External sender warning'
+  )
+
+  New-TransportRule $Name -FromScope 'NotInOrganization' -PrependSubject '[External] ' | Out-Null
+}
+
+function Remove-ExoExternalSenderWarningRule {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $false)]
+    [string]$Identity = 'FunctionalTest External sender warning'
+  )
+
+  Get-TransportRule |
+    Where-Object { $_.Identity -eq $Identity } |
+    Remove-TransportRule
+}
+
+function Set-ExoOrganizationAuditDisabled {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [bool]$AuditDisabled
+  )
+
+  Set-OrganizationConfig -AuditDisabled $AuditDisabled
+}
+
+# -----------------------------------------------------------------------
 # Power Platform REST wrappers for functional test preconditions
 # These replace the removed Microsoft.PowerApps.Administration.PowerShell
 # cmdlets. $script:PPBaseUrl and $script:PPAccessToken must be set by

--- a/Testing/Functional/Products/FunctionalTestUtils.ps1
+++ b/Testing/Functional/Products/FunctionalTestUtils.ps1
@@ -440,7 +440,18 @@ function Set-ExoEnabledSharingPoliciesDomain {
     throw 'Set-ExoEnabledSharingPoliciesDomain did not find any enabled sharing policies to update.'
   }
 
-  $Targets | Set-SharingPolicy -Domains $Domains
+  # Use foreach+try/catch instead of pipeline so that a stale ghost policy left
+  # behind by the previous test's Remove postcondition does not abort the entire
+  # update. A failed Set on a deleted policy is logged and skipped; valid policies
+  # still get updated.
+  foreach ($Target in $Targets) {
+    try {
+      Set-SharingPolicy -InputObject $Target -Domains $Domains
+    }
+    catch {
+      Write-Warning "Set-ExoEnabledSharingPoliciesDomain: Could not update policy '$([string]$Target.Name)' - $($_.Exception.Message). Skipping."
+    }
+  }
 
   # The Domains property may be returned as an array by EXO REST; check both forms.
   # Use a long window (300 s) because GCC replica propagation can take several minutes.
@@ -520,14 +531,17 @@ function Set-ExoOrganizationAuditDisabled {
     Write-Warning "Set-ExoOrganizationAuditDisabled: Could not set AuditDisabled=$AuditDisabled - $($_.Exception.Message). The tenant may not permit this change."
   }
 
-  # Verify the actual state matches the desired state regardless of whether the
-  # call succeeded or was silently rejected. If not, throw so the test reports
-  # a clear environment-restriction error rather than a misleading assertion failure.
-  $ActualConfig = Invoke-FunctionalExoCommand -CmdletName 'Get-OrganizationConfig' | Select-Object -First 1
-  $ActualValue = ConvertTo-FunctionalExoBoolean -Value $ActualConfig.AuditDisabled
-  if ($ActualValue -ne $AuditDisabled) {
-    throw "Set-ExoOrganizationAuditDisabled: Tenant AuditDisabled is '$ActualValue' but '$AuditDisabled' was requested. Tenant policy prohibits this change - this test cannot complete in this environment."
-  }
+  # Wait for the desired value to become visible on a read replica. An immediate
+  # single readback can return a stale value even when the write succeeded.
+  # If the wait times out the tenant likely prohibits this change via service principal.
+  Wait-FunctionalExoCondition -MaxAttempts 12 -DelaySeconds 10 -Condition {
+    $Cfg = Invoke-FunctionalExoCommand -CmdletName 'Get-OrganizationConfig' | Select-Object -First 1
+    (ConvertTo-FunctionalExoBoolean -Value $Cfg.AuditDisabled) -eq $AuditDisabled
+  } -FailureMessage "Set-ExoOrganizationAuditDisabled: Tenant AuditDisabled did not reach '$AuditDisabled' after waiting. Tenant policy prohibits this change - this test cannot complete in this environment."
+
+  # Allow extra time for the write to propagate to all EXO replicas before
+  # ScubaGear's independent REST session reads tenant state.
+  Start-Sleep -Seconds 60
 }
 
 # -----------------------------------------------------------------------

--- a/Testing/Functional/Products/Products.Tests.ps1
+++ b/Testing/Functional/Products/Products.Tests.ps1
@@ -179,6 +179,30 @@ BeforeAll {
     # Dot source utility functions
     . (Join-Path -Path $PSScriptRoot -ChildPath "FunctionalTestUtils.ps1")
 
+    # EXO functional tests still use Exchange cmdlets in pre/postconditions.
+    # Establish a dedicated EXO session here so test setup can mutate tenant
+    # state without changing the production EXO runtime path.
+    if ($ProductName -eq "exo") {
+        $ConnectHelpersPath = Join-Path -Path $PSScriptRoot -ChildPath "../../../PowerShell/ScubaGear/Modules/Connection/ConnectHelpers.psm1"
+        Import-Module $ConnectHelpersPath -Force
+
+        $EXOHelperParams = @{
+            M365Environment = $M365Environment
+        }
+
+        if (-not [string]::IsNullOrEmpty($AppId)) {
+            $EXOHelperParams.ServicePrincipalParams = @{
+                CertThumbprintParams = @{
+                    CertificateThumbprint = $Thumbprint
+                    AppID = $AppId
+                    Organization = $TenantDomain
+                }
+            }
+        }
+
+        Connect-EXOHelper @EXOHelperParams
+    }
+
     # SharePoint functional tests: acquire SPO REST token for precondition Set-SPOTenant calls.
     # Must be in BeforeAll (not InModuleScope) so $script: refers to this file's scope,
     # which is visible to functions dot-sourced from FunctionalTestUtils.ps1.

--- a/Testing/Functional/Products/Products.Tests.ps1
+++ b/Testing/Functional/Products/Products.Tests.ps1
@@ -179,28 +179,58 @@ BeforeAll {
     # Dot source utility functions
     . (Join-Path -Path $PSScriptRoot -ChildPath "FunctionalTestUtils.ps1")
 
-    # EXO functional tests still use Exchange cmdlets in pre/postconditions.
-    # Establish a dedicated EXO session here so test setup can mutate tenant
-    # state without changing the production EXO runtime path.
+    # EXO functional tests use REST-backed helper wrappers from FunctionalTestUtils.
+    # Initialize EXO REST auth context for test pre/postconditions.
     if ($ProductName -eq "exo") {
+        $EXOHelperPath = Join-Path -Path $PSScriptRoot -ChildPath "../../../PowerShell/ScubaGear/Modules/Providers/ProviderHelpers/EXORestHelper.psm1"
+        Import-Module $EXOHelperPath -Force
         $ConnectHelpersPath = Join-Path -Path $PSScriptRoot -ChildPath "../../../PowerShell/ScubaGear/Modules/Connection/ConnectHelpers.psm1"
         Import-Module $ConnectHelpersPath -Force
 
-        $EXOHelperParams = @{
-            M365Environment = $M365Environment
+        $EXOScope = Get-ExchangeOnlineScope -M365Environment $M365Environment
+        if (-Not [string]::IsNullOrEmpty($AppId)) {
+            $script:EXOAccessToken = Get-MsalAccessToken `
+                -CertificateThumbprint $Thumbprint `
+                -AppID $AppId `
+                -Tenant $TenantDomain `
+                -M365Environment $M365Environment `
+                -Scope $EXOScope
+        }
+        else {
+            # Microsoft Exchange Online Remote PowerShell well-known client ID
+            $EXOClientId = "fb78d390-0c51-40cd-8e17-fdbfab77341b"
+            $script:EXOAccessToken = Get-MsalAccessToken `
+                -Tenant $TenantDomain `
+                -M365Environment $M365Environment `
+                -ClientId $EXOClientId `
+                -Scope $EXOScope
         }
 
-        if (-not [string]::IsNullOrEmpty($AppId)) {
-            $EXOHelperParams.ServicePrincipalParams = @{
-                CertThumbprintParams = @{
-                    CertificateThumbprint = $Thumbprint
-                    AppID = $AppId
-                    Organization = $TenantDomain
-                }
-            }
+        $TokenParts = $script:EXOAccessToken.Split('.')
+        if ($TokenParts.Count -lt 2) {
+            throw 'Unable to parse EXO access token for tenant id.'
         }
 
-        Connect-EXOHelper @EXOHelperParams
+        $JwtPayload = $TokenParts[1].Replace('-', '+').Replace('_', '/')
+        switch ($JwtPayload.Length % 4) {
+            2 { $JwtPayload += '==' }
+            3 { $JwtPayload += '=' }
+        }
+
+        $PayloadJson = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($JwtPayload))
+        $Payload = $PayloadJson | ConvertFrom-Json
+        $script:EXOTenantId = $Payload.tid
+
+        if ([string]::IsNullOrWhiteSpace($script:EXOTenantId)) {
+            throw 'Unable to resolve tenant id (tid) from EXO access token.'
+        }
+
+        $script:EXOApiEndpoint = Get-ExchangeOnlineApiEndpoint `
+            -TenantId $script:EXOTenantId `
+            -TenantDomain $TenantDomain `
+            -M365Environment $M365Environment `
+            -AccessToken $script:EXOAccessToken
+
     }
 
     # SharePoint functional tests: acquire SPO REST token for precondition Set-SPOTenant calls.
@@ -327,7 +357,12 @@ BeforeAll {
             Invoke-SCuBA -CertificateThumbPrint $Thumbprint -AppId $AppId -Organization $TenantDomain -Productnames $ProductName -OutPath . -Quiet -KeepIndividualJSON -SilenceBODWarnings
         }
         else {
-            Invoke-SCuBA -Login $false -Productnames $ProductName -OutPath . -M365Environment $M365Environment -Quiet -KeepIndividualJSON -SilenceBODWarnings
+            if ($ProductName -eq 'exo') {
+                Invoke-SCuBA -Productnames $ProductName -OutPath . -M365Environment $M365Environment -Quiet -KeepIndividualJSON -SilenceBODWarnings
+            }
+            else {
+                Invoke-SCuBA -Login $false -Productnames $ProductName -OutPath . -M365Environment $M365Environment -Quiet -KeepIndividualJSON -SilenceBODWarnings
+            }
         }
     }
 

--- a/Testing/Functional/Products/TestPlans/exo.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/exo.testplan.yaml
@@ -5,12 +5,18 @@ TestPlan:
     Tests:
       - TestDescription: MS.EXO.1.1v2 Non-Compliant case - domains have auto forwarding Enabled
         Preconditions:
-          - Command: "Get-RemoteDomain | Where {$_.AutoForwardEnabled -eq $false} | Set-RemoteDomain -AutoForwardEnabled $true"
+          - Command: Set-ExoRemoteDomainAutoForwardEnabled
+            Splat:
+              CurrentValue: false
+              DesiredValue: true
         Postconditions: []
         ExpectedResult: false
       - TestDescription: MS.EXO.1.1v2 Compliant case - domains have auto forwarding Disabled
         Preconditions:
-          - Command: "Get-RemoteDomain | Where {$_.AutoForwardEnabled -eq $true} | Set-RemoteDomain -AutoForwardEnabled $false"
+          - Command: Set-ExoRemoteDomainAutoForwardEnabled
+            Splat:
+              CurrentValue: true
+              DesiredValue: false
         Postconditions: []
         ExpectedResult: true
 
@@ -236,14 +242,14 @@ TestPlan:
     Tests:
       - TestDescription: MS.EXO.5.1v1 Non-Compliant case - SMTP AUTH is Enabled
         Preconditions:
-          - Command: Set-TransportConfig
+          - Command: Set-ExoTransportConfigSmtpClientAuthenticationDisabled
             Splat:
               SmtpClientAuthenticationDisabled: false
         Postconditions: []
         ExpectedResult: false
       - TestDescription: MS.EXO.5.1v1 Compliant case - SMTP AUTH is Disabled
         Preconditions:
-          - Command: Set-TransportConfig
+          - Command: Set-ExoTransportConfigSmtpClientAuthenticationDisabled
             Splat:
               SmtpClientAuthenticationDisabled: true
         Postconditions: []
@@ -254,13 +260,20 @@ TestPlan:
     Tests:
       - TestDescription: MS.EXO.6.1v1 Non-Compliant case - Contacts shared with all domains
         Preconditions:
-          - Command: 'New-SharingPolicy -Name "FunctionalTest ContactSharingAllDomains" -Domains "*:ContactsSharing"'
+          - Command: New-ExoSharingPolicy
+            Splat:
+              Name: "FunctionalTest ContactSharingAllDomains"
+              Domains: "*:ContactsSharing"
         Postconditions:
-          - Command: 'Remove-SharingPolicy -Identity "FunctionalTest ContactSharingAllDomains" -Confirm:$false'
+          - Command: Remove-ExoSharingPolicy
+            Splat:
+              Identity: "FunctionalTest ContactSharingAllDomains"
         ExpectedResult: false
       - TestDescription: MS.EXO.6.1v1 Compliant case - Contacts NOT shared with all domains
         Preconditions:
-          - Command: 'Get-SharingPolicy | Where {$_.Enabled -eq $true} | Set-SharingPolicy -Domains "ted.com:ContactsSharing"'
+          - Command: Set-ExoEnabledSharingPoliciesDomain
+            Splat:
+              Domains: "ted.com:ContactsSharing"
         Postconditions: []
         ExpectedResult: true
 
@@ -269,13 +282,20 @@ TestPlan:
     Tests:
       - TestDescription: MS.EXO.6.2v1 Non-Compliant case - Calendar shared with all domains
         Preconditions:
-          - Command: 'New-SharingPolicy -Name "FunctionalTest CalendarSharingAllDomains" -Domains "*:CalendarSharingFreeBusyReviewer"'
+          - Command: New-ExoSharingPolicy
+            Splat:
+              Name: "FunctionalTest CalendarSharingAllDomains"
+              Domains: "*:CalendarSharingFreeBusyReviewer"
         Postconditions:
-          - Command: 'Remove-SharingPolicy -Identity "FunctionalTest CalendarSharingAllDomains" -Confirm:$false'
+          - Command: Remove-ExoSharingPolicy
+            Splat:
+              Identity: "FunctionalTest CalendarSharingAllDomains"
         ExpectedResult: false
       - TestDescription: MS.EXO.6.2v1 Compliant case - Calendar NOT shared with all domains
         Preconditions:
-          - Command: 'Get-SharingPolicy | Where {$_.Enabled -eq $true} | Set-SharingPolicy -Domains "ted.com:CalendarSharingFreeBusyReviewer"'
+          - Command: Set-ExoEnabledSharingPoliciesDomain
+            Splat:
+              Domains: "ted.com:CalendarSharingFreeBusyReviewer"
         Postconditions: []
         ExpectedResult: true
 
@@ -285,16 +305,16 @@ TestPlan:
       - TestDescription: MS.EXO.7.1v1 Non-Compliant case - External sender warning rules Disabled
         Preconditions:
           ### Disable all rules that match what the policy is checking for
-          - Command: 'Get-TransportRule | Where {$_.State -eq "Enabled" -AND $_.Mode -eq "Enforce" -AND $_.FromScope -eq "NotInOrganization"} | Disable-TransportRule -Confirm:$false'
+          - Command: Disable-ExoExternalSenderWarningRules
         Postconditions:
-          - Command: 'Get-TransportRule | Where {$_.State -eq "Disabled" -AND $_.Mode -eq "Enforce" -AND $_.FromScope -eq "NotInOrganization"} | Enable-TransportRule -Confirm:$false'
+          - Command: Enable-ExoExternalSenderWarningRules
         ExpectedResult: false
       - TestDescription: MS.EXO.7.1v1 Compliant case - External sender warning rule exists
         Preconditions:
           ### By creating a new rule that matches what the policy is checking for, we guarantee that it exists in the tenant
-          - Command: 'New-TransportRule "FunctionalTest External sender warning" -FromScope "NotInOrganization" -PrependSubject "[External] "'
+          - Command: New-ExoExternalSenderWarningRule
         Postconditions:
-          - Command: 'Get-TransportRule | Where {$_.Identity -eq "FunctionalTest External sender warning"} | Remove-TransportRule -Confirm:$false'
+          - Command: Remove-ExoExternalSenderWarningRule
         ExpectedResult: true
 
   - PolicyId: MS.EXO.13.1v1
@@ -302,14 +322,14 @@ TestPlan:
     Tests:
       - TestDescription: MS.EXO.13.1v1 Non-Compliant case - Mailbox auditing is Disabled
         Preconditions:
-          - Command: Set-OrganizationConfig
+          - Command: Set-ExoOrganizationAuditDisabled
             Splat:
               AuditDisabled: true
         Postconditions: []
         ExpectedResult: false
       - TestDescription: MS.EXO.13.1v1 Compliant case - Mailbox auditing is Enabled
         Preconditions:
-          - Command: Set-OrganizationConfig
+          - Command: Set-ExoOrganizationAuditDisabled
             Splat:
               AuditDisabled: false
         Postconditions: []

--- a/Testing/Functional/Products/TestPlans/exo.testplan.yaml
+++ b/Testing/Functional/Products/TestPlans/exo.testplan.yaml
@@ -271,10 +271,14 @@ TestPlan:
         ExpectedResult: false
       - TestDescription: MS.EXO.6.1v1 Compliant case - Contacts NOT shared with all domains
         Preconditions:
-          - Command: Set-ExoEnabledSharingPoliciesDomain
+          - Command: New-ExoSharingPolicy
             Splat:
+              Name: "FunctionalTest ContactSharingLimitedDomains"
               Domains: "ted.com:ContactsSharing"
-        Postconditions: []
+        Postconditions:
+          - Command: Remove-ExoSharingPolicy
+            Splat:
+              Identity: "FunctionalTest ContactSharingLimitedDomains"
         ExpectedResult: true
 
   - PolicyId: MS.EXO.6.2v1
@@ -293,10 +297,14 @@ TestPlan:
         ExpectedResult: false
       - TestDescription: MS.EXO.6.2v1 Compliant case - Calendar NOT shared with all domains
         Preconditions:
-          - Command: Set-ExoEnabledSharingPoliciesDomain
+          - Command: New-ExoSharingPolicy
             Splat:
+              Name: "FunctionalTest CalendarSharingLimitedDomains"
               Domains: "ted.com:CalendarSharingFreeBusyReviewer"
-        Postconditions: []
+        Postconditions:
+          - Command: Remove-ExoSharingPolicy
+            Splat:
+              Identity: "FunctionalTest CalendarSharingLimitedDomains"
         ExpectedResult: true
 
   - PolicyId: MS.EXO.7.1v1


### PR DESCRIPTION
## 🗣 Description ##

- Moves Exchange Online collection from ExchangeOnlineManagement cmdlets to direct EXO Admin REST API calls.
- Introduces token and endpoint acquisition flow used by the REST provider path.
- Updates unit coverage for REST-based EXO authentication and provider behavior.
- Fixes report command dependency tracking so REST wrapper execution is mapped to underlying EXO cmdlet names (for example Get-RemoteDomain), preventing false Error results.
- Includes authentication/runtime follow-up fix so interactive auth works in this execution environment.

## 💭 Motivation and context ##

This PR is the EXO REST migration workstream for issue #2090.

The goal is to stop depending on the EXO module cmdlet execution path for provider data collection and instead call the EXO Admin API directly, while preserving baseline evaluation behavior and report correctness.

During validation, two follow-up issues were identified and fixed in this branch:

- Interactive auth runtime behavior in this shell environment.
- Report dependency mismatch caused by tracking only Invoke-EXORestMethod instead of the underlying EXO command names expected by report dependency checks.

Resolves #2090.

## 🧪 Testing ##

Branch validation performed with EXO-only assessment in commercial tenant:

- Import-Module .\\PowerShell\\ScubaGear\\ScubaGear.psd1 -Force
- Invoke-SCuBA -ProductNames exo -M365Environment commercial -OutPath sample-report/exo-commercial-validation -Quiet -DisconnectOnExit -SilenceBODWarnings -ErrorAction Continue

Observed results:

- Authentication succeeded.
- EXO provider REST calls succeeded.
- OPA and report generation succeeded.
- Command dependency false Errors were eliminated after tracker mapping fix.
- Final EXO summary from latest validation run: Passes=5, Failures=5, Warnings=2, Errors=0.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] All relevant type-of-change labels added.
- [ ] All relevant project fields are set.
- [ ] All relevant repo and/or project documentation updated to reflect these changes.
- [ ] Unit tests added/updated to cover PowerShell and Rego changes.
- [ ] Functional tests added/updated to cover PowerShell and Rego changes.
- [ ] All relevant functional tests passed.
- [ ] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

- [ ] PR passed smoke test check.
- [ ] Feature branch has been rebased against changes from parent branch, as needed.
- [ ] Resolved all merge conflicts on branch.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge checklist ##

- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.