### PR TITLE
Fixes Email for Functional Tests

### DIFF
--- a/.github/workflows/function_test_defender.yaml
+++ b/.github/workflows/function_test_defender.yaml
@@ -506,7 +506,7 @@ jobs:
           password: ${{ secrets.NotifierPassword }}
           subject: "ScubaGear Functional Test Failure - Defender - branch: ${{ inputs.RefName || github.ref_name }}"
           to: ${{ steps.extract-email.outputs.emails }}
-          from: ScubaGear Notifier
+          from: ${{ format('ScubaGear Notifier <{0}>', secrets.NotifierUsername) }}
           body: |
             ScubaGear Functional Test Failure
 

--- a/.github/workflows/function_test_entra.yaml
+++ b/.github/workflows/function_test_entra.yaml
@@ -506,7 +506,7 @@ jobs:
           password: ${{ secrets.NotifierPassword }}
           subject: "ScubaGear Functional Test Failure - Entra ID - branch: ${{ inputs.RefName || github.ref_name }}"
           to: ${{ steps.extract-email.outputs.emails }}
-          from: ScubaGear Notifier
+          from: ${{ format('ScubaGear Notifier <{0}>', secrets.NotifierUsername) }}
           body: |
             ScubaGear Functional Test Failure
 

--- a/.github/workflows/function_test_exchange.yaml
+++ b/.github/workflows/function_test_exchange.yaml
@@ -282,7 +282,7 @@ jobs:
           password: ${{ secrets.NotifierPassword }}
           subject: "ScubaGear Functional Test Failure - Exchange - branch: ${{ inputs.RefName || github.ref_name }}"
           to: ${{ steps.extract-email.outputs.emails }}
-          from: ScubaGear Notifier
+          from: ${{ format('ScubaGear Notifier <{0}>', secrets.NotifierUsername) }}
           body: |
             ScubaGear Functional Test Failure
 

--- a/.github/workflows/function_test_powerbi.yaml
+++ b/.github/workflows/function_test_powerbi.yaml
@@ -250,3 +250,4 @@ jobs:
           password: ${{ secrets.NotifierPassword }}
           subject: ScubaGear Functional Test Failure
           to: ${{ steps.extract-email.outputs.emails }}
+          from: ${{ format('ScubaGear Notifier <{0}>', secrets.NotifierUsername) }}

--- a/.github/workflows/function_test_powerplatform.yaml
+++ b/.github/workflows/function_test_powerplatform.yaml
@@ -282,7 +282,7 @@ jobs:
           password: ${{ secrets.NotifierPassword }}
           subject: "ScubaGear Functional Test Failure - Power Platform - branch: ${{ inputs.RefName || github.ref_name }}"
           to: ${{ steps.extract-email.outputs.emails }}
-          from: ScubaGear Notifier
+          from: ${{ format('ScubaGear Notifier <{0}>', secrets.NotifierUsername) }}
           body: |
             ScubaGear Functional Test Failure
 

--- a/.github/workflows/function_test_sharepoint.yaml
+++ b/.github/workflows/function_test_sharepoint.yaml
@@ -282,7 +282,7 @@ jobs:
           password: ${{ secrets.NotifierPassword }}
           subject: "ScubaGear Functional Test Failure - SharePoint - branch: ${{ inputs.RefName || github.ref_name }}"
           to: ${{ steps.extract-email.outputs.emails }}
-          from: ScubaGear Notifier
+          from: ${{ format('ScubaGear Notifier <{0}>', secrets.NotifierUsername) }}
           body: |
             ScubaGear Functional Test Failure
 

--- a/.github/workflows/function_test_teams.yaml
+++ b/.github/workflows/function_test_teams.yaml
@@ -506,7 +506,7 @@ jobs:
           password: ${{ secrets.NotifierPassword }}
           subject: "ScubaGear Functional Test Failure - Teams - branch: ${{ inputs.RefName || github.ref_name }}"
           to: ${{ steps.extract-email.outputs.emails }}
-          from: ScubaGear Notifier
+          from: ${{ format('ScubaGear Notifier <{0}>', secrets.NotifierUsername) }}
           body: |
             ScubaGear Functional Test Failure
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##
Closes #2213 
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
Fixes issue with sending emails via functional tests on failure.
With the update with from v3 to v17, there was a breaking change with v12 where the `from` field shifted from needing a display name, to now needing the entire email address and an optional display name. As a result our functional tests pipeline was failing at sending out the emails on failure

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
1. Run functional tests on this branch, and select email on failure
2. Check there is a green check on send email step on any workflow which failed
3. Reach out to TCO to ensure the email gets sent out if the workflow failed 
4. 
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [ ] Unit tests added/updated to cover PowerShell and Rego changes.
- [ ] Functional tests added/updated to cover PowerShell and Rego changes.
- [ ] All relevant functional tests passed.
- [ ] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] PR passed smoke test check.
- [ ] Feature branch has been rebased against changes from parent branch, as needed.

  Use `Update branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [ ] Resolved all merge conflicts on branch.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the PR assignee to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
