### PR TITLE
Fix DMARC discovery with RFC 9989 DNS tree walk

### DIFF
--- a/PowerShell/ScubaGear/Modules/Providers/ExportEXOProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportEXOProvider.psm1
@@ -717,26 +717,51 @@ function Get-ScubaDmarcRecord {
             continue
         }
         $LogEntries = @()
-        # First check to see if the record is available at the full domain level
         $DomainName = $d.DomainName
-        $Response = Invoke-RobustDnsTxt "_dmarc.$DomainName" -PreferredDnsResolvers $PreferredDnsResolvers `
-            -SkipDoH $SkipDoH
-        $LogEntries += $Response.LogEntries
-        if ($Response.Answers.Length -eq 0) {
-            # The domain does not exist. If the record is not available at the full domain
-            # level, we need to check at the organizational domain level.
-            $Labels = $d.DomainName.Split(".")
-            $Labels = $d.DomainName.Split(".")
-            $OrgDomain = $Labels[-2] + "." + $Labels[-1]
-            $Response = Invoke-RobustDnsTxt "_dmarc.$OrgDomain" -PreferredDnsResolvers $PreferredDnsResolvers `
-                -SkipDoH $SkipDoH
-            $LogEntries += $Response.LogEntries
+        $Labels = @($DomainName.Split(".", [System.StringSplitOptions]::RemoveEmptyEntries))
+        $QueryDomains = @($DomainName)
+
+        if ($Labels.Count -gt 1) {
+            # RFC 9989 section 4.10 limits the tree walk to eight total queries.
+            $StartIndex = if ($Labels.Count -gt 7) {
+                $Labels.Count - 7
+            }
+            else {
+                1
+            }
+
+            for ($Index = $StartIndex; $Index -lt $Labels.Count; $Index++) {
+                $QueryDomains += $Labels[$Index..($Labels.Count - 1)] -join "."
+            }
         }
 
-        $DomainName = $d.DomainName
+        $SelectedResponse = $null
+        foreach ($QueryDomain in $QueryDomains) {
+            $Response = Invoke-RobustDnsTxt "_dmarc.$QueryDomain" `
+                -PreferredDnsResolvers $PreferredDnsResolvers `
+                -SkipDoH $SkipDoH
+            $LogEntries += $Response.LogEntries
+
+            $DmarcAnswers = @($Response.Answers | Where-Object {
+                $_ -match "^\s*v=DMARC1\s*;"
+            })
+            if ($DmarcAnswers.Count -ne 1) {
+                continue
+            }
+
+            $SelectedResponse = $Response
+            if ($QueryDomain -eq $DomainName -or $DmarcAnswers[0] -match "(?i)(?:^|;)\s*psd\s*=\s*[yn]\s*(?:;|$)") {
+                break
+            }
+        }
+
+        if ($null -eq $SelectedResponse) {
+            $SelectedResponse = $Response
+        }
+
         $DMARCRecords += [PSCustomObject]@{
             "domain" = $DomainName;
-            "rdata" = @($Response.Answers);
+            "rdata" = @($SelectedResponse.Answers);
             "log" = $LogEntries;
         }
     }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/EXOProvider/Get-ScubaDmarcRecord.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/EXOProvider/Get-ScubaDmarcRecord.Tests.ps1
