### PR TITLE
Fix report creation failure caused by null FilePath when output path is inaccessible

### DIFF
--- a/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
+++ b/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
@@ -198,10 +198,16 @@ function New-Report {
 
     $ProductSecureBaseline = $SecureBaselines.$BaselineName
 
-    $FileName = Join-Path -Path $OutPath -ChildPath "$($OutProviderFileName).json" -Resolve
+    $FileName = Join-Path -Path $OutPath -ChildPath "$($OutProviderFileName).json"
+    if (-not (Test-Path -LiteralPath $FileName -PathType Leaf)) {
+        throw "Provider settings file not found at '$FileName'. Verify the output path is accessible and does not contain issues (e.g., Some paths with spaces may require specifying an explicit -OutPath)."
+    }
     $SettingsExport =  Get-Utf8NoBom -FilePath $FileName | ConvertFrom-Json
 
-    $FileName = Join-Path -Path $OutPath -ChildPath "$($OutRegoFileName).json" -Resolve
+    $FileName = Join-Path -Path $OutPath -ChildPath "$($OutRegoFileName).json"
+    if (-not (Test-Path -LiteralPath $FileName -PathType Leaf)) {
+        throw "Rego output file not found at '$FileName'. The OPA evaluation may have failed for all products. If the module is installed in a folder with spaces in the path, try specifying an explicit -OutPath to a local directory without spaces."
+    }
     $RegoOutput =  Get-Utf8NoBom -FilePath $FileName | ConvertFrom-Json
 
     $Fragments = @()

--- a/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
+++ b/PowerShell/ScubaGear/Modules/CreateReport/CreateReport.psm1
@@ -161,14 +161,14 @@ function New-Report {
 
         # The location to save the html report in.
         [Parameter(Mandatory=$true)]
-        [ValidateScript({Test-Path -PathType Container $_})]
+        [ValidateScript({Test-Path -LiteralPath $_ -PathType Container})]
         [ValidateNotNullOrEmpty()]
         [string]
         $IndividualReportPath,
 
         # The location to save the html report in.
         [Parameter(Mandatory=$true)]
-        [ValidateScript({Test-Path -PathType Container $_})]
+        [ValidateScript({Test-Path -LiteralPath $_ -PathType Container})]
         [ValidateScript({Test-Path -IsValid $_})]
         [string]
         $OutPath,
@@ -431,7 +431,7 @@ function New-Report {
     $ReportJson = $ReportJson.replace("\u003c", "<")
     $ReportJson = $ReportJson.replace("\u003e", ">")
     $ReportJson = $ReportJson.replace("\u0027", "'")
-    $ReportJson | Out-File $JsonFileName
+    $ReportJson | Out-File -LiteralPath $JsonFileName
 
     # Finish building the html report
     $Title = "$($FullName) Baseline Report"
@@ -701,7 +701,7 @@ function New-Report {
     $ReportHTML = $ReportHTML.Replace("{JS_FILES}", "<script>`n $($JSFiles) `n</script>")
     $ReportHTML = $ReportHTML.Replace("{TABLES}", $Fragments)
     $FileName = Join-Path -Path $IndividualReportPath -ChildPath "$($BaselineName)Report.html"
-    [System.Web.HttpUtility]::HtmlDecode($ReportHTML) | Out-File $FileName
+    [System.Web.HttpUtility]::HtmlDecode($ReportHTML) | Out-File -LiteralPath $FileName
 
     $ReportSummary
 }

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -456,8 +456,9 @@ function Invoke-SCuBA {
         $FormattedTimeStamp = $Date.ToString("yyyy_MM_dd_HH_mm_ss")
         $OutFolderPath = $ScubaConfig.OutPath
         $FolderName = "$($ScubaConfig.OutFolderName)_$($FormattedTimeStamp)"
-        New-Item -Path $OutFolderPath -Name $($FolderName) -ItemType Directory -ErrorAction 'Stop' | Out-Null
         $OutFolderPath = Join-Path -Path $OutFolderPath -ChildPath $FolderName -ErrorAction 'Stop'
+        # New-Item has no -LiteralPath; use .NET so output paths with wildcard chars (e.g. []) are created literally.
+        [System.IO.Directory]::CreateDirectory($OutFolderPath) | Out-Null
 
         # Initialize logging for troubleshooting - debug logs are ALWAYS created
         # Logs are placed in a DebugLogs subfolder within the output folder
@@ -1069,8 +1070,8 @@ function Invoke-RunRego {
                     OPAPath     = $resolvedOPAPath
                     InputFile   = $InputFile
                     RegoFile    = $RegoFile
-                    InputExists = (Test-Path $InputFile)
-                    RegoExists  = (Test-Path $RegoFile)
+                    InputExists = (Test-Path -LiteralPath $InputFile)
+                    RegoExists  = (Test-Path -LiteralPath $RegoFile)
                 }
                 try {
                     $RetVal = Invoke-Rego @params
@@ -1092,13 +1093,14 @@ function Invoke-RunRego {
                 }
             }
 
-            if ($null -eq $RegoOutput -or $RegoOutput.Count -eq 0) {
-                $RegoOutputJson = '[]'
+            # Guard against an empty $TestResults so ConvertTo-Json emits '[]' rather than $null
+            if ($null -eq $TestResults -or $TestResults.Count -eq 0) {
+                $TestResultsJson = '[]'
             } else {
-                $RegoOutputJson = $RegoOutput | ConvertTo-Json -Depth 5 -ErrorAction 'Stop'
+                $TestResultsJson = $TestResults | ConvertTo-Json -Depth 5 -ErrorAction 'Stop'
             }
             $FileName = Join-Path -Path $OutFolderPath "$($ScubaConfig.OutRegoFileName).json" -ErrorAction 'Stop'
-            $TestResultsJson | Set-Content -Path $FileName -Encoding (Get-FileEncoding) -ErrorAction 'Stop'
+            $TestResultsJson | Set-Content -LiteralPath $FileName -Encoding (Get-FileEncoding) -ErrorAction 'Stop'
 
             $ProdRegoFailed
         }
@@ -1281,9 +1283,9 @@ function ConvertTo-ResultsCsv {
         try {
             $ScubaResultsPath = Join-Path $OutFolderPath -ChildPath $FullScubaResultsName
 
-            if (Test-Path $ScubaResultsPath -PathType Leaf) {
+            if (Test-Path -LiteralPath $ScubaResultsPath -PathType Leaf) {
                 # The ScubaResults file exists, no need to look for the individual json files
-                $ScubaResults = Get-Content -Encoding UTF8 (Get-ChildItem $ScubaResultsPath).FullName | ConvertFrom-Json
+                $ScubaResults = Get-Content -Encoding UTF8 -LiteralPath $ScubaResultsPath | ConvertFrom-Json
             }
             else {
                 # The ScubaResults file does not exists, so we need to look inside the IndividualReports
@@ -1293,7 +1295,7 @@ function ConvertTo-ResultsCsv {
                 foreach ($Product in $ProductNames) {
                     $BaselineName = $ArgToProd[$Product]
                     $FileName = Join-Path $IndividualReportPath "$($BaselineName)Report.json"
-                    $IndividualResults = Get-Content -Encoding UTF8 $FileName | ConvertFrom-Json
+                    $IndividualResults = Get-Content -Encoding UTF8 -LiteralPath $FileName | ConvertFrom-Json
                     $ScubaResults.Results | Add-Member -NotePropertyName $BaselineName `
                         -NotePropertyValue $IndividualResults.Results
                 }
@@ -1326,16 +1328,16 @@ function ConvertTo-ResultsCsv {
             $ResultsCsvFileName = Join-Path -Path $OutFolderPath "$OutCsvFileName.csv"
             $PlanCsvFileName = Join-Path -Path $OutFolderPath "$OutActionPlanFileName.csv"
             $Encoding = Get-FileEncoding
-            $ScubaResultsCsv | ConvertTo-Csv -NoTypeInformation | Set-Content -Path $ResultsCsvFileName -Encoding $Encoding
+            $ScubaResultsCsv | ConvertTo-Csv -NoTypeInformation | Set-Content -LiteralPath $ResultsCsvFileName -Encoding $Encoding
             if ($ActionPlanCsv.Length -eq 0) {
                 # If no tests failed, add the column names to ensure a file is still output
                 $Headers = $ScubaResultsCsv[0].psobject.Properties.Name -Join '","'
                 $Headers = "`"$Headers`""
                 $Headers += '"Non-Compliance Reason","Remediation Completion Date","Justification"'
-                $Headers | Set-Content -Path $PlanCsvFileName -Encoding $Encoding
+                $Headers | Set-Content -LiteralPath $PlanCsvFileName -Encoding $Encoding
             }
             else {
-                $ActionPlanCsv | ConvertTo-Csv -NoTypeInformation | Set-Content -Path $PlanCsvFileName -Encoding $Encoding
+                $ActionPlanCsv | ConvertTo-Csv -NoTypeInformation | Set-Content -LiteralPath $PlanCsvFileName -Encoding $Encoding
             }
         }
         catch {
@@ -1405,7 +1407,7 @@ function Merge-JsonOutput {
             # Load the raw provider output
             $SettingsExportPath = Join-Path $OutFolderPath -ChildPath "$($OutProviderFileName).json"
             $DeletionList += $SettingsExportPath
-            $SettingsExport =  Get-Content -Encoding UTF8 $SettingsExportPath -Raw
+            $SettingsExport =  Get-Content -Encoding UTF8 -LiteralPath $SettingsExportPath -Raw
             $SettingsExportObject = $(ConvertFrom-Json $SettingsExport)
             $TimestampZulu = $SettingsExportObject.timestamp_zulu
 
@@ -1443,7 +1445,7 @@ function Merge-JsonOutput {
                 $BaselineName = $ArgToProd[$Product]
                 $FileName = Join-Path $IndividualReportPath "$($BaselineName)Report.json"
                 $DeletionList += $FileName
-                $IndividualResults = Get-Content -Encoding UTF8 $FileName | ConvertFrom-Json
+                $IndividualResults = Get-Content -Encoding UTF8 -LiteralPath $FileName | ConvertFrom-Json
 
                 $Results | Add-Member -NotePropertyName $BaselineName `
                     -NotePropertyValue $IndividualResults.Results
@@ -1500,11 +1502,11 @@ function Merge-JsonOutput {
             $ReportJson = $ReportJson.replace("\u0027", "'")
 
             $ScubaResultsPath = Join-Path $OutFolderPath -ChildPath $FullScubaResultsName -ErrorAction 'Stop'
-            $ReportJson | Set-Content -Path $ScubaResultsPath -Encoding $(Get-FileEncoding) -ErrorAction 'Stop'
+            $ReportJson | Set-Content -LiteralPath $ScubaResultsPath -Encoding $(Get-FileEncoding) -ErrorAction 'Stop'
 
             # Delete the now redundant files
             foreach ($File in $DeletionList) {
-                Remove-Item $File
+                Remove-Item -LiteralPath $File
             }
         }
         catch {
@@ -1585,7 +1587,8 @@ function Invoke-ReportCreation {
             $Len = $ScubaConfig.ProductNames.Length
             $Fragment = @()
             $IndividualReportPath = Join-Path -Path $OutFolderPath -ChildPath $IndividualReportFolderName
-            New-Item -Path $IndividualReportPath -ItemType "Directory" -ErrorAction "SilentlyContinue" | Out-Null
+            # New-Item has no -LiteralPath; use .NET so paths with wildcard chars (e.g. []) are created literally.
+            [System.IO.Directory]::CreateDirectory($IndividualReportPath) | Out-Null
 
             $ReporterPath = Join-Path -Path $PSScriptRoot -ChildPath "CreateReport" -ErrorAction 'Stop'
             $Images = Join-Path -Path $ReporterPath -ChildPath "images" -ErrorAction 'Stop'
@@ -1691,7 +1694,8 @@ function Invoke-ReportCreation {
             $TenantMetaData = $TenantMetaData -replace '^(.*?)<table>','<table class ="tenantdata" style = "text-align:center;">'
             $Fragment = $Fragment | ConvertTo-Html -Fragment -ErrorAction 'Stop'
 
-            $ProviderJSONFilePath = Join-Path -Path $OutFolderPath -ChildPath "$($ScubaConfig.OutProviderFileName).json" -Resolve
+            # No -Resolve: it expands wildcard chars (e.g. []); Get-Utf8NoBom resolves the path literally.
+            $ProviderJSONFilePath = Join-Path -Path $OutFolderPath -ChildPath "$($ScubaConfig.OutProviderFileName).json"
             $ReportUuid = $(Get-Utf8NoBom -FilePath $ProviderJSONFilePath | ConvertFrom-Json).report_uuid
 
             $ReportHtmlPath = Join-Path -Path $ReporterPath -ChildPath "ParentReport" -ErrorAction 'Stop'
@@ -1726,10 +1730,11 @@ function Invoke-ReportCreation {
             $ReportHTML = $ReportHTML.Replace("{JS_FILES}", "<script>`n $($JSFiles) `n</script>")
             Add-Type -AssemblyName System.Web -ErrorAction 'Stop'
             $ReportFileName = Join-Path -Path $OutFolderPath "$($ScubaConfig.OutReportName).html" -ErrorAction 'Stop'
-            [System.Web.HttpUtility]::HtmlDecode($ReportHTML) | Out-File $ReportFileName -ErrorAction 'Stop'
+            [System.Web.HttpUtility]::HtmlDecode($ReportHTML) | Out-File -LiteralPath $ReportFileName -ErrorAction 'Stop'
 
             if (-Not $Quiet) {
-                Invoke-Item $ReportFileName
+                # LiteralPath so a report path with wildcard chars (e.g. []) opens instead of failing to resolve
+                Invoke-Item -LiteralPath $ReportFileName
             }
         }
         catch {
@@ -2286,9 +2291,10 @@ function Invoke-SCuBACached {
             }
 
             # Create outpath if $Outpath does not exist
-            if(-not (Test-Path -PathType "container" $OutPath))
+            if(-not (Test-Path -LiteralPath $OutPath -PathType "container"))
             {
-                New-Item -ItemType "Directory" -Path $OutPath | Out-Null
+                # New-Item has no -LiteralPath; use .NET so paths with wildcard chars (e.g. []) are created literally.
+                [System.IO.Directory]::CreateDirectory($OutPath) | Out-Null
             }
             $OutFolderPath = $OutPath
             $ProductNames = $ProductNames | Sort-Object -Unique
@@ -2396,10 +2402,10 @@ function Invoke-SCuBACached {
 
                     # Check if there is a previous ScubaResults file
                     # delete if found
-                    $PreviousResultsFiles = Get-ChildItem -Path $OutPath -Filter "$($OutJsonFileName)*.json"
+                    $PreviousResultsFiles = Get-ChildItem -LiteralPath $OutPath -Filter "$($OutJsonFileName)*.json"
                     if ($PreviousResultsFiles) {
                         $PreviousResultsFiles | ForEach-Object {
-                            Remove-Item $_.FullName -Force
+                            Remove-Item -LiteralPath $_.FullName -Force
                         }
                         Write-ScubaLog -Message "Removed $($PreviousResultsFiles.Count) previous result file(s)" -Level "Debug" -Source "ScubaCached"
                     }
@@ -2469,11 +2475,11 @@ function Invoke-SCuBACached {
             #####################################
             # If a ScubaResults file exists we grab its System.IO.FileInfo object which is referenced further down.
             #####################################
-            $ScubaResultsFileNameWildcard = Join-Path -Path $OutPath -ChildPath "$($OutJsonFileName)*.json"
             $ScubaResultsFileFound = $false
             $ScubaResultsFileObject = $null
-            if (Test-Path $ScubaResultsFileNameWildcard) {
-                $ScubaResultsFilesArray = @(Get-ChildItem $ScubaResultsFileNameWildcard)
+            # -LiteralPath on the folder (handles wildcard chars like [] in OutPath) + -Filter for the file wildcard.
+            $ScubaResultsFilesArray = @(Get-ChildItem -LiteralPath $OutPath -Filter "$($OutJsonFileName)*.json" -ErrorAction SilentlyContinue)
+            if ($ScubaResultsFilesArray.Count -gt 0) {
                 if ($ScubaResultsFilesArray.Count -gt 1) {
                     throw "You must only have a single ScubaResults file in this folder: $OutPath"
                 }
@@ -2489,7 +2495,7 @@ function Invoke-SCuBACached {
             # ProjectSettingsObject keeps a PowerShell object of the provider JSON in memory so we can reference its properties such as tenant_details further down.
             $ProviderSettingsObject = $null
             # If the provider output does not exist as a file, extract it from the ScubaResults file .Raw section so downstream functions that rely on it can execute.
-            if (-not (Test-Path $ProviderJSONFilePath)) {
+            if (-not (Test-Path -LiteralPath $ProviderJSONFilePath)) {
                 Write-ScubaLog -Message "Provider JSON file not found so extracting from ScubaResults" -Level "Info" -Source "ScubaCached"
                 if (-not $ScubaResultsFileFound) {
                     throw "No provider JSON or ScubaResults JSON file was found in folder: $OutPath. Double check the values you passed for -OutPath or -OutProviderFileName to ensure one of those file exists in that folder."
@@ -2525,10 +2531,10 @@ function Invoke-SCuBACached {
             if ($ScubaResultsFileFound -and $KeepIndividualJSON) {
                 $NewScubaResultsName = "Unused-$($ScubaResultsFileObject.Name)"
                 $NewScubaResultsPath = Join-Path $ScubaResultsFileObject.DirectoryName $NewScubaResultsName
-                if (Test-Path $NewScubaResultsPath) {
-                    Remove-Item $NewScubaResultsPath -Force
+                if (Test-Path -LiteralPath $NewScubaResultsPath) {
+                    Remove-Item -LiteralPath $NewScubaResultsPath -Force
                 }
-                Rename-Item -Path $ScubaResultsFileObject.FullName -NewName $NewScubaResultsName
+                Rename-Item -LiteralPath $ScubaResultsFileObject.FullName -NewName $NewScubaResultsName
                 Write-Warning "Detected a ScubaResults file along with a ProviderSettingsExport file when calling with the -KeepIndividualJSON parameter."
                 Write-Warning "Renamed the ScubaResults to $NewScubaResultsName to avoid ambiguous results. ScubaCached will use the ProviderSettingsExport file since that takes priority."
             }
@@ -2632,7 +2638,7 @@ function Repair-ScubaGearJson {
     if ($ReturnObject.RepairedJson) {
         Write-Warning "The provider JSON file required automatic repair."
     }
-    
+
     $ProviderJsonObject = $ProviderSettingsObject.JsonObject
 
     .EXAMPLE
@@ -2671,7 +2677,7 @@ function Repair-ScubaGearJson {
     # We are parsing a JSON file
     if ($FilePath) {
         # The -Raw parameter returns a large string instead of an array of strings which makes the pipeline processing faster for ConvertFrom-Json
-        $JsonString = Get-Content $FilePath -Encoding UTF8 -Raw
+        $JsonString = Get-Content -LiteralPath $FilePath -Encoding UTF8 -Raw
     }
     # We are parsing a JSON string
     else {
@@ -2690,7 +2696,7 @@ function Repair-ScubaGearJson {
         else {
             $ReturnObject.JsonString = $JsonInputString
         }
-       
+
         return $ReturnObject
     }
     catch {
@@ -2709,7 +2715,7 @@ function Repair-ScubaGearJson {
         else {
             Write-Warning "Repair-ScubaGearJson: ScubaGear detected an invalid JSON object"
         }
-        
+
         Write-Warning "Please report this to the ScubaGear team as a bug report either by GitHub or the Scuba mailbox."
         Write-Warning "Attempting to auto repair the JSON..."
 

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -1092,7 +1092,11 @@ function Invoke-RunRego {
                 }
             }
 
-            $TestResultsJson = $TestResults | ConvertTo-Json -Depth 5 -ErrorAction 'Stop'
+            if ($null -eq $RegoOutput -or $RegoOutput.Count -eq 0) {
+                $RegoOutputJson = '[]'
+            } else {
+                $RegoOutputJson = $RegoOutput | ConvertTo-Json -Depth 5 -ErrorAction 'Stop'
+            }
             $FileName = Join-Path -Path $OutFolderPath "$($ScubaConfig.OutRegoFileName).json" -ErrorAction 'Stop'
             $TestResultsJson | Set-Content -Path $FileName -Encoding (Get-FileEncoding) -ErrorAction 'Stop'
 

--- a/PowerShell/ScubaGear/Modules/RunRego/RunRego.psm1
+++ b/PowerShell/ScubaGear/Modules/RunRego/RunRego.psm1
@@ -10,7 +10,7 @@ function Invoke-Rego {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
-        [ValidateScript({Test-Path -PathType Leaf $_})]
+        [ValidateScript({Test-Path -LiteralPath $_ -PathType Leaf})]
         [string]
         $InputFile,
 
@@ -34,33 +34,34 @@ function Invoke-Rego {
     $Cmd = Join-Path -Path $OPAPath -ChildPath $OPAFileName  -ErrorAction 'Stop'
 
     # Set backup execution path to be current directory if ScubaTools path fails
-    if (-not (Test-Path $Cmd -PathType Leaf)) {
+    if (-not (Test-Path -LiteralPath $Cmd -PathType Leaf)) {
         $Cmd = Join-Path -Path (Get-Location | Select-Object -ExpandProperty Path) -ChildPath $OPAFileName -ErrorAction 'Stop'
     }
 
     # See if the OPA executable is in the current executing directory
-    if (-not (Test-Path $Cmd)) {
+    if (-not (Test-Path -LiteralPath $Cmd)) {
         throw "Open Policy Agent executable was not found. Please see the README for instructions on how to retry downloading the executable and which directory it should be placed."
     }
 
     # Load Utils
-    if (-not (Test-Path $RegoFile -PathType Leaf)) {
+    if (-not (Test-Path -LiteralPath $RegoFile -PathType Leaf)) {
         throw "Rego file not found at: $RegoFile"
     }
 
-    $ResolvedInputFile = (Resolve-Path -Path $InputFile -ErrorAction Stop).Path
-    $ResolvedRegoFile = (Resolve-Path -Path $RegoFile -ErrorAction Stop).Path
+    # LiteralPath so input/output paths containing wildcard characters (e.g. []) resolve correctly.
+    $ResolvedInputFile = (Resolve-Path -LiteralPath $InputFile -ErrorAction Stop).Path
+    $ResolvedRegoFile = (Resolve-Path -LiteralPath $RegoFile -ErrorAction Stop).Path
 
-    $RegoFileObject = Get-Item $ResolvedRegoFile -ErrorAction Stop
+    $RegoFileObject = Get-Item -LiteralPath $ResolvedRegoFile -ErrorAction Stop
     if ($null -eq $RegoFileObject) {
         throw "Failed to get Rego file object at: $RegoFile"
     }
 
     $ScubaUtils = Join-Path -Path $RegoFileObject.DirectoryName -ChildPath "Utils" -ErrorAction 'Stop'
-    if (-not (Test-Path $ScubaUtils -PathType Container)) {
+    if (-not (Test-Path -LiteralPath $ScubaUtils -PathType Container)) {
         throw "Rego Utils directory not found at: $ScubaUtils"
     }
-    $ResolvedScubaUtils = (Resolve-Path -Path $ScubaUtils -ErrorAction Stop).Path
+    $ResolvedScubaUtils = (Resolve-Path -LiteralPath $ScubaUtils -ErrorAction Stop).Path
 
     $CmdArgs = @("eval", "data.$PackageName.tests", "-i", $ResolvedInputFile, "-d", $ResolvedRegoFile, "-d", $ResolvedScubaUtils, "-f", "values")
 

--- a/PowerShell/ScubaGear/Modules/Utility/ScubaLogging.psm1
+++ b/PowerShell/ScubaGear/Modules/Utility/ScubaLogging.psm1
@@ -92,8 +92,9 @@ function Initialize-ScubaLogging {
         # Setup log directory and file path with timestamp
         if ($LogPath) {
             # Create the log directory if it doesn't exist
-            if (!(Test-Path $LogPath)) {
-                New-Item -ItemType Directory -Path $LogPath -Force | Out-Null
+            if (!(Test-Path -LiteralPath $LogPath)) {
+                # New-Item has no -LiteralPath; use .NET so paths with wildcard chars (e.g. []) are created literally.
+                [System.IO.Directory]::CreateDirectory($LogPath) | Out-Null
             }
 
             # Create unique timestamped log filename to avoid conflicts
@@ -131,7 +132,7 @@ function Initialize-ScubaLogging {
             # Create transcript file with same timestamp as main log
             $transcriptPath = Join-Path $LogPath "ScubaGear-Transcript-$timestamp.log"
             # Start transcript to capture all PowerShell console activity
-            Start-Transcript -Path $transcriptPath -Append -ErrorAction SilentlyContinue
+            Start-Transcript -LiteralPath $transcriptPath -Append -ErrorAction SilentlyContinue
             Write-ScubaLog -Message "Transcript logging started: $transcriptPath (verbose/debug output enabled globally)" -Level "Info" -Source "LoggingSystem"
         }
     }
@@ -222,18 +223,19 @@ function Write-ScubaLog {
 
         # Write to log file if path is configured (file logging is optional)
         if ($Script:ScubaLogPath) {
-            # Append to log file with UTF8 encoding, silently continue on errors to not break execution
-            $logLine | Out-File -FilePath $Script:ScubaLogPath -Append -Encoding UTF8 -ErrorAction SilentlyContinue
+            # Append to log file with UTF8 encoding, silently continue on errors to not break execution.
+            # LiteralPath so log paths containing wildcard characters (e.g. []) are written literally.
+            $logLine | Out-File -LiteralPath $Script:ScubaLogPath -Append -Encoding UTF8 -ErrorAction SilentlyContinue
 
             # Add structured data on separate lines if present (indented for readability)
             if ($Data.Count -gt 0) {
                 # Convert data to compact JSON format for structured logging
-                "    Data: $($Data | ConvertTo-Json -Compress -Depth 3)" | Out-File -FilePath $Script:ScubaLogPath -Append -Encoding UTF8 -ErrorAction SilentlyContinue
+                "    Data: $($Data | ConvertTo-Json -Compress -Depth 3)" | Out-File -LiteralPath $Script:ScubaLogPath -Append -Encoding UTF8 -ErrorAction SilentlyContinue
             }
 
             # Add exception details on separate line if exception was provided
             if ($Exception) {
-                "    Exception: $($Exception.GetType().Name) - $($Exception.Message)" | Out-File -FilePath $Script:ScubaLogPath -Append -Encoding UTF8 -ErrorAction SilentlyContinue
+                "    Exception: $($Exception.GetType().Name) - $($Exception.Message)" | Out-File -LiteralPath $Script:ScubaLogPath -Append -Encoding UTF8 -ErrorAction SilentlyContinue
             }
         }
 
@@ -275,8 +277,9 @@ function Write-ScubaLog {
 
     }
     catch {
-        # Fallback logging - don't let logging errors break the main process
-        Write-Output "Logging error: $_"
+        # Fallback logging - don't let logging errors break the main process.
+        # Write-Warning (not Write-Output) so a logging hiccup never pollutes a caller's output/data stream.
+        Write-Warning "Logging error: $_"
     }
 }
 
@@ -1255,7 +1258,7 @@ function Get-ScubaDebugLogReport {
     param(
         [Parameter(Mandatory = $true, Position = 0)]
         [ValidateScript({
-            if (-not (Test-Path $_ -PathType Leaf)) {
+            if (-not (Test-Path -LiteralPath $_ -PathType Leaf)) {
                 throw "File not found: $_"
             }
             $fileName = Split-Path $_ -Leaf
@@ -1298,7 +1301,7 @@ function Get-ScubaDebugLogReport {
     $entries = [System.Collections.Generic.List[PSCustomObject]]::new()
     $current = $null
 
-    foreach ($line in (Get-Content $DebugLogPath -Encoding UTF8)) {
+    foreach ($line in (Get-Content -LiteralPath $DebugLogPath -Encoding UTF8)) {
         if ($line -match $linePattern) {
             if ($current) { $entries.Add($current) }
             $current = [PSCustomObject]@{
@@ -1821,7 +1824,7 @@ function Get-ScubaDebugLogReport {
     }
 
     if ($OutputPath) {
-        $reportText | Set-Content -Path $OutputPath -Encoding UTF8
+        $reportText | Set-Content -LiteralPath $OutputPath -Encoding UTF8
         Write-Output "Report saved to: $OutputPath"
     }
 }

--- a/PowerShell/ScubaGear/Modules/Utility/Utility.psm1
+++ b/PowerShell/ScubaGear/Modules/Utility/Utility.psm1
@@ -62,7 +62,7 @@ function Get-Utf8NoBom {
         # The $false in the next line indicates that the BOM should not be used.
         $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
 
-        $ResolvedPath = $(Resolve-Path $FilePath).ProviderPath
+        $ResolvedPath = $(Resolve-Path -LiteralPath $FilePath).ProviderPath
         $Content = Invoke-ReadAllText -Path $ResolvedPath -Encoding $Utf8NoBomEncoding
         $Content
     }

--- a/PowerShell/ScubaGear/Modules/Utility/Utility.psm1
+++ b/PowerShell/ScubaGear/Modules/Utility/Utility.psm1
@@ -33,7 +33,8 @@ function Set-Utf8NoBom {
     )
     process {
         # Need to insure the location is an absolute path, otherwise you can get some inconsistent behavior.
-        $ResolvedPath = $(Resolve-Path $Location).ProviderPath
+        # LiteralPath so output folders containing wildcard characters (e.g. []) are treated literally.
+        $ResolvedPath = $(Resolve-Path -LiteralPath $Location).ProviderPath
         $FinalPath = Join-Path -Path $ResolvedPath -ChildPath $FileName -ErrorAction 'Stop'
         # The $false in the next line indicates that the BOM should not be used.
         $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-ReportCreation.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-ReportCreation.Tests.ps1
@@ -52,7 +52,7 @@ InModuleScope Orchestrator {
             It 'Show report' {
                 $ScubaConfig.ProductNames = @("aad")
                 { Invoke-ReportCreation -ScubaConfig $ScubaConfig -TenantDetails $TenantDetails -ModuleVersion $ModuleVersion -OutFolderPath $OutFolderPath -DarkMode:$DarkMode } | Should -Not -Throw
-                Should -Invoke -CommandName Invoke-Item -Exactly -Times 1 -ParameterFilter {-Not [string]::IsNullOrEmpty($Path) }
+                Should -Invoke -CommandName Invoke-Item -Exactly -Times 1 -ParameterFilter { (-Not [string]::IsNullOrEmpty($LiteralPath)) -or (-Not [string]::IsNullOrEmpty($Path)) }
                 $ScubaConfig.ProductNames = @()
             }
             It 'With -ProductNames "aad", should not throw' {

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/RunRego/Run-Rego.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/RunRego/Run-Rego.Tests.ps1
@@ -34,6 +34,31 @@ InModuleScope 'RunRego' {
             {Invoke-Rego @RegoParams} | Should -Throw
         }
     }
+
+    Describe -Tag 'RunRego' -Name 'Invoke-Rego wildcard path handling' {
+        BeforeAll {
+            Mock -ModuleName RunRego Invoke-ExternalCmd { return 0 }
+            Mock -CommandName Test-Path { $true }
+        }
+        It 'Passes an InputFile path containing square brackets ([]) to OPA literally' {
+            # Real bracketed input file so Resolve-Path must handle [] literally (wildcard -Path would resolve to $null)
+            $BracketDir = Join-Path $TestDrive '2185test[test]\lab'
+            [void][System.IO.Directory]::CreateDirectory($BracketDir)
+            $BracketInput = Join-Path $BracketDir 'ProviderSettingsExport.json'
+            Copy-Item -LiteralPath (Join-Path -Path $PSScriptRoot -ChildPath './RunRegoStubs/ProviderSettingsExport.json') -Destination $BracketInput
+            $RegoParams = @{
+                'InputFile'   = $BracketInput
+                'RegoFile'    = Join-Path -Path $PSScriptRoot -ChildPath '../../../../Rego/AADConfig.rego'
+                'PackageName' = 'aad'
+                'OPAPath'     = Join-Path -Path $env:USERPROFILE -ChildPath '.scubagear/Tools'
+            }
+            { Invoke-Rego @RegoParams } | Should -Not -Throw
+            # The resolved bracketed input path must appear in the OPA arguments (regex-escaped brackets)
+            Should -Invoke -ModuleName RunRego -CommandName Invoke-ExternalCmd -ParameterFilter {
+                ($PassThruArgs -join '|') -match '2185test\[test\]'
+            }
+        }
+    }
 }
 
 AfterAll {

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/Get-Utf8NoBom.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/Get-Utf8NoBom.Tests.ps1
@@ -66,6 +66,16 @@ InModuleScope Utility {
             }
         }
 
+        # Paths containing [ ] are treated as wildcards by -Path; the function must read them literally.
+        Context 'Wildcard characters in path' {
+            It 'Reads a file whose path contains square brackets' {
+                [void][System.IO.Directory]::CreateDirectory("$TestDrive\wc\2185test[test]\lab")
+                $TestFile = "$TestDrive\wc\2185test[test]\lab\output.json"
+                Set-Content -LiteralPath $TestFile -Value 'x'
+                Get-Utf8NoBom -FilePath $TestFile | Should -Be "Pass"
+            }
+        }
+
         # Uses default system drive share to test building UNC paths that exist
         # Assumes TestDrive is on system drive
         Context 'UNC path' {

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/ScubaLogging.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/ScubaLogging.Tests.ps1
@@ -46,6 +46,37 @@ InModuleScope ScubaLogging {
             }
         }
 
+        Context "Wildcard characters in log path (literal path handling)" {
+            BeforeAll {
+                # Folder name contains [ ] which PowerShell treats as wildcards unless -LiteralPath is used
+                $script:BracketLogRoot = Join-Path $env:TEMP "ScubaLogging-WC-$(Get-Date -Format 'yyyyMMddHHmmss')"
+                $script:BracketLogPath = Join-Path $script:BracketLogRoot '2185test[test]\lab\DebugLogs'
+                [void][System.IO.Directory]::CreateDirectory($script:BracketLogPath)
+            }
+
+            AfterAll {
+                if (Test-Path -LiteralPath $script:BracketLogRoot) {
+                    Remove-Item -LiteralPath $script:BracketLogRoot -Recurse -Force -ErrorAction SilentlyContinue
+                }
+            }
+
+            It "Creates and writes the debug log when the path contains square brackets" {
+                Initialize-ScubaLogging -LogPath $script:BracketLogPath -DisableAutoReport
+                $Script:ScubaLogPath | Should -Not -BeNullOrEmpty
+                Write-ScubaLog -Message "wildcard log path works" -Level "Info" -Source "Test"
+                Test-Path -LiteralPath $Script:ScubaLogPath | Should -Be $true
+                (Get-Content -LiteralPath $Script:ScubaLogPath -Raw) | Should -Match "wildcard log path works"
+            }
+
+            It "Does not leak logging errors to the output stream when path contains brackets" {
+                Initialize-ScubaLogging -LogPath $script:BracketLogPath -DisableAutoReport
+                # Redirect warning/verbose/debug/information away; capture only the success (output) stream
+                $leaked = Write-ScubaLog -Message "no leak expected" -Level "Info" -Source "Test" 3>$null 4>$null 5>$null 6>$null
+                $leaked | Should -BeNullOrEmpty
+                (Get-Content -LiteralPath $Script:ScubaLogPath -Raw) | Should -Not -Match "Logging error"
+            }
+        }
+
         Context "Initialize-ScubaLogging Function" {
 
             It "Should initialize logging with minimal parameters" {
@@ -87,10 +118,12 @@ InModuleScope ScubaLogging {
             }
 
             It "Should handle errors gracefully" {
-                # Mock an error condition
-                Mock New-Item { throw "Test error" } -ParameterFilter { $ItemType -eq "Directory" }
+                # Force directory creation to fail portably: make a parent path component a file
+                $fileAsParent = Join-Path $script:TestLogPath "not-a-dir"
+                Set-Content -LiteralPath $fileAsParent -Value "x" -Force
+                $badLogPath = Join-Path $fileAsParent "Logs"
 
-                { Initialize-ScubaLogging -LogPath "C:\InvalidPath\That\DoesNot\Exist" } | Should -Not -Throw
+                { Initialize-ScubaLogging -LogPath $badLogPath } | Should -Not -Throw
                 $Script:ScubaLogEnabled | Should -Be $false
             }
 
@@ -615,10 +648,10 @@ InModuleScope ScubaLogging {
                 )
 
                 # Mock Test-Path so the ValidateScript on LogPath passes without a real file on disk
-                Mock Test-Path { $true } -ParameterFilter { $Path -eq $script:FakeLogPath }
+                Mock Test-Path { $true } -ParameterFilter { ($Path -eq $script:FakeLogPath) -or ($LiteralPath -eq $script:FakeLogPath) }
 
                 # Mock Get-Content to always return $script:TestLines (which tests can modify)
-                Mock Get-Content { return $script:TestLines } -ParameterFilter { $Path -eq $script:FakeLogPath }
+                Mock Get-Content { return $script:TestLines } -ParameterFilter { ($Path -eq $script:FakeLogPath) -or ($LiteralPath -eq $script:FakeLogPath) }
             }
 
             BeforeEach {
@@ -928,10 +961,10 @@ InModuleScope ScubaLogging {
                 $script:FakeLogPath = 'C:\fake\ScubaGear-DebugLog-redaction-test.log'
 
                 # Mock Test-Path so ValidateScript passes
-                Mock Test-Path { $true } -ParameterFilter { $Path -eq $script:FakeLogPath }
+                Mock Test-Path { $true } -ParameterFilter { ($Path -eq $script:FakeLogPath) -or ($LiteralPath -eq $script:FakeLogPath) }
 
                 # Mock Get-Content to return test log content
-                Mock Get-Content { return $script:TestRedactionLines } -ParameterFilter { $Path -eq $script:FakeLogPath }
+                Mock Get-Content { return $script:TestRedactionLines } -ParameterFilter { ($Path -eq $script:FakeLogPath) -or ($LiteralPath -eq $script:FakeLogPath) }
 
                 # Override Get-Content for the redaction schema to return the real file as-is
                 Mock Get-Content {

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/Set-Utf8NoBom.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/Set-Utf8NoBom.Tests.ps1
@@ -72,6 +72,24 @@ InModuleScope Utility {
             }
         }
 
+        # Paths containing [ ] are treated as wildcards by -Path; the function must resolve them literally.
+        Context 'Wildcard characters in path' {
+            BeforeAll {
+                # New-Item -Path cannot create bracketed folders (no -LiteralPath); use .NET.
+                [void][System.IO.Directory]::CreateDirectory("$TestDrive\wc\2185test[test]\lab")
+            }
+
+            It 'Resolves an absolute path containing square brackets' {
+                Set-Utf8NoBom -Content "test" -Location "$TestDrive\wc\2185test[test]\lab" -FileName "output.json" `
+                | Should -Be "$TestDrive\wc\2185test[test]\lab\output.json"
+            }
+
+            It 'Resolves a relative path containing square brackets' {
+                Set-Utf8NoBom -Content "test" -Location "wc\2185test[test]\lab" -FileName "output.json" `
+                | Should -Be "$TestDrive\wc\2185test[test]\lab\output.json"
+            }
+        }
+
         AfterAll {
             Pop-Location
         }


### PR DESCRIPTION

## 🗣 Description ##

Replaces `Join-Path -Resolve` calls in `New-Report` with `Test-Path -LiteralPath` existence checks that produce descriptive error messages. Also ensures `RegoOutput.json` is always written with valid JSON content (`[]`) even when all OPA/Rego evaluations fail, and switches `Resolve-Path` to use `-LiteralPath` in `Get-Utf8NoBom` to prevent wildcard misinterpretation of paths containing `[` or `]`.

## 💭 Motivation and context ##

Resolves #2185.

Users who install ScubaGear into an OneDrive-synced module path (e.g., `C:\Users\<user>\OneDrive - Company Name\Documents\WindowsPowerShell\Modules\ScubaGear\`) encounter a fatal error during report creation:
`
Cannot validate argument on parameter 'FilePath'. The argument is null or empty.
at New-Report, ...\CreateReport.psm1: line 205
This is caused by a chain of three behaviors:

1. **`Join-Path -Resolve` silently returns `$null`** when its target file does not exist, rather than throwing. `New-Report` passed this `$null` directly to `Get-Utf8NoBom -FilePath`, which then failed with a confusing parameter validation error that gave no indication of which file was missing or why.

2. **OPA evaluation can fail against paths with spaces.** When the module's Rego files live in a path like `OneDrive - Company Name`, OPA (a native binary) may fail to access them, particularly when OneDrive Files On-Demand leaves them as cloud-only placeholders. All products then end up in `$ProdRegoFailed`, leaving `$RegoOutput` as an empty array.

3. **`@() | ConvertTo-Json` returns `$null` in PowerShell 5.1** because an empty pipeline produces no output. The subsequent `$null | Set-Content` either writes nothing or creates a zero-byte file, leaving `RegoOutput.json` absent or unreadable, which then triggers issue 1.

The fix addresses all three root causes, and the behavior now validates regardless of why a file might be missing.

## 🧪 Testing ##

 ---
A test runner script and JSON scenario file are attached to this PR. Download both files and rename `Invoke-ScubaTests.ps1.txt` to `Invoke-ScubaTests.ps1` before running. Place both files in the same folder.
 
[Invoke-ScubaTests.ps1.txt](https://github.com/user-attachments/files/29149538/Invoke-ScubaTests.ps1.txt)
[PR2185-TestCases.shared.json](https://github.com/user-attachments/files/29149550/PR2185-TestCases.shared.json)

### Configuring `PR2185-TestCases.shared.json` before running

Update the two fields under `defaults` before running:

**1. Set `scubaPath` to your local checkout of the branch**

```json
"scubaPath": "C:\\path\\to\\2185-reportcreation-fails-with-filepath-null"
```

If you leave it as-is and the folder does not exist, the runner will automatically clone the branch from GitHub into that path. (requires: Git for Windows)

**2. Set your credentials under `defaults.environments.commercial`**

Option A: config file:

```json
"configFile": "C:\\path\\to\\your\\scuba-config.yaml"
```

Option B: service principal:

```json
"organization":            "yourtenant.onmicrosoft.com",
"appId":                   "your-app-id",
"certificateThumbprint":   "your-cert-thumbprint"
```
> **TIP:** Each scenario can target one or more environments. Set `environments` to an array of keys defined under `defaults.environments`; the key name can be anything you choose (e.g. `["mycommercial"]`, or `["gcc", "gcchigh"]`) or whatever. Use the special value `"all"` to run the scenario against every configured environment automatically. When multiple environments are used, output folders are named `Scenario1-commercial`, `Scenario1-gcchigh`, etc.

> **NOTE:** The `-Automated` flag controls pausing behavior, not authentication:
>
> - **With `-Automated`:** No prompts between scenarios. Requires either a `configFile` with SP credentials **or** all three SP fields (`appId`, `certificateThumbprint`, `organization`) set in the JSON. Omitting credentials causes the scenario to be skipped with a warning.
> - **Without `-Automated`:** Pauses between scenarios and opens a browser login prompt if no credentials are configured. Use this for interactive/manual runs.
> - **If your `configFile` already contains SP credentials:** You do not need `-Automated`; the config file handles auth in both modes.

**3. Run the tests**

Standard run against a tenant with a path with spaces to exercise the fix:

```powershell
.\Invoke-ScubaTests.ps1 -TestCasesJson .\PR2185-TestCases.shared.json -Automated -OutBase "C:\ScubaTests\PR 2185 Spaces Test"
```

And against a plain path:

```powershell
.\Invoke-ScubaTests.ps1 -TestCasesJson .\PR2185-TestCases.shared.json -Automated
```

> **NOTE:** Each scenario runs ScubaGear in a separate PowerShell 5.1 window. This keeps each run isolated with a clean module state and ensures the injected code changes are picked up correctly. In `-Automated` mode the window closes automatically when the run completes. Without `-Automated` the window stays open so you can inspect output before continuing.

## 📷 Screenshots ##

<img width="1178" height="1126" alt="image" src="https://github.com/user-attachments/assets/d55c46cf-efd6-4e42-92de-98f8fa9948e3" />


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] Changes are sized such that they do not touch excessive number of files.
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [ ] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] All relevant type-of-change labels added.
- [ ] All relevant project fields are set.
- [ ] All relevant repo and/or project documentation updated to reflect these changes.
- [ ] Unit tests added/updated to cover PowerShell and Rego changes.
- [ ] Functional tests added/updated to cover PowerShell and Rego changes.
- [ ] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] PR passed smoke test check.
- [ ] PR/feature branch passes functional tests for relevant products, if applicable.
- [ ] Feature branch has been rebased against changes from parent branch, as needed.

  Use `Update branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [ ] Resolved all merge conflicts on branch.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the PR assignee to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.