### PR TITLE
Update service principal helpers for security suite

### DIFF
--- a/PowerShell/ScubaGear/Modules/Permissions/PermissionsHelper.psm1
+++ b/PowerShell/ScubaGear/Modules/Permissions/PermissionsHelper.psm1
@@ -19,7 +19,7 @@ Function Get-ScubaGearPermissions {
         The switch to indicate that the permissions are to be retrieved for a service principal
 
     .PARAMETER Product
-        The product for which the permissions are to be retrieved. Options are 'aad', 'exo', 'defender', 'teams', 'sharepoint', 'powerplatform'. Can be an array of products and used in pipeline
+        The product for which the permissions are to be retrieved. Options are 'aad', 'exo', 'defender', 'securitysuite', 'teams', 'sharepoint', 'powerplatform'. Can be an array of products and used in pipeline
 
     .PARAMETER Environment
         The Environment for which the permissions are to be retrieved. Options are 'commercial', 'gcc', 'gcchigh', 'dod'. Default is 'commercial'
@@ -107,7 +107,7 @@ Function Get-ScubaGearPermissions {
         [switch]$ServicePrincipal,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'ServicePrincipal',ValueFromPipeline=$true)]
-        [ValidateSet('aad', 'exo', 'defender', 'teams', 'sharepoint', 'scubatank', 'powerplatform', '*')]
+        [ValidateSet('aad', 'exo', 'defender', 'securitysuite', 'teams', 'sharepoint', 'scubatank', 'powerplatform', '*')]
         [string[]]$Product,
 
         [Parameter(Mandatory = $false)]