@@ -8,7 +8,7 @@ InModuleScope 'ExportEXOProvider' {
             BeforeAll {
                 Mock -CommandName Invoke-RobustDnsTxt {
                     @{
-                        "Answers" = @("v=DMARC1...");
+                        "Answers" = @("v=DMARC1; p=reject");
                         "Errors" = @();
                         "NXDomain" = $false;
                         "LogEntries" = @("some text")
@@ -16,7 +16,6 @@ InModuleScope 'ExportEXOProvider' {
                 }
             }
             It "Resolves 1 domain name" {
-                # Test basic functionality
                 $Response = Get-ScubaDmarcRecord -Domains @(
                     @{
                         "DomainName" = "example.com";
@@ -24,7 +23,7 @@ InModuleScope 'ExportEXOProvider' {
                     }
                 ) -PreferredDnsResolvers @() -SkipDoH $false
                 Should -Invoke -CommandName Invoke-RobustDnsTxt -Exactly -Times 1
-                $Response.rdata -Contains "v=DMARC1..." | Should -Be $true
+                $Response.rdata -Contains "v=DMARC1; p=reject" | Should -Be $true
             }
 
             It "Resolves multiple domain names" {
@@ -40,12 +39,10 @@ InModuleScope 'ExportEXOProvider' {
                     }
                 ) -PreferredDnsResolvers @() -SkipDoH $false
                 Should -Invoke -CommandName Invoke-RobustDnsTxt -Exactly -Times 2
-                $Response.rdata -Contains "v=DMARC1..." | Should -Be $true
+                $Response.rdata -Contains "v=DMARC1; p=reject" | Should -Be $true
             }
 
             It "Ignores the coexistence domain" {
-                # Get-ScubaDmarcRecord needs to skip the coexistence domain because DMARC
-                # records can't be added for it
                 $Response = Get-ScubaDmarcRecord -Domains @(
                     @{
                         "DomainName" = "example1.com";
@@ -57,40 +54,96 @@ InModuleScope 'ExportEXOProvider' {
                     }
                 ) -PreferredDnsResolvers @() -SkipDoH $false
                 Should -Invoke -CommandName Invoke-RobustDnsTxt -Exactly -Times 1
-                $Response.rdata -Contains "v=DMARC1..." | Should -Be $true
+                $Response.rdata -Contains "v=DMARC1; p=reject" | Should -Be $true
             }
         }
 
         Context "When the DMARC record is unavailable at the full domain" {
             BeforeAll {
                 Mock -CommandName Invoke-RobustDnsTxt {
-                    Mock -CommandName Invoke-RobustDnsTxt {
-                        if ($Qname -eq "_dmarc.example.com") {
-                            @{
-                                "Answers" = @("v=DMARC1...");
-                                "Errors" = @();
-                                "NXDomain" = $false;
-                                "LogEntries" = @("some text")
-                            }
+                    if ($Qname -eq "_dmarc.example.com") {
+                        @{
+                            "Answers" = @("v=DMARC1; p=reject");
+                            "Errors" = @();
+                            "NXDomain" = $false;
+                            "LogEntries" = @("some text")
                         }
-                        else {
-                            @{
-                                "Answers" = @();
-                                "Errors" = @();
-                                "NXDomain" = $false;
-                                "LogEntries" = @("Query returned NXDomain")
-                            }
+                    }
+                    else {
+                        @{
+                            "Answers" = @();
+                            "Errors" = @();
+                            "NXDomain" = $false;
+                            "LogEntries" = @("Query returned NXDomain")
                         }
                     }
                 }
             }
-            It "Checks at the organization level" {
-                # There are two locations where DMARC records can be found. If it's not available at the
-                # full domain level, GetScubaDmarcRecord should try again at the organization domain level
+            It "Returns the highest valid policy found by the tree walk" {
                 $Response = Get-ScubaDmarcRecord -Domains @(@{"DomainName" = "a.b.example.com"}) `
                     -PreferredDnsResolvers @() -SkipDoH $false
+                Should -Invoke -CommandName Invoke-RobustDnsTxt -Exactly -Times 4
+                Should -Invoke -CommandName Invoke-RobustDnsTxt -ParameterFilter {
+                    $Qname -eq "_dmarc.example.com"
+                } -Exactly -Times 1
+                $Response.rdata -Contains "v=DMARC1; p=reject" | Should -Be $true
+            }
+        }
+
+        Context "When the public suffix contains multiple labels" {
+            BeforeAll {
+                Mock -CommandName Invoke-RobustDnsTxt {
+                    if ($Qname -eq "_dmarc.example.fed.us") {
+                        @{
+                            "Answers" = @("v=DMARC1; p=reject; psd=n");
+                            "Errors" = @();
+                            "NXDomain" = $false;
+                            "LogEntries" = @("some text")
+                        }
+                    }
+                    else {
+                        @{
+                            "Answers" = @();
+                            "Errors" = @();
+                            "NXDomain" = $false;
+                            "LogEntries" = @("Query returned NXDomain")
+                        }
+                    }
+                }
+            }
+
+            It "Finds the organizational-domain policy and stops at its PSD boundary" {
+                $Response = Get-ScubaDmarcRecord -Domains @(
+                    @{"DomainName" = "subdomain.example.fed.us"}
+                ) -PreferredDnsResolvers @() -SkipDoH $false
+
                 Should -Invoke -CommandName Invoke-RobustDnsTxt -Exactly -Times 2
-                $Response.rdata -Contains "v=DMARC1..." | Should -Be $true
+                Should -Invoke -CommandName Invoke-RobustDnsTxt -ParameterFilter {
+                    $Qname -eq "_dmarc.example.fed.us"
+                } -Exactly -Times 1
+                $Response.rdata -Contains "v=DMARC1; p=reject; psd=n" | Should -Be $true
+            }
+        }
+
+        Context "When the domain exceeds the tree-walk query limit" {
+            BeforeAll {
+                Mock -CommandName Invoke-RobustDnsTxt {
+                    @{
+                        "Answers" = @();
+                        "Errors" = @();
+                        "NXDomain" = $false;
+                        "LogEntries" = @("Query returned NXDomain")
+                    }
+                }
+            }
+
+            It "Makes no more than eight DNS queries" {
+                $Response = Get-ScubaDmarcRecord -Domains @(
+                    @{"DomainName" = "a.b.c.d.e.f.g.h.i.j.k.example.com"}
+                ) -PreferredDnsResolvers @() -SkipDoH $false
+
+                Should -Invoke -CommandName Invoke-RobustDnsTxt -Exactly -Times 8
+                $Response.rdata.Count | Should -Be 0
             }
         }
     }


### PR DESCRIPTION
## Summary

Replace the fixed last-two-label DMARC fallback with the bounded DNS Tree Walk defined by RFC 9989 section 4.10.

## Changes

- query the full domain first;
- when no direct policy exists, walk toward the DNS root and retain the highest valid DMARC policy found;
- cap discovery at eight total DNS queries, skipping intermediate labels for deeply nested domains as required by RFC 9989;
- stop early at an explicit `psd=y` or `psd=n` boundary;
- require exactly one answer beginning with `v=DMARC1;` before treating a response as a DMARC policy;
- preserve log entries from every attempted DNS query; and
- remove the duplicate domain-label split in the previous fallback.

## Tests

Added regression coverage for:

- direct-domain policy lookup;
- highest valid policy selection during a normal tree walk;
- `subdomain.example.fed.us` resolving through `_dmarc.example.fed.us`;
- stopping at a PSD boundary; and
- the eight-query limit for a deeply nested domain.

Validation:

- focused DMARC Pester tests: 6 passed;
- complete EXO provider Pester folder: 42 passed;
- `git diff --check`: passed;
- direct PSScriptAnalyzer on changed files: no new findings in changed code (one existing `PSUseSingularNouns` warning remains at `ExportEXOProvider.psm1:299`).

Fixes #89

Standard: https://www.rfc-editor.org/rfc/rfc9989.html#section-4.10