@@ -134,7 +134,7 @@ Function Get-ScubaGearPermissions {
 
         # If ProductName is * then set Product to all possible values
         if ($Product -contains '*') {
-            $Product = @('aad', 'exo', 'defender', 'teams', 'sharepoint', 'powerplatform')
+            $Product = @('aad', 'exo', 'securitysuite', 'teams', 'sharepoint', 'powerplatform')
         }
 
         if($OutAs -eq "endpoint" -and $Product -eq 'sharepoint' -and !$Domain){
@@ -157,6 +157,7 @@ Function Get-ScubaGearPermissions {
                 '00000007-0000-0ff1-ce00-000000000000'
             )
             'defender'   = '00000002-0000-0ff1-ce00-000000000000'
+            'securitysuite' = '00000002-0000-0ff1-ce00-000000000000'
             'sharepoint' = '00000003-0000-0ff1-ce00-000000000000'
             'scubatank'  = '00000003-0000-0000-c000-000000000000'
         }
@@ -197,7 +198,7 @@ Function Get-ScubaGearPermissions {
                             # Filter the resourceAPIAppId based on the product
                             $conditions += {$_.resourceAPIAppId -match ($ResourceAPIHash[$ProductItem] -join '|')}
                             $conditionsmsg += '`$_.resourceAPIAppId -match "' + ($ResourceAPIHash[$ProductItem] -Join '|') + '"'
-                        }elseif($ProductItem -match 'exo|sharepoint|defender'){
+                        }elseif($ProductItem -match 'exo|sharepoint|defender|securitysuite'){
                             # If the product is exo or SharePoint, then the resourceAPIAppId should not match the Exchange/SharePoint resourceAPIAppId
                             # This accounts for interactive permissions needed for Exchange when running the SCuBAGear, and doesn't list SharePoint interactive permissions
                             $conditions += {$_.resourceAPIAppId -notmatch ($ResourceAPIHash[$ProductItem] -join '|')}

--- a/PowerShell/ScubaGear/Modules/Permissions/PermissionsHelper.psm1
+++ b/PowerShell/ScubaGear/Modules/Permissions/PermissionsHelper.psm1
@@ -137,6 +137,11 @@ Function Get-ScubaGearPermissions {
             $Product = @('aad', 'exo', 'securitysuite', 'teams', 'sharepoint', 'powerplatform')
         }
 
+        # Alias: 'defender' is a backward-compatible alias for 'securitysuite'
+        if ($Product) {
+            $Product = $Product | ForEach-Object { if ($_ -eq 'defender') { 'securitysuite' } else { $_ } }
+        }
+
         if($OutAs -eq "endpoint" -and $Product -eq 'sharepoint' -and !$Domain){
             Write-Error -Message "Parameter [-Domain] is required when OutAs is endpoint"
         }
@@ -156,8 +161,14 @@ Function Get-ScubaGearPermissions {
                 '00000002-0000-0ff1-ce00-000000000000',
                 '00000007-0000-0ff1-ce00-000000000000'
             )
-            'defender'   = '00000002-0000-0ff1-ce00-000000000000'
-            'securitysuite' = '00000002-0000-0ff1-ce00-000000000000'
+            'defender'      = @(
+                '00000002-0000-0ff1-ce00-000000000000',
+                '00000007-0000-0ff1-ce00-000000000000'
+            )
+            'securitysuite' = @(
+                '00000002-0000-0ff1-ce00-000000000000',
+                '00000007-0000-0ff1-ce00-000000000000'
+            )
             'sharepoint' = '00000003-0000-0ff1-ce00-000000000000'
             'scubatank'  = '00000003-0000-0000-c000-000000000000'
         }
@@ -312,7 +323,7 @@ Function Get-ScubaGearPermissions {
             }
             'appId'{
                 Write-Verbose -Message "Command: `$collection | Select-Object -ExpandProperty resourceAPIAppId -Unique"
-                $output += ($collection | Where-Object $filterScript | Select-Object -ExpandProperty resourceAPIAppId -Unique).Split('#')[0]
+                $output += $collection | Where-Object $filterScript | Select-Object -ExpandProperty resourceAPIAppId -Unique | ForEach-Object { $_.Split('#')[0] }
             }
             'role' {
                 Try{
@@ -438,7 +449,7 @@ Function Get-ServicePrincipalPermissions {
         [string]$Environment = 'commercial'
     )
 
-    $ProductNames = "aad", "exo", "sharepoint"
+    $ProductNames = "aad", "exo", "sharepoint", "securitysuite"
 
     # Create a list to hold the filtered permissions
     $filteredPermissions = @()

--- a/PowerShell/ScubaGear/Modules/Permissions/PermissionsHelper.psm1
+++ b/PowerShell/ScubaGear/Modules/Permissions/PermissionsHelper.psm1
@@ -95,6 +95,7 @@ Function Get-ScubaGearPermissions {
         2024-11-15 - Removed redundantpermissions and added verbose messages
         2024-12-20 - Added version and changelog. Added support for pipeline and for multiple products. Fixed issue with role output for null values
         2024-12-23 - Adjusted endpoint output based on structure changes in the permissions file
+        2026-06-19 - Added SecuritySuite and removed ScubaTank to product list
     #>
 
     [CmdletBinding(DefaultParameterSetName = 'CmdletName')]

--- a/PowerShell/ScubaGear/Modules/Permissions/PermissionsHelper.psm1
+++ b/PowerShell/ScubaGear/Modules/Permissions/PermissionsHelper.psm1
@@ -108,7 +108,7 @@ Function Get-ScubaGearPermissions {
         [switch]$ServicePrincipal,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'ServicePrincipal',ValueFromPipeline=$true)]
-        [ValidateSet('aad', 'exo', 'securitysuite', 'teams', 'sharepoint', 'scubatank', 'powerplatform', '*')]
+        [ValidateSet('aad', 'exo', 'securitysuite', 'teams', 'sharepoint', 'powerplatform', '*')]
         [string[]]$Product,
 
         [Parameter(Mandatory = $false)]

--- a/PowerShell/ScubaGear/Modules/Permissions/PermissionsHelper.psm1
+++ b/PowerShell/ScubaGear/Modules/Permissions/PermissionsHelper.psm1
@@ -82,7 +82,7 @@ Function Get-ScubaGearPermissions {
 
     .NOTES
         NAME: Get-ScubaGearPermissions
-        VERSION: 1.9
+        VERSION: 2.0
 
         USE TO FIND PERMS:
             (Find-MgGraphCommand -Command Get-MgBetaPolicyRoleManagementPolicyAssignment).Permissions | Select Name, IsLeastPrivilege

--- a/PowerShell/ScubaGear/Modules/Permissions/PermissionsHelper.psm1
+++ b/PowerShell/ScubaGear/Modules/Permissions/PermissionsHelper.psm1
@@ -162,7 +162,6 @@ Function Get-ScubaGearPermissions {
                 '00000007-0000-0ff1-ce00-000000000000'
             )
             'sharepoint' = '00000003-0000-0ff1-ce00-000000000000'
-            'scubatank'  = '00000003-0000-0000-c000-000000000000'
         }
 
         # Start with an empty array to build the filter

--- a/PowerShell/ScubaGear/Modules/Permissions/PermissionsHelper.psm1
+++ b/PowerShell/ScubaGear/Modules/Permissions/PermissionsHelper.psm1
@@ -19,7 +19,7 @@ Function Get-ScubaGearPermissions {
         The switch to indicate that the permissions are to be retrieved for a service principal
 
     .PARAMETER Product
-        The product for which the permissions are to be retrieved. Options are 'aad', 'exo', 'defender', 'securitysuite', 'teams', 'sharepoint', 'powerplatform'. Can be an array of products and used in pipeline
+        The product for which the permissions are to be retrieved. Options are 'aad', 'exo', 'securitysuite', 'teams', 'sharepoint', 'powerplatform'. Can be an array of products and used in pipeline
 
     .PARAMETER Environment
         The Environment for which the permissions are to be retrieved. Options are 'commercial', 'gcc', 'gcchigh', 'dod'. Default is 'commercial'
@@ -107,7 +107,7 @@ Function Get-ScubaGearPermissions {
         [switch]$ServicePrincipal,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'ServicePrincipal',ValueFromPipeline=$true)]
-        [ValidateSet('aad', 'exo', 'defender', 'securitysuite', 'teams', 'sharepoint', 'scubatank', 'powerplatform', '*')]
+        [ValidateSet('aad', 'exo', 'securitysuite', 'teams', 'sharepoint', 'scubatank', 'powerplatform', '*')]
         [string[]]$Product,
 
         [Parameter(Mandatory = $false)]
@@ -137,11 +137,6 @@ Function Get-ScubaGearPermissions {
             $Product = @('aad', 'exo', 'securitysuite', 'teams', 'sharepoint', 'powerplatform')
         }
 
-        # Alias: 'defender' is a backward-compatible alias for 'securitysuite'
-        if ($Product) {
-            $Product = $Product | ForEach-Object { if ($_ -eq 'defender') { 'securitysuite' } else { $_ } }
-        }
-
         if($OutAs -eq "endpoint" -and $Product -eq 'sharepoint' -and !$Domain){
             Write-Error -Message "Parameter [-Domain] is required when OutAs is endpoint"
         }
@@ -158,10 +153,6 @@ Function Get-ScubaGearPermissions {
         $ResourceAPIHash = @{
             'aad'        = '00000003-0000-0000-c000-000000000000'
             'exo'        = @(
-                '00000002-0000-0ff1-ce00-000000000000',
-                '00000007-0000-0ff1-ce00-000000000000'
-            )
-            'defender'      = @(
                 '00000002-0000-0ff1-ce00-000000000000',
                 '00000007-0000-0ff1-ce00-000000000000'
             )
@@ -209,7 +200,7 @@ Function Get-ScubaGearPermissions {
                             # Filter the resourceAPIAppId based on the product
                             $conditions += {$_.resourceAPIAppId -match ($ResourceAPIHash[$ProductItem] -join '|')}
                             $conditionsmsg += '`$_.resourceAPIAppId -match "' + ($ResourceAPIHash[$ProductItem] -Join '|') + '"'
-                        }elseif($ProductItem -match 'exo|sharepoint|defender|securitysuite'){
+                        }elseif($ProductItem -match 'exo|sharepoint|securitysuite'){
                             # If the product is exo or SharePoint, then the resourceAPIAppId should not match the Exchange/SharePoint resourceAPIAppId
                             # This accounts for interactive permissions needed for Exchange when running the SCuBAGear, and doesn't list SharePoint interactive permissions
                             $conditions += {$_.resourceAPIAppId -notmatch ($ResourceAPIHash[$ProductItem] -join '|')}

--- a/PowerShell/ScubaGear/Modules/Permissions/PermissionsHelper.psm1
+++ b/PowerShell/ScubaGear/Modules/Permissions/PermissionsHelper.psm1
@@ -147,8 +147,8 @@ Function Get-ScubaGearPermissions {
 
         [string]$ResourceRoot = ($PWD.ProviderPath, $PSScriptRoot)[[bool]$PSScriptRoot]
 
-        $permissionSet = Get-Content -Path "$ResourceRoot\ScubaGearPermissions.json" | ConvertFrom-Json
-        Write-Verbose "Command: `$permissionSet = Get-Content -Path '$ResourceRoot\ScubaGearPermissions.json' | ConvertFrom-Json"
+        $permissionSet = Get-Content -Path "$ResourceRoot\..\..\schemas\ScubaGearApiCatalog.json" | ConvertFrom-Json
+        Write-Verbose "Command: `$permissionSet = Get-Content -Path '$ResourceRoot\..\..\schemas\ScubaGearApiCatalog.json' | ConvertFrom-Json"
 
         $ResourceAPIHash = @{
             'aad'        = '00000003-0000-0000-c000-000000000000'

--- a/PowerShell/ScubaGear/Modules/Permissions/PermissionsHelper.psm1
+++ b/PowerShell/ScubaGear/Modules/Permissions/PermissionsHelper.psm1
@@ -45,7 +45,7 @@ Function Get-ScubaGearPermissions {
     .EXAMPLE
         Get-ScubaGearPermissions -Product aad
         Get-ScubaGearPermissions -Product exo
-        Get-ScubaGearPermissions -Product scubatank
+        Get-ScubaGearPermissions -Product securitysuite
 
     .EXAMPLE
         Get-ScubaGearPermissions -CmdletName Get-MgBetaUser -OutAs modules

--- a/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfigDefaults.json
+++ b/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfigDefaults.json
@@ -13,7 +13,7 @@
       "Linux": "opa_linux_amd64_static"
     },
     "ProductNames": ["aad", "securitysuite", "exo", "sharepoint", "teams"],
-    "AllProductNames": ["aad", "securitysuite", "exo", "powerplatform", "sharepoint", "teams", "powerbi"],
+    "AllProductNames": ["aad", "securitysuite", "exo", "powerplatform", "sharepoint", "teams", "powerbi","intune"],
     "M365Environment": "commercial",
     "LogIn": true,
     "DisconnectOnExit": false,

--- a/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfigDefaults.json
+++ b/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfigDefaults.json
@@ -13,7 +13,7 @@
       "Linux": "opa_linux_amd64_static"
     },
     "ProductNames": ["aad", "securitysuite", "exo", "sharepoint", "teams"],
-    "AllProductNames": ["aad", "securitysuite", "exo", "powerplatform", "sharepoint", "teams", "powerbi","intune"],
+    "AllProductNames": ["aad", "securitysuite", "exo", "powerplatform", "sharepoint", "teams", "powerbi"],
     "M365Environment": "commercial",
     "LogIn": true,
     "DisconnectOnExit": false,

--- a/PowerShell/ScubaGear/Modules/ScubaConfigApp/ScubaConfigApp.psm1
+++ b/PowerShell/ScubaGear/Modules/ScubaConfigApp/ScubaConfigApp.psm1
@@ -110,7 +110,7 @@ Function Start-SCuBAConfigApp {
         [ValidateScript({ Test-Path $_ -PathType Leaf })]
         [string]$ConfigFilePath,
 
-        [ValidateSet('en-US')]
+        [ValidateSet('en-US','en-ES','fr-FR','de-DE')]
         $Language = 'en-US',
 
         [Parameter(Mandatory = $false,ParameterSetName = 'Online')]

--- a/PowerShell/ScubaGear/Modules/ScubaConfigApp/ScubaConfigApp.psm1
+++ b/PowerShell/ScubaGear/Modules/ScubaConfigApp/ScubaConfigApp.psm1
@@ -110,7 +110,7 @@ Function Start-SCuBAConfigApp {
         [ValidateScript({ Test-Path $_ -PathType Leaf })]
         [string]$ConfigFilePath,
 
-        [ValidateSet('en-US','en-ES','fr-FR','de-DE')]
+        [ValidateSet('en-US')]
         $Language = 'en-US',
 
         [Parameter(Mandatory = $false,ParameterSetName = 'Online')]

--- a/PowerShell/ScubaGear/Modules/Support/ServicePrincipal.psm1
+++ b/PowerShell/ScubaGear/Modules/Support/ServicePrincipal.psm1
@@ -446,7 +446,7 @@ function Set-ScubaGearRole {
         Used to define the AppID of the service principal that will be added to the roles specified by the ScubaGearSPRole parameter.
 
     .PARAMETER roleDefinitionID
-        The role definition ID that is required for the ScubaGear application. Current roles are defined in the ScubaGearPermissions.json file.
+        The role definition ID that is required for the ScubaGear application. Current roles are defined in the ScubaGearApiCatalog.json file.
 
     .PARAMETER M365Environment
         Used to define the environment that the application will be created in. The options are commercial, gcc, gcchigh, dod
@@ -532,7 +532,7 @@ function Get-ScubaGearAppRoleID {
         This function will retrieve the AppRole IDs for the permissions specified in the ScubaGearSPPermissions parameter.
 
     .PARAMETER ScubaGearSPPermissions
-        The permissions that are required for the ScubaGear application. Current permissions are defined in the ScubaGearPermissions.json file.
+        The permissions that are required for the ScubaGear application. Current permissions are defined in the ScubaGearApiCatalog.json file.
 
     .PARAMETER M365Environment
         Used to define the environment that the application will be created in. The options are commercial, gcc, gcchigh, dod
@@ -651,7 +651,7 @@ function Set-AppRegistrationPermission {
         Used to define the AppID of the service principal that will be updated with the required permissions.
 
     .PARAMETER ScubaGearSPPermissions
-        The permissions that are required for the ScubaGear application. Current permissions are defined in the ScubaGearPermissions.json file.
+        The permissions that are required for the ScubaGear application. Current permissions are defined in the ScubaGearApiCatalog.json file.
 
     .PARAMETER M365Environment
         Used to define the environment that the application will be created in. The options are commercial, gcc, gcchigh, dod

--- a/PowerShell/ScubaGear/Modules/Support/ServicePrincipal.psm1
+++ b/PowerShell/ScubaGear/Modules/Support/ServicePrincipal.psm1
@@ -2326,7 +2326,11 @@ function New-ScubaGearServicePrincipal {
         $allPermissions = Get-ServicePrincipalPermissions -Environment $M365Environment
 
         # Filter permissions based on selected products
-        $filteredPermissions = $allPermissions | Where-Object { $_.scubaGearProduct -in $ProductNames }
+        # scubaGearProduct is an array on each row, so use -contains instead of -in
+        $filteredPermissions = $allPermissions | Where-Object {
+            $prod = $_.scubaGearProduct
+            ($ProductNames | Where-Object { $prod -contains $_ }).Count -gt 0
+        }
 
         if ($(@($filteredPermissions).Count) -eq 0) {
             Write-Verbose "No API permissions needed for selected products (may require Entra role instead)"

--- a/PowerShell/ScubaGear/Modules/Support/ServicePrincipal.psm1
+++ b/PowerShell/ScubaGear/Modules/Support/ServicePrincipal.psm1
@@ -132,7 +132,7 @@ function Compare-ScubaGearPermission {
         Used to pass in the service principal permissions if already obtained. This can be used to skip the call to Microsoft Graph to get the service principal permissions.
 
     .PARAMETER ProductNames
-        Used to filter the required permissions by product. This can be used to only check for permissions required by specific products. Valid values are "aad", "exo", "sharepoint", "teams", "powerplatform", "defender", "securitysuite", and "*". The default is to check for all permissions.
+        Used to filter the required permissions by product. This can be used to only check for permissions required by specific products. Valid values are "aad", "exo", "sharepoint", "teams", "powerplatform", "securitysuite", and "*". The default is to check for all permissions.
 
     .EXAMPLE
         Compare-ScubaGearPermission -ServicePrincipalID "AppID" -AppRoleIDs $AppRoleIDs -M365Environment commercial
@@ -179,7 +179,7 @@ function Compare-ScubaGearPermission {
         [Object]$SPPerms,
 
         [Parameter(Mandatory = $false)]
-        [ValidateSet("aad", "exo", "sharepoint", "teams", "powerplatform", "defender", "securitysuite", '*', IgnoreCase = $True)]
+        [ValidateSet("aad", "exo", "sharepoint", "teams", "powerplatform", "securitysuite", '*', IgnoreCase = $True)]
         [string[]]$ProductNames
     )
 
@@ -859,7 +859,7 @@ function Get-ScubaGearAppPermission {
 
     .PARAMETER ProductNames
         This allows you to define which products that the Service Principal will be assessing and only compare against those needed permissions.
-        Valid options are: 'aad', 'exo', 'sharepoint', 'teams', 'powerplatform', 'defender', 'securitysuite', '*' (which includes all products)
+        Valid options are: 'aad', 'exo', 'sharepoint', 'teams', 'powerplatform', 'securitysuite', '*' (which includes all products)
 
     .EXAMPLE
         Get-ScubaGearAppPermission -AppID "AppID" -M365Environment commercial -ProductNames 'aad'
@@ -904,20 +904,11 @@ function Get-ScubaGearAppPermission {
         [string]$M365Environment,
 
         [Parameter(Mandatory = $false)]
-        [ValidateSet("aad", "exo", "sharepoint", "teams", "powerplatform", "defender", "securitysuite", '*', IgnoreCase = $True)]
+        [ValidateSet("aad", "exo", "sharepoint", "teams", "powerplatform", "securitysuite", '*', IgnoreCase = $True)]
         [string[]]$ProductNames = '*'
     )
 
     $M365Environment = $M365Environment.ToLower()
-
-    # defender is an alias for securitysuite, substitute securitysuite in for defender if specified
-    if ($ProductNames -contains 'defender'){
-        if (-not ($ProductNames -contains 'securitysuite')) {
-            $ProductNames = $ProductNames + 'securitysuite'
-        }
-        $ProductNames = @($ProductNames | Where-Object {$_ -ne "defender" })
-        Write-Debug "Substituting defender with securitysuite in ProductNames"
-    }
 
     try {
         # Connect to Microsoft Graph
@@ -1419,7 +1410,7 @@ function Set-ScubaGearAppPermission {
 
     .PARAMETER ProductNames
         Products to configure permissions for. Required when not using pipeline.
-        Valid values are: 'aad', 'exo', 'sharepoint', 'teams', 'powerplatform', 'defender', 'securitysuite', '*'
+        Valid values are: 'aad', 'exo', 'sharepoint', 'teams', 'powerplatform', 'securitysuite', '*'
 
     .EXAMPLE
         Get-ScubaGearAppPermission -AppID "AppID" -M365Environment commercial -ProductNames "aad" | Set-ScubaGearAppPermission
@@ -1478,7 +1469,7 @@ function Set-ScubaGearAppPermission {
             Mandatory = $false,
             ParameterSetName = 'Standalone'
         )]
-        [ValidateSet("aad", "exo", "sharepoint", "teams", "powerplatform", "defender", "securitysuite", '*', IgnoreCase = $True)]
+        [ValidateSet("aad", "exo", "sharepoint", "teams", "powerplatform", "securitysuite", '*', IgnoreCase = $True)]
         [string[]]$ProductNames = '*'
     )
 
@@ -1489,15 +1480,6 @@ function Set-ScubaGearAppPermission {
     }
 
     process {
-        # defender is an alias for securitysuite, substitute securitysuite in for defender if specified
-        if ($ProductNames -contains 'defender'){
-            if (-not ($ProductNames -contains 'securitysuite')) {
-                $ProductNames = $ProductNames + 'securitysuite'
-            }
-            $ProductNames = @($ProductNames | Where-Object {$_ -ne "defender" })
-            Write-Debug "Substituting defender with securitysuite in ProductNames"
-        }
-
         # Determine which parameter set is being used
         if ($PSCmdlet.ParameterSetName -eq 'Standalone') {
             Write-Verbose "Running in standalone mode - fetching current permissions"
@@ -2259,7 +2241,7 @@ function New-ScubaGearServicePrincipal {
 
     .PARAMETER ProductNames
         This allows you to define which products that the Service Principal will be configured for and only apply those needed permissions.
-        Valid options are: 'aad', 'exo', 'sharepoint', 'teams', 'powerplatform', 'defender', 'securitysuite', '*' (which includes all products)
+        Valid options are: 'aad', 'exo', 'sharepoint', 'teams', 'powerplatform', 'securitysuite', '*' (which includes all products)
 
     .PARAMETER ServicePrincipalName
         Used to define the name of the Service Principal that will be created. The default is "ScubaGear Application"
@@ -2318,7 +2300,7 @@ function New-ScubaGearServicePrincipal {
         [string]$M365Environment,
 
         [Parameter(Mandatory=$false)]
-        [ValidateSet("aad", "exo", "sharepoint", "teams", "powerplatform", "defender", "securitysuite", '*', IgnoreCase = $True)]
+        [ValidateSet("aad", "exo", "sharepoint", "teams", "powerplatform", "securitysuite", '*', IgnoreCase = $True)]
         [string[]]$ProductNames = '*',
 
         [Parameter(Mandatory=$false)]
@@ -2331,15 +2313,6 @@ function New-ScubaGearServicePrincipal {
     )
 
     Try {
-        # defender is an alias for securitysuite, substitute securitysuite in for defender if specified
-        if ($ProductNames -contains 'defender'){
-            if (-not ($ProductNames -contains 'securitysuite')) {
-                $ProductNames = $ProductNames + 'securitysuite'
-            }
-            $ProductNames = @($ProductNames | Where-Object {$_ -ne "defender" })
-            Write-Debug "Substituting defender with securitysuite in ProductNames"
-        }
-
         # Handle wildcard for ProductNames
         if($ProductNames -contains '*'){
             # If wildcard is specified, include all products

--- a/PowerShell/ScubaGear/Modules/Support/ServicePrincipal.psm1
+++ b/PowerShell/ScubaGear/Modules/Support/ServicePrincipal.psm1
@@ -132,7 +132,7 @@ function Compare-ScubaGearPermission {
         Used to pass in the service principal permissions if already obtained. This can be used to skip the call to Microsoft Graph to get the service principal permissions.
 
     .PARAMETER ProductNames
-        Used to filter the required permissions by product. This can be used to only check for permissions required by specific products. Valid values are "aad", "exo", "sharepoint", "teams", "powerplatform", "defender", and "*". The default is to check for all permissions.
+        Used to filter the required permissions by product. This can be used to only check for permissions required by specific products. Valid values are "aad", "exo", "sharepoint", "teams", "powerplatform", "defender", "securitysuite", and "*". The default is to check for all permissions.
 
     .EXAMPLE
         Compare-ScubaGearPermission -ServicePrincipalID "AppID" -AppRoleIDs $AppRoleIDs -M365Environment commercial
@@ -179,7 +179,7 @@ function Compare-ScubaGearPermission {
         [Object]$SPPerms,
 
         [Parameter(Mandatory = $false)]
-        [ValidateSet("aad", "exo", "sharepoint", "teams", "powerplatform", "defender", '*', IgnoreCase = $True)]
+        [ValidateSet("aad", "exo", "sharepoint", "teams", "powerplatform", "defender", "securitysuite", '*', IgnoreCase = $True)]
         [string[]]$ProductNames
     )
 
@@ -223,7 +223,7 @@ function Compare-ScubaGearPermission {
         $FilteredAppRoleIDs = $AppRoleIDs
     }
 
-    # Handle case where NO application permissions are required (e.g., Defender - role-only)
+    # Handle case where NO application permissions are required (e.g., Security Suite - role-only)
     # Some products only require directory roles and no application permissions
     if ($null -eq $FilteredAppRoleIDs -or $FilteredAppRoleIDs.Count -eq 0) {
         Write-Verbose "No application permissions required for product(s): $($ProductNames -join ', ')"
@@ -859,7 +859,7 @@ function Get-ScubaGearAppPermission {
 
     .PARAMETER ProductNames
         This allows you to define which products that the Service Principal will be assessing and only compare against those needed permissions.
-        Valid options are: 'aad', 'exo', 'sharepoint', 'teams', 'powerplatform', 'defender', '*' (which includes all products)
+        Valid options are: 'aad', 'exo', 'sharepoint', 'teams', 'powerplatform', 'defender', 'securitysuite', '*' (which includes all products)
 
     .EXAMPLE
         Get-ScubaGearAppPermission -AppID "AppID" -M365Environment commercial -ProductNames 'aad'
@@ -904,11 +904,20 @@ function Get-ScubaGearAppPermission {
         [string]$M365Environment,
 
         [Parameter(Mandatory = $false)]
-        [ValidateSet("aad", "exo", "sharepoint", "teams", "powerplatform", "defender", '*', IgnoreCase = $True)]
+        [ValidateSet("aad", "exo", "sharepoint", "teams", "powerplatform", "defender", "securitysuite", '*', IgnoreCase = $True)]
         [string[]]$ProductNames = '*'
     )
 
     $M365Environment = $M365Environment.ToLower()
+
+    # defender is an alias for securitysuite, substitute securitysuite in for defender if specified
+    if ($ProductNames -contains 'defender'){
+        if (-not ($ProductNames -contains 'securitysuite')) {
+            $ProductNames = $ProductNames + 'securitysuite'
+        }
+        $ProductNames = @($ProductNames | Where-Object {$_ -ne "defender" })
+        Write-Debug "Substituting defender with securitysuite in ProductNames"
+    }
 
     try {
         # Connect to Microsoft Graph
@@ -921,7 +930,7 @@ function Get-ScubaGearAppPermission {
 
     if($ProductNames -contains '*'){
         # If wildcard is specified, include all products
-        $ProductNames = @('aad', 'exo', 'sharepoint', 'teams', 'powerplatform', 'defender')
+        $ProductNames = @('aad', 'exo', 'sharepoint', 'teams', 'powerplatform', 'securitysuite')
     }
 
     # Check Power Platform registration - always check to report current status
@@ -1410,7 +1419,7 @@ function Set-ScubaGearAppPermission {
 
     .PARAMETER ProductNames
         Products to configure permissions for. Required when not using pipeline.
-        Valid values are: 'aad', 'exo', 'sharepoint', 'teams', 'powerplatform', 'defender', '*'
+        Valid values are: 'aad', 'exo', 'sharepoint', 'teams', 'powerplatform', 'defender', 'securitysuite', '*'
 
     .EXAMPLE
         Get-ScubaGearAppPermission -AppID "AppID" -M365Environment commercial -ProductNames "aad" | Set-ScubaGearAppPermission
@@ -1469,7 +1478,7 @@ function Set-ScubaGearAppPermission {
             Mandatory = $false,
             ParameterSetName = 'Standalone'
         )]
-        [ValidateSet("aad", "exo", "sharepoint", "teams", "powerplatform", "defender", '*', IgnoreCase = $True)]
+        [ValidateSet("aad", "exo", "sharepoint", "teams", "powerplatform", "defender", "securitysuite", '*', IgnoreCase = $True)]
         [string[]]$ProductNames = '*'
     )
 
@@ -1480,6 +1489,15 @@ function Set-ScubaGearAppPermission {
     }
 
     process {
+        # defender is an alias for securitysuite, substitute securitysuite in for defender if specified
+        if ($ProductNames -contains 'defender'){
+            if (-not ($ProductNames -contains 'securitysuite')) {
+                $ProductNames = $ProductNames + 'securitysuite'
+            }
+            $ProductNames = @($ProductNames | Where-Object {$_ -ne "defender" })
+            Write-Debug "Substituting defender with securitysuite in ProductNames"
+        }
+
         # Determine which parameter set is being used
         if ($PSCmdlet.ParameterSetName -eq 'Standalone') {
             Write-Verbose "Running in standalone mode - fetching current permissions"
@@ -2241,7 +2259,7 @@ function New-ScubaGearServicePrincipal {
 
     .PARAMETER ProductNames
         This allows you to define which products that the Service Principal will be configured for and only apply those needed permissions.
-        Valid options are: 'aad', 'exo', 'sharepoint', 'teams', 'powerplatform', 'defender', '*' (which includes all products)
+        Valid options are: 'aad', 'exo', 'sharepoint', 'teams', 'powerplatform', 'defender', 'securitysuite', '*' (which includes all products)
 
     .PARAMETER ServicePrincipalName
         Used to define the name of the Service Principal that will be created. The default is "ScubaGear Application"
@@ -2300,7 +2318,7 @@ function New-ScubaGearServicePrincipal {
         [string]$M365Environment,
 
         [Parameter(Mandatory=$false)]
-        [ValidateSet("aad", "exo", "sharepoint", "teams", "powerplatform", "defender", '*', IgnoreCase = $True)]
+        [ValidateSet("aad", "exo", "sharepoint", "teams", "powerplatform", "defender", "securitysuite", '*', IgnoreCase = $True)]
         [string[]]$ProductNames = '*',
 
         [Parameter(Mandatory=$false)]
@@ -2313,10 +2331,19 @@ function New-ScubaGearServicePrincipal {
     )
 
     Try {
+        # defender is an alias for securitysuite, substitute securitysuite in for defender if specified
+        if ($ProductNames -contains 'defender'){
+            if (-not ($ProductNames -contains 'securitysuite')) {
+                $ProductNames = $ProductNames + 'securitysuite'
+            }
+            $ProductNames = @($ProductNames | Where-Object {$_ -ne "defender" })
+            Write-Debug "Substituting defender with securitysuite in ProductNames"
+        }
+
         # Handle wildcard for ProductNames
         if($ProductNames -contains '*'){
             # If wildcard is specified, include all products
-            $ProductNames = @('aad', 'exo', 'sharepoint', 'teams', 'powerplatform', 'defender')
+            $ProductNames = @('aad', 'exo', 'sharepoint', 'teams', 'powerplatform', 'securitysuite')
         }
 
         # Get permissions using the same approach as Get-ScubaGearAppPermission

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Permissions/PermissionsHelper.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Permissions/PermissionsHelper.Tests.ps1
@@ -150,14 +150,6 @@ InModuleScope PermissionsHelper {
             }
         }
 
-        Context "Check that 'defender' is a valid alias for securitysuite" {
-            It "should return the same result for -Product defender as -Product securitysuite" {
-                $expected = Get-ScubaGearPermissions -Product securitysuite -ServicePrincipal
-                $result   = Get-ScubaGearPermissions -Product defender    -ServicePrincipal
-                $result | Should -Be $expected
-            }
-        }
-
         Context "Wildcard expansion includes securitysuite" {
             It "should include securitysuite permissions when -Product * is used with -ServicePrincipal" {
                 $result = Get-ScubaGearPermissions -Product * -ServicePrincipal

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Permissions/PermissionsHelper.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Permissions/PermissionsHelper.Tests.ps1
@@ -109,3 +109,103 @@ InModuleScope PermissionsHelper {
         }
     }
 }
+
+InModuleScope PermissionsHelper {
+    Describe -Tag 'PermissionsHelper' -Name "Get-ScubaGearPermissions - securitysuite" {
+
+        Context "Check service principal API permissions for securitysuite (commercial)" {
+            It "should return Exchange.ManageAsApp for securitysuite commercial" {
+                $expected = @(
+                    "Exchange.ManageAsApp"
+                )
+                $result = Get-ScubaGearPermissions -Product securitysuite -ServicePrincipal
+                $result | Should -Be $expected
+            }
+        }
+
+        Context "Check service principal API permissions for securitysuite (gcchigh)" {
+            It "should return Exchange.ManageAsApp for securitysuite gcchigh" {
+                $result = Get-ScubaGearPermissions -Product securitysuite -ServicePrincipal -Environment gcchigh
+                $result | Should -Contain "Exchange.ManageAsApp"
+            }
+
+            It "should include both Exchange Online and EOP resource API IDs for securitysuite gcchigh" {
+                # gcchigh requires Exchange.ManageAsApp on BOTH
+                #   00000002-0000-0ff1-ce00-000000000000 (Exchange Online)
+                #   00000007-0000-0ff1-ce00-000000000000 (Exchange Online Protection)
+                $result = Get-ScubaGearPermissions -Product securitysuite -ServicePrincipal -OutAs appId -Environment gcchigh
+                $result | Should -HaveCount 2
+                $result | Should -Contain "00000002-0000-0ff1-ce00-000000000000"
+                $result | Should -Contain "00000007-0000-0ff1-ce00-000000000000"
+            }
+        }
+
+        Context "Check role permissions for securitysuite" {
+            It "should return Global Reader for securitysuite" {
+                $expected = @(
+                    "Global Reader"
+                )
+                $result = Get-ScubaGearPermissions -Product securitysuite -OutAs role
+                $result | Should -Be $expected
+            }
+        }
+
+        Context "Check that 'defender' is a valid alias for securitysuite" {
+            It "should return the same result for -Product defender as -Product securitysuite" {
+                $expected = Get-ScubaGearPermissions -Product securitysuite -ServicePrincipal
+                $result   = Get-ScubaGearPermissions -Product defender    -ServicePrincipal
+                $result | Should -Be $expected
+            }
+        }
+
+        Context "Wildcard expansion includes securitysuite" {
+            It "should include securitysuite permissions when -Product * is used with -ServicePrincipal" {
+                $result = Get-ScubaGearPermissions -Product * -ServicePrincipal
+                $result | Should -Contain "Exchange.ManageAsApp"
+            }
+        }
+    }
+}
+
+InModuleScope PermissionsHelper {
+    Describe -Tag 'PermissionsHelper' -Name "Get-ServicePrincipalPermissions - securitysuite" {
+
+        Context "securitysuite entries are included in service principal permission table" {
+            It "should return at least one row with scubaGearProduct containing securitysuite" {
+                $result = Get-ServicePrincipalPermissions
+                $ssRows = $result | Where-Object { $_.scubaGearProduct -contains "securitysuite" }
+                $ssRows | Should -Not -BeNullOrEmpty
+            }
+
+            It "should return Exchange.ManageAsApp as leastPermissions for securitysuite" {
+                $result = Get-ServicePrincipalPermissions
+                $ssRows = $result | Where-Object { $_.scubaGearProduct -contains "securitysuite" }
+                $ssRows.leastPermissions | Should -Contain "Exchange.ManageAsApp"
+            }
+
+            It "should reference the Office 365 Exchange Online resource API for securitysuite" {
+                $result = Get-ServicePrincipalPermissions
+                $ssRows = $result | Where-Object { $_.scubaGearProduct -contains "securitysuite" }
+                $ssRows.resourceAPIAppId | Should -Contain "00000002-0000-0ff1-ce00-000000000000"
+            }
+        }
+
+        Context "EXO service principal permissions are still present" {
+            It "should still include Exchange.ManageAsApp for exo product" {
+                $result = Get-ServicePrincipalPermissions
+                $exoRows = $result | Where-Object { $_.scubaGearProduct -contains "exo" }
+                $exoRows | Should -Not -BeNullOrEmpty
+                $exoRows.leastPermissions | Should -Contain "Exchange.ManageAsApp"
+            }
+        }
+
+        Context "SharePoint service principal permissions are still present" {
+            It "should still include Sites.FullControl.All for sharepoint product" {
+                $result = Get-ServicePrincipalPermissions
+                $spRows = $result | Where-Object { $_.scubaGearProduct -contains "sharepoint" }
+                $spRows | Should -Not -BeNullOrEmpty
+                $spRows.leastPermissions | Should -Contain "Sites.FullControl.All"
+            }
+        }
+    }
+}

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/AADProvider/Invoke-GraphDirectly.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/AADProvider/Invoke-GraphDirectly.Tests.ps1
@@ -70,7 +70,7 @@ InModuleScope Utility {
             }
         }
 
-        # Tests to ensure that corrent Microsoft Graph API URL is returned. The URL is stored in the permissions configuration file (ScubaGearPermissions.json).
+        # Tests to ensure that corrent Microsoft Graph API URL is returned. The URL is stored in the permissions configuration file (ScubaGearApiCatalog.json).
         It "should return the expected value from Invoke-GraphDirectly for <Cmdlet> in <EnvName>" -TestCases $combinedCases {
             param($EnvName, $EnvUrl, $Cmdlet, $Path, $NeedsID, $IdValue)
 
@@ -85,7 +85,7 @@ InModuleScope Utility {
             $result | Should -Be $expected
         }
 
-        # Tests to ensure that the correct API header is returned for each cmdlet that requires it. The API header is stored in the permissions configuration file (ScubaGearPermissions.json).
+        # Tests to ensure that the correct API header is returned for each cmdlet that requires it. The API header is stored in the permissions configuration file (ScubaGearApiCatalog.json).
         $ApiHeaderCases = @(
             @{ Cmdlet = "Get-MgBetaUserCount"; Path = "users/`$count"; NeedsID = $false; IdValue = $null; apiHeader = @{ConsistencyLevel = "eventual"} }
         )

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/ServicePrincipalSnippets/MockExtraPermissions.json
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/ServicePrincipalSnippets/MockExtraPermissions.json
@@ -40,7 +40,7 @@
         "missing": false
     },
     "powerPlatformRegistered": false,
-    "productNames": ["aad", "exo", "defender", "sharepoint", "teams", "powerplatform"],
+    "productNames": ["aad", "exo", "securitysuite", "sharepoint", "teams", "powerplatform"],
     "expectedResult": {
         "hasFixPermissionIssues": true,
         "statusPattern": "Action needed.*extra permissions"

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/ServicePrincipalSnippets/MockMissingPermissions.json
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/ServicePrincipalSnippets/MockMissingPermissions.json
@@ -35,7 +35,7 @@
         "missing": false
     },
     "powerPlatformRegistered": false,
-    "productNames": ["aad", "exo", "defender", "sharepoint", "teams", "powerplatform"],
+    "productNames": ["aad", "exo", "securitysuite", "sharepoint", "teams", "powerplatform"],
     "expectedResult": {
         "hasFixPermissionIssues": true,
         "statusPattern": "Action needed.*missing permissions"

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/ServicePrincipalSnippets/MockMissingRole.json
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/ServicePrincipalSnippets/MockMissingRole.json
@@ -35,7 +35,7 @@
         "missing": true
     },
     "powerPlatformRegistered": true,
-    "productNames": ["aad", "exo", "defender", "sharepoint", "teams", "powerplatform"],
+    "productNames": ["aad", "exo", "securitysuite", "sharepoint", "teams", "powerplatform"],
     "expectedResult": {
         "hasFixPermissionIssues": true,
         "statusPattern": "Action needed.*missing role"

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/ServicePrincipalSnippets/MockOptimalPermissions.json
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/ServicePrincipalSnippets/MockOptimalPermissions.json
@@ -125,7 +125,7 @@
         "missing": false
     },
     "powerPlatformRegistered": true,
-    "productNames": ["aad", "exo", "defender", "sharepoint", "teams", "powerplatform"],
+    "productNames": ["aad", "exo", "securitysuite", "sharepoint", "teams", "powerplatform"],
     "expectedResult": {
         "hasFixPermissionIssues": false,
         "statusPattern": "No action needed"

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/ServicePrincipalSnippets/MockPowerPlatformNeeded.json
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/ServicePrincipalSnippets/MockPowerPlatformNeeded.json
@@ -35,7 +35,7 @@
         "missing": false
     },
     "powerPlatformRegistered": false,
-    "productNames": ["aad", "exo", "defender", "sharepoint", "teams", "powerplatform"],
+    "productNames": ["aad", "exo", "securitysuite", "sharepoint", "teams", "powerplatform"],
     "expectedResult": {
         "hasFixPermissionIssues": true,
         "statusPattern": "Action needed.*Power Platform not registered"

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/ServicePrincipalSnippets/MockPowerPlatformUnneeded.json
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/ServicePrincipalSnippets/MockPowerPlatformUnneeded.json
@@ -35,7 +35,7 @@
         "missing": false
     },
     "powerPlatformRegistered": true,
-    "productNames": ["aad", "exo", "defender", "sharepoint", "teams"],
+    "productNames": ["aad", "exo", "securitysuite", "sharepoint", "teams"],
     "expectedResult": {
         "hasFixPermissionIssues": true,
         "statusPattern": "Action needed.*Power Platform registered but not required"

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/SetScubaGearAppPermissionData/MockExtraPermissions.json
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/SetScubaGearAppPermissionData/MockExtraPermissions.json
@@ -7,7 +7,7 @@
         "sharepoint",
         "teams",
         "powerplatform",
-        "defender"
+        "securitysuite"
     ],
     "ServicePrincipalID":  "00000000-0000-0000-0000-000000000002",
     "MissingPermissions":  false,
@@ -229,5 +229,5 @@
         }
     ],
     "Status":  "Action needed: you have extra permissions [Acronym.Read.All]. See FixPermissionIssues for resolution.",
-    "FixPermissionIssues":  "Get-ScubaGearAppPermission -AppID 00000000-0000-0000-0000-000000000001 -M365Environment commercial -ProductNames \u0027aad\u0027, \u0027exo\u0027, \u0027sharepoint\u0027, \u0027teams\u0027, \u0027powerplatform\u0027, \u0027defender\u0027 | Set-ScubaGearAppPermission"
+    "FixPermissionIssues":  "Get-ScubaGearAppPermission -AppID 00000000-0000-0000-0000-000000000001 -M365Environment commercial -ProductNames \u0027aad\u0027, \u0027exo\u0027, \u0027sharepoint\u0027, \u0027teams\u0027, \u0027powerplatform\u0027, \u0027securitysuite\u0027 | Set-ScubaGearAppPermission"
 }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/SetScubaGearAppPermissionData/MockManifestMissingAdminConsent.json
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/SetScubaGearAppPermissionData/MockManifestMissingAdminConsent.json
@@ -7,7 +7,7 @@
                          "sharepoint",
                          "teams",
                          "powerplatform",
-                         "defender"
+                         "securitysuite"
                      ],
     "ServicePrincipalID":  "00000000-0000-0000-0000-000000000002",
     "MissingPermissions":  [
@@ -207,5 +207,5 @@
                        }
                    ],
     "Status":  "Action needed: you have permissions [User.Read.All, Exchange.ManageAsApp] (in manifest, just need admin consent). See FixPermissionIssues for resolution.",
-    "FixPermissionIssues":  "Get-ScubaGearAppPermission -AppID 00000000-0000-0000-0000-000000000001 -M365Environment commercial -ProductNames \u0027aad\u0027, \u0027exo\u0027, \u0027sharepoint\u0027, \u0027teams\u0027, \u0027powerplatform\u0027, \u0027defender\u0027 | Set-ScubaGearAppPermission"
+    "FixPermissionIssues":  "Get-ScubaGearAppPermission -AppID 00000000-0000-0000-0000-000000000001 -M365Environment commercial -ProductNames \u0027aad\u0027, \u0027exo\u0027, \u0027sharepoint\u0027, \u0027teams\u0027, \u0027powerplatform\u0027, \u0027securitysuite\u0027 | Set-ScubaGearAppPermission"
 }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/SetScubaGearAppPermissionData/MockMissingGCCHighExoPermission.json
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/SetScubaGearAppPermissionData/MockMissingGCCHighExoPermission.json
@@ -7,7 +7,7 @@
                          "sharepoint",
                          "teams",
                          "powerplatform",
-                         "defender"
+                         "securitysuite"
                      ],
     "ServicePrincipalID":  "00000000-0000-0000-0000-000000000002",
     "MissingPermissions":  [
@@ -233,5 +233,5 @@
                        }
                    ],
     "Status":  "Action needed: you have missing permissions [Exchange.ManageAsApp] (need to be added to manifest). See FixPermissionIssues for resolution.",
-    "FixPermissionIssues":  "Get-ScubaGearAppPermission -AppID 00000000-0000-0000-0000-000000000001 -M365Environment gcchigh -ProductNames \u0027aad\u0027, \u0027exo\u0027, \u0027sharepoint\u0027, \u0027teams\u0027, \u0027powerplatform\u0027, \u0027defender\u0027 | Set-ScubaGearAppPermission"
+    "FixPermissionIssues":  "Get-ScubaGearAppPermission -AppID 00000000-0000-0000-0000-000000000001 -M365Environment gcchigh -ProductNames \u0027aad\u0027, \u0027exo\u0027, \u0027sharepoint\u0027, \u0027teams\u0027, \u0027powerplatform\u0027, \u0027securitysuite\u0027 | Set-ScubaGearAppPermission"
 }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/SetScubaGearAppPermissionData/MockMissingPermission.json
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/SetScubaGearAppPermissionData/MockMissingPermission.json
@@ -7,7 +7,7 @@
         "sharepoint",
         "teams",
         "powerplatform",
-        "defender"
+        "securitysuite"
     ],
     "MissingPermissions":  {
         "ResourceAPI":  "00000003-0000-0000-c000-000000000000",
@@ -218,5 +218,5 @@
         }
     ],
     "Status":  "Action needed: you have missing permissions [Policy.Read.All] (need to be added to manifest). See FixPermissionIssues for resolution.",
-    "FixPermissionIssues":  "Get-ScubaGearAppPermission -AppID 00000000-0000-0000-0000-000000000001 -M365Environment commercial -ProductNames \u0027aad\u0027, \u0027exo\u0027, \u0027sharepoint\u0027, \u0027teams\u0027, \u0027powerplatform\u0027, \u0027defender\u0027 | Set-ScubaGearAppPermission"
+    "FixPermissionIssues":  "Get-ScubaGearAppPermission -AppID 00000000-0000-0000-0000-000000000001 -M365Environment commercial -ProductNames \u0027aad\u0027, \u0027exo\u0027, \u0027sharepoint\u0027, \u0027teams\u0027, \u0027powerplatform\u0027, \u0027securitysuite\u0027 | Set-ScubaGearAppPermission"
 }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/SetScubaGearAppPermissionData/MockMissingRole.json
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/SetScubaGearAppPermissionData/MockMissingRole.json
@@ -7,7 +7,7 @@
         "sharepoint",
         "teams",
         "powerplatform",
-        "defender"
+        "securitysuite"
     ],
     "MissingPermissions":  false,
     "PermissionsNotInManifest":  false,
@@ -118,5 +118,5 @@
         }
     ],
     "Status":  "Action needed: you have missing role [Global Reader]. See FixPermissionIssues for resolution.",
-    "FixPermissionIssues":  "Get-ScubaGearAppPermission -AppID 00000000-0000-0000-0000-000000000001 -M365Environment commercial -ProductNames \u0027aad\u0027, \u0027exo\u0027, \u0027sharepoint\u0027, \u0027teams\u0027, \u0027powerplatform\u0027, \u0027defender\u0027 | Set-ScubaGearAppPermission"
+    "FixPermissionIssues":  "Get-ScubaGearAppPermission -AppID 00000000-0000-0000-0000-000000000001 -M365Environment commercial -ProductNames \u0027aad\u0027, \u0027exo\u0027, \u0027sharepoint\u0027, \u0027teams\u0027, \u0027powerplatform\u0027, \u0027securitysuite\u0027 | Set-ScubaGearAppPermission"
 }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/SetScubaGearAppPermissionData/MockMultipleIssues.json
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/SetScubaGearAppPermissionData/MockMultipleIssues.json
@@ -7,7 +7,7 @@
         "sharepoint",
         "teams",
         "powerplatform",
-        "defender"
+        "securitysuite"
     ],
     "ServicePrincipalID": "00000000-0000-0000-0000-000000000002",
     "MissingPermissions":  [
@@ -237,5 +237,5 @@
         }
     ],
     "Status":  "Action needed: you have missing permissions [Policy.Read.All] (need to be added to manifest) and extra permissions [Acronym.Read.All] and missing role [Global Reader]. See FixPermissionIssues for resolution.",
-    "FixPermissionIssues":  "Get-ScubaGearAppPermission -AppID 00000000-0000-0000-0000-000000000001 -M365Environment commercial -ProductNames \u0027aad\u0027, \u0027exo\u0027, \u0027sharepoint\u0027, \u0027teams\u0027, \u0027powerplatform\u0027, \u0027defender\u0027 | Set-ScubaGearAppPermission"
+    "FixPermissionIssues":  "Get-ScubaGearAppPermission -AppID 00000000-0000-0000-0000-000000000001 -M365Environment commercial -ProductNames \u0027aad\u0027, \u0027exo\u0027, \u0027sharepoint\u0027, \u0027teams\u0027, \u0027powerplatform\u0027, \u0027securitysuite\u0027 | Set-ScubaGearAppPermission"
 }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/SetScubaGearAppPermissionData/MockNoCurrentPermissions.json
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/SetScubaGearAppPermissionData/MockNoCurrentPermissions.json
@@ -7,7 +7,7 @@
         "sharepoint",
         "teams",
         "powerplatform",
-        "defender"
+        "securitysuite"
     ],
     "ServicePrincipalID":  "00000000-0000-0000-0000-000000000002",
     "MissingPermissions":  [
@@ -191,5 +191,5 @@
                        }
                    ],
     "Status":  "Action needed: you have missing permissions [Policy.Read.All, PrivilegedEligibilitySchedule.Read.AzureADGroup, RoleManagementPolicy.Read.AzureADGroup, Directory.Read.All, RoleManagement.Read.Directory, User.Read.All, Exchange.ManageAsApp, Sites.FullControl.All] and delegated permissions [User.Read] and missing role [Global Reader] and Power Platform not registered. See FixPermissionIssues for resolution.",
-    "FixPermissionIssues":  "Get-ScubaGearAppPermission -AppID 52420846-b406-49f2-96fe-5232048659f5 -M365Environment commercial -ProductNames \u0027aad\u0027, \u0027exo\u0027, \u0027sharepoint\u0027, \u0027teams\u0027, \u0027powerPlatform\u0027, \u0027defender\u0027 | Set-ScubaGearAppPermission"
+    "FixPermissionIssues":  "Get-ScubaGearAppPermission -AppID 52420846-b406-49f2-96fe-5232048659f5 -M365Environment commercial -ProductNames \u0027aad\u0027, \u0027exo\u0027, \u0027sharepoint\u0027, \u0027teams\u0027, \u0027powerPlatform\u0027, \u0027securitysuite\u0027 | Set-ScubaGearAppPermission"
 }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/SetScubaGearAppPermissionData/MockOptimalPermissions.json
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/SetScubaGearAppPermissionData/MockOptimalPermissions.json
@@ -7,7 +7,7 @@
         "sharepoint",
         "teams",
         "powerplatform",
-        "defender"
+        "securitysuite"
     ],
     "ServicePrincipalID":  "00000000-0000-0000-0000-000000000002",
     "MissingPermissions":  false,

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/SetScubaGearAppPermissionData/MockPowerPlatformNeeded.json
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/SetScubaGearAppPermissionData/MockPowerPlatformNeeded.json
@@ -7,7 +7,7 @@
         "sharepoint",
         "teams",
         "powerPlatform",
-        "defender"
+        "securitysuite"
     ],
     "ServicePrincipalID": "00000000-0000-0000-0000-000000000002",
     "MissingPermissions": false,

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/SetScubaGearAppPermissionData/MockPowerPlatformUnneeded.json
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Support/SetScubaGearAppPermissionData/MockPowerPlatformUnneeded.json
@@ -6,7 +6,7 @@
         "exo",
         "sharepoint",
         "teams",
-        "defender"
+        "securitysuite"
     ],
     "ServicePrincipalID": "00000000-0000-0000-0000-000000000002",
     "MissingPermissions": false,

--- a/PowerShell/ScubaGear/schemas/ScubaGearApiCatalog.json
+++ b/PowerShell/ScubaGear/schemas/ScubaGearApiCatalog.json
@@ -1637,7 +1637,9 @@
         "poshModule": [
             "ExchangeOnlineManagement"
         ],
-        "leastPermissions": [],
+        "leastPermissions": [
+            "Exchange.ManageAsApp"
+        ],
         "higherPermissions": [],
         "spRolePermissions": [
             "Global Reader"
@@ -1667,7 +1669,9 @@
         "poshModule": [
             "ExchangeOnlineManagement"
         ],
-        "leastPermissions": [],
+        "leastPermissions": [
+            "Exchange.ManageAsApp"
+        ],
         "higherPermissions": [],
         "spRolePermissions": [
             "Global Reader"
@@ -1696,7 +1700,9 @@
         "poshModule": [
             "ExchangeOnlineManagement"
         ],
-        "leastPermissions": [],
+        "leastPermissions": [
+            "Exchange.ManageAsApp"
+        ],
         "higherPermissions": [],
         "spRolePermissions": [
             "Global Reader"
@@ -1712,6 +1718,38 @@
             "https://learn.microsoft.com/en-us/powershell/module/exchange/connect-ippssession?view=exchange-ps"
         ],
         "notes": "",
+        "oauthScope": ""
+    },
+
+    {
+        "moduleCmdlet": "Connect-IPPSSession",
+        "apiResource": "https://ps.compliance.protection.office365.us/powershell-liveid/",
+        "apiFilter": "",
+        "apiHeader": [
+            { }
+        ],
+        "poshModule": [
+            "ExchangeOnlineManagement"
+        ],
+        "leastPermissions": [
+            "Exchange.ManageAsApp"
+        ],
+        "higherPermissions": [],
+        "spRolePermissions": [
+            "Global Reader"
+        ],
+        "scubaGearProduct": [
+            "securitysuite"
+        ],
+        "supportedEnv": [
+            "gcchigh",
+            "dod"
+        ],
+        "resourceAPIAppId": "00000007-0000-0ff1-ce00-000000000000",
+        "supportLinks": [
+            "https://learn.microsoft.com/en-us/powershell/module/exchange/connect-ippssession?view=exchange-ps"
+        ],
+        "notes": "Microsoft Exchange Online Protection app id is required for gcchigh/DoD environments.",
         "oauthScope": ""
     },
 

--- a/PowerShell/ScubaGear/schemas/ScubaGearApiCatalog.json
+++ b/PowerShell/ScubaGear/schemas/ScubaGearApiCatalog.json
@@ -1643,7 +1643,7 @@
             "Global Reader"
         ],
         "scubaGearProduct": [
-            "defender"
+            "securitysuite"
         ],
         "supportedEnv": [
             "commercial",
@@ -1673,7 +1673,7 @@
             "Global Reader"
         ],
         "scubaGearProduct": [
-            "defender"
+            "securitysuite"
         ],
         "supportedEnv": [
             "gcchigh"
@@ -1702,7 +1702,7 @@
             "Global Reader"
         ],
         "scubaGearProduct": [
-            "defender"
+            "securitysuite"
         ],
         "supportedEnv": [
             "dod"

--- a/docs/prerequisites/interactive.md
+++ b/docs/prerequisites/interactive.md
@@ -9,7 +9,7 @@ ScubaGear queries various M365 APIs to gather information about their security s
 | Product                 | Role                                                                    |
 | ----------------------- | ----------------------------------------------------------------------- |
 | Entra ID                | Global Reader                                                           |
-| Defender for Office 365 | Global Reader (or Exchange Administrator)                               |
+| Security Suite          | Global Reader (or Exchange Administrator)                               |
 | Exchange Online         | Global Reader (or Exchange Administrator)                               |
 | Power BI                | Fabric Administrator (or Global Administrator) with a Power BI or Fabric license <sup>1</sup> |
 | Power Platform          | Power Platform Administrator with a "Power Apps for Office 365" license |

--- a/docs/prerequisites/noninteractive.md
+++ b/docs/prerequisites/noninteractive.md
@@ -21,7 +21,7 @@ The table below lists the minimum permissions and roles required for ScubaGear t
 |                         | RoleManagement.Read.Directory                   |               |                                       |                                       |
 |                         | RoleManagementPolicy.Read.AzureADGroup          |               |                                       |                                       |
 |                         | User.Read.All                                   |               |                                       |                                       |
-| Defender for Office 365 |                                                 | Global Reader |                                       |                                       |
+| Security Suite          | Exchange.ManageAsApp                            | Global Reader | Office 365 Exchange Online<sup>1</sup>            | 00000002-0000-0ff1-ce00-000000000000  |
 | Exchange Online         | Exchange.ManageAsApp                            | Global Reader | Office 365 Exchange Online<sup>1</sup>            | 00000002-0000-0ff1-ce00-000000000000  |
 | Power BI                | Tenant setting required <sup>3</sup>            |               |                                       |                                       |
 | Power Platform          | Registration required <sup>2</sup>                                     |               |                                       |                                       |
@@ -168,9 +168,9 @@ Get-PowerAppManagementApp -ApplicationId "your-app-id"
 
 This section contains additional, non-interactive authentication details that are required to successfully run ScubaGear against a GCC High tenant.
 
-### Defender in GCC High
+### Security Suite in GCC High
 
-When running ScubaGear to assess Defender for Office 365 in a GCC High tenant, the `Exchange.ManageAsApp` must be added as an application permission from both the `Microsoft Exchange Online Protection` and the `Office 365 Exchange Online`  APIs. This is mentioned in a GCC High application manifest writer's note in this section of the [Exchange Online App Only Auth MS Learn documentation](https://learn.microsoft.com/en-us/powershell/exchange/app-only-auth-powershell-v2?view=exchange-ps#modify-the-app-manifest-to-assign-api-permissions).
+When running ScubaGear to assess the Security Suite baseline in a GCC High tenant, the `Exchange.ManageAsApp` must be added as an application permission from both the `Microsoft Exchange Online Protection` and the `Office 365 Exchange Online`  APIs. This is mentioned in a GCC High application manifest writer's note in this section of the [Exchange Online App Only Auth MS Learn documentation](https://learn.microsoft.com/en-us/powershell/exchange/app-only-auth-powershell-v2?view=exchange-ps#modify-the-app-manifest-to-assign-api-permissions).
 
 ### SharePoint in GCC High
 

--- a/docs/prerequisites/noninteractive.md
+++ b/docs/prerequisites/noninteractive.md
@@ -44,7 +44,7 @@ ScubaGear supports two setup approaches:
 > The custom PowerShell functions were **created exclusively for ScubaGear**. They configure service principals with the exact permissions and roles needed for ScubaGear assessments.
 
 **Get started with automated setup:**
-- [Service Principal Workflows](serviceprincipal-workflows.md/#initial-setup-workflow) - Step-by-step guide
+- [Service Principal Workflows](serviceprincipal-workflows.md#initial-setup-workflow) - Step-by-step guide
 - [Service Principal Troubleshooting](serviceprincipal-troubleshooting.md) - Solutions to common issues
 
 ---

--- a/docs/prerequisites/serviceprincipal-workflows.md
+++ b/docs/prerequisites/serviceprincipal-workflows.md
@@ -315,7 +315,7 @@ $Audit | Set-ScubaGearAppPermission
 
 ### Scenario 2: Remove Unused Products
 
-**Example:** You no longer need Teams and Defender permissions.
+**Example:** You no longer need Teams and SecuritySuite permissions.
 
 #### Step 1: Audit with Reduced Products
 

--- a/docs/prerequisites/serviceprincipal-workflows.md
+++ b/docs/prerequisites/serviceprincipal-workflows.md
@@ -60,7 +60,7 @@ Before using the Service Principal module, ensure you have:
 ### Step 1: Plan Your Configuration
 
 Before creating the service principal, determine:
-- **Products to assess:** Choose from aad, exo, sharepoint, teams, defender, powerPlatform, or use `*` for all products
+- **Products to assess:** Choose from aad, exo, sharepoint, teams, securitysuite, powerplatform, or use `*` for all products
 - **Environment:** commercial, gcc, gcchigh, or dod
 - **Certificate validity:** Default 6 months, customizable up to 12 months maximum
 
@@ -71,7 +71,7 @@ Test the creation without making changes:
 ```powershell
 New-ScubaGearServicePrincipal `
     -M365Environment commercial `
-    -ProductNames 'aad', 'exo', 'sharepoint', 'teams', 'defender', 'powerplatform', 'powerbi' `
+    -ProductNames 'aad', 'exo', 'sharepoint', 'teams', 'securitysuite', 'powerplatform' `
     -WhatIf
 ```
 
@@ -88,7 +88,7 @@ Create the Service Principal:
 ```powershell
 $NewSP = New-ScubaGearServicePrincipal `
     -M365Environment commercial `
-    -ProductNames 'aad', 'exo', 'sharepoint', 'teams', 'defender', 'powerplatform', 'powerbi' `
+    -ProductNames 'aad', 'exo', 'sharepoint', 'teams', 'securitysuite', 'powerplatform' `
     -ServicePrincipalName "ScubaGear-Production"
 ```
 
@@ -142,7 +142,7 @@ Invoke-Scuba `
 $Audit = Get-ScubaGearAppPermission `
     -AppID "your-app-id-here" `
     -M365Environment commercial `
-    -ProductNames 'aad', 'exo', 'sharepoint', 'teams', 'defender', 'powerPlatform'
+    -ProductNames 'aad', 'exo', 'sharepoint', 'teams', 'securitysuite', 'powerplatform'
 ```
 
 ### Step 2: Review Audit Results
@@ -210,7 +210,7 @@ Confirm all issues were resolved:
 Get-ScubaGearAppPermission `
     -AppID $Audit.AppID `
     -M365Environment $Audit.M365Environment `
-    -ProductNames 'aad', 'exo', 'sharepoint', 'teams', 'defender', 'powerPlatform'
+    -ProductNames 'aad', 'exo', 'sharepoint', 'teams', 'securitysuite', 'powerplatform'
 ```
 
 **Expected result:** Status should now show "No action needed."

--- a/docs/prerequisites/serviceprincipal-workflows.md
+++ b/docs/prerequisites/serviceprincipal-workflows.md
@@ -326,7 +326,7 @@ $Audit = Get-ScubaGearAppPermission `
     -ProductNames 'aad', 'exo', 'sharepoint'
 ```
 
-**Expected result:** Shows extra permissions for Teams and Defender.
+**Expected result:** Shows extra permissions for Teams and SecuritySuite.
 
 #### Step 2: Remove Extra Permissions
 

--- a/docs/prerequisites/serviceprincipal-workflows.md
+++ b/docs/prerequisites/serviceprincipal-workflows.md
@@ -26,7 +26,7 @@ The benefits of using the ScubaGear Service Principal module include:
 > [!IMPORTANT]
 > **This module is designed exclusively for ScubaGear.**
  - ✅ Creates a service principal for ScubaGear assessments
- - ✅ Manages ScubaGear product permissions (Entra, Exchange, SharePoint, Teams, Defender, Power Platform)
+ - ✅ Manages ScubaGear product permissions (Entra, Exchange, SharePoint, Teams, SecuritySuite, Power Platform)
  - ✅ Handles certificate management
  - ✅ Audits and fixes ScubaGear Service Principal permission issues
  - ❌ NOT for general service principal management


### PR DESCRIPTION
## 🗣 Description ##

- Renamed the permissions catalog consumed by the service principal helpers:
  `Modules/Permissions/ScubaGearPermissions.json` to  `schemas/ScubaGearApiCatalog.json`
- Updated all callers of that file to reference the new path
- Removed the `defender` alias from all `ValidateSet` declarations and `.PARAMETER` doc strings.
- Updated service principal prerequisite documentation to reflect the above

closes #2121 

## 💭 Motivation and context ##

The permissions catalog file was renamed and moved as part of the broader schema baseline work. Additionally the `defender` product name was changed to `securitysuite` as part of the broader Security Suite baseline work.

## 🧪 Testing ##

Ensure modules are looking for new json but still have the same output
```powershell
Get-ScubaGearEntraMinimumPermissions -Verbose
```
```text
VERBOSE: Command: $permissionSet = Get-Content -Path
'C:\ActiveDevelopment\Github\cisagov\2121-update-service-principal-helpers-for-security-suite\PowerShell\ScubaGear\Modules\Per
missions\..\..\schemas\ScubaGearApiCatalog.json' | ConvertFrom-Json
VERBOSE: Command: $collection = $permissionSet | Where-Object { $_.scubaGearProduct -contains any of "aad" -and
$_.supportedEnv -contains "commercial" }
VERBOSE: Command: $collection | Sort-Object
Directory.Read.All
Policy.Read.All
PrivilegedAccess.Read.AzureADGroup
PrivilegedEligibilitySchedule.Read.AzureADGroup
RoleManagement.Read.Directory
RoleManagementPolicy.Read.AzureADGroup
User.Read.All
```

```powershell
Get-ScubaGearPermissions -Verbose
```
```text
VERBOSE: Command: $permissionSet = Get-Content -Path
'C:\ActiveDevelopment\Github\cisagov\2121-update-service-principal-helpers-for-security-suite\PowerShell\ScubaGear\Modules\Per
missions\..\..\schemas\ScubaGearApiCatalog.json' | ConvertFrom-Json
VERBOSE: Command: $collection = $permissionSet | Where-Object { $_.supportedEnv -contains "commercial" }
VERBOSE: Command: $collection | Where-Object {$_.moduleCmdlet -notlike 'Connect-Mg*'} | Select-Object -ExpandProperty
leastPermissions -Unique
Application.Read.All
Application.ReadWrite.All
AppRoleAssignment.ReadWrite.All
DelegatedPermissionGrant.ReadWrite.All
Directory.Read.All
Domain.Read.All
Exchange.ManageAsApp
GroupMember.Read.All
Organization.Read.All
Policy.Read.All
PrivilegedAccess.Read.AzureADGroup
PrivilegedEligibilitySchedule.Read.AzureADGroup
RoleAssignmentSchedule.Read.Directory
RoleAssignmentSchedule.ReadWrite.Directory
RoleEligibilitySchedule.Read.Directory
RoleManagement.Read.Directory
RoleManagement.ReadWrite.Directory
RoleManagementPolicy.Read.AzureADGroup
RoleManagementPolicy.Read.Directory
Sites.FullControl.All
User.Read
User.Read.All
```

```powershell
Get-ServicePrincipalPermissions -Verbose
```
```text
# VERBOSE: ...ScubaGearApiCatalog.json...
# leastPermissions / resourceAPIAppId / scubaGearProduct table returned correctly
....
leastPermissions                                  resourceAPIAppId                     scubaGearProduct
----------------                                  ----------------                     ----------------
{Policy.Read.All}                                 00000003-0000-0000-c000-000000000000 aad
{PrivilegedAccess.Read.AzureADGroup}              00000003-0000-0000-c000-000000000000 aad
{Exchange.ManageAsApp}                            00000002-0000-0ff1-ce00-000000000000 {exo, securitysuite}
{Sites.FullControl.All}                           00000003-0000-0ff1-ce00-000000000000 sharepoint
{Directory.Read.All}                              00000003-0000-0000-c000-000000000000 aad
{RoleManagementPolicy.Read.AzureADGroup}          00000003-0000-0000-c000-000000000000 aad
{PrivilegedEligibilitySchedule.Read.AzureADGroup} 00000003-0000-0000-c000-000000000000 aad
RoleManagement.Read.Directory                     00000003-0000-0000-c000-000000000000 aad
User.Read.All                                     00000003-0000-0000-c000-000000000000 aad
```
Ensure security suite is listed a product name
```powershell
New-ScubaGearServicePrincipal -CertName scubasecuritysuite-gcchtest -M365Environment gcchigh -ProductNames securitysuite -ServicePrincipalName ScubaApplication-securitysuite-test
```
```text
Performing the operation "Creating new ScubaGear Service Principal with the following configuration:
  - Display Name: ScubaApplication-securitysuite-test
  - Products: securitysuite
  - Certificate Name: scubasecuritysuite-gcchtest
  - Certificate Validity: 6 months
  - API Permissions: 2 permission(s)
  - Directory Roles: Global Reader" on target "ScubaApplication-securitysuite-test".
```
<img width="1523" height="658" alt="image" src="https://github.com/user-attachments/assets/6be6e488-a24c-44ea-9af2-0716fbe4d965" />

Should not throw; 'defender' is treated as 'securitysuite'
```powershell
Get-ScubaGearPermissions -Product defender -ServicePrincipal

Get-ScubaGearPermissions : Cannot validate argument on parameter 'Product'. The argument "defender" does not belong to the
set "aad,exo,securitysuite,teams,sharepoint,scubatank,powerplatform,*" specified by the ValidateSet attribute. Supply an
argument that is in the set and then try the command again.
```

Should list securitysuite rows in the returned table
```powershell
Get-ServicePrincipalPermissions | Where-Object { $_.scubaGearProduct -contains 'securitysuite' }
leastPermissions       resourceAPIAppId                     scubaGearProduct
----------------       ----------------                     ----------------
{Exchange.ManageAsApp} 00000002-0000-0ff1-ce00-000000000000 {exo, securitysuite}
```

GCC High: should show 1 Exchange.ManageAsApp entries
```powershell
Get-ScubaGearPermissions -Product securitysuite -ServicePrincipal -Environment gcchigh
Exchange.ManageAsApp
```
## 📷 Screenshots (if appropriate) ##


## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] PR passed smoke test check.
- [x] PR/feature branch passes functional tests for relevant products, if applicable.
- [x] Feature branch has been rebased against changes from parent branch, as needed.

  Use `Update branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [x] Resolved all merge conflicts on branch.
- [x] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the PR assignee to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
