### PR TITLE
Fix DMARC policy discovery tree walk

### DIFF
--- a/PowerShell/ScubaGear/Modules/Providers/ExportEXOProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportEXOProvider.psm1
@@ -741,14 +741,36 @@ function Get-ScubaDmarcRecord {
             -SkipDoH $SkipDoH
         $LogEntries += $Response.LogEntries
         if ($Response.Answers.Length -eq 0) {
-            # The domain does not exist. If the record is not available at the full domain
-            # level, we need to check at the organizational domain level.
-            $Labels = $d.DomainName.Split(".")
-            $Labels = $d.DomainName.Split(".")
-            $OrgDomain = $Labels[-2] + "." + $Labels[-1]
-            $Response = Invoke-RobustDnsTxt "_dmarc.$OrgDomain" -PreferredDnsResolvers $PreferredDnsResolvers `
-                -SkipDoH $SkipDoH
-            $LogEntries += $Response.LogEntries
+            # RFC 9989 replaces Public Suffix List organizational-domain discovery with
+            # a bounded DNS Tree Walk. Keep the author-domain query above, then walk
+            # parent domains without exceeding eight total DNS queries.
+            $Labels = @($d.DomainName.Split(".") | Where-Object { $_ -ne "" })
+            $Queries = 1
+            $CandidateResponse = $null
+
+            while ($Labels.Length -gt 1 -and $Queries -lt 8) {
+                if ($Labels.Length -ge 8) {
+                    $Labels = @($Labels[($Labels.Length - 7)..($Labels.Length - 1)])
+                }
+                else {
+                    $Labels = @($Labels[1..($Labels.Length - 1)])
+                }
+
+                $TreeWalkDomain = $Labels -join "."
+                $CandidateResponse = Invoke-RobustDnsTxt "_dmarc.$TreeWalkDomain" `
+                    -PreferredDnsResolvers $PreferredDnsResolvers `
+                    -SkipDoH $SkipDoH
+                $Queries += 1
+                $LogEntries += $CandidateResponse.LogEntries
+
+                if ($CandidateResponse.Answers.Length -gt 0) {
+                    $Response = $CandidateResponse
+                }
+            }
+
+            if ($Response.Answers.Length -eq 0 -and $null -ne $CandidateResponse) {
+                $Response = $CandidateResponse
+            }
         }
 
         $DomainName = $d.DomainName

--- a/PowerShell/ScubaGear/Modules/Providers/ExportEXOProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportEXOProvider.psm1
@@ -763,13 +763,27 @@ function Get-ScubaDmarcRecord {
                 $Queries += 1
                 $LogEntries += $CandidateResponse.LogEntries
 
-                if ($CandidateResponse.Answers.Length -gt 0) {
-                    $Response = $CandidateResponse
-                }
-            }
+                # RFC 9989 tree-walk steps 2 and 6: an answer only counts as this
+                # target's DMARC policy if it is itself a valid DMARC record (begins
+                # with the version tag). Multiple valid records at the same target are
+                # ambiguous per RFC 7489 6.6.3 and are treated as no usable record
+                # there, same as zero answers. A single valid record carrying the psd
+                # tag marks the walk boundary explicitly, so stop there instead of
+                # continuing unconditionally through the remaining labels.
+                $ValidAnswers = @($CandidateResponse.Answers | Where-Object { $_ -match '^v=DMARC1' })
 
-            if ($Response.Answers.Length -eq 0 -and $null -ne $CandidateResponse) {
-                $Response = $CandidateResponse
+                if ($ValidAnswers.Length -eq 1) {
+                    $Response = [PSCustomObject]@{
+                        "Answers"    = @($ValidAnswers)
+                        "Errors"     = $CandidateResponse.Errors
+                        "NXDomain"   = $CandidateResponse.NXDomain
+                        "LogEntries" = $CandidateResponse.LogEntries
+                    }
+
+                    if ($ValidAnswers[0] -match 'psd=(n|y)\b') {
+                        break
+                    }
+                }
             }
         }
 

--- a/PowerShell/ScubaGear/Modules/Providers/ExportEXOProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportEXOProvider.psm1
@@ -740,7 +740,27 @@ function Get-ScubaDmarcRecord {
         $Response = Invoke-RobustDnsTxt "_dmarc.$DomainName" -PreferredDnsResolvers $PreferredDnsResolvers `
             -SkipDoH $SkipDoH
         $LogEntries += $Response.LogEntries
-        if ($Response.Answers.Length -eq 0) {
+        # RFC 9989 step 2 applies to the starting target as well as every
+        # subsequent tree-walk target. Do not let unrelated TXT records or an
+        # ambiguous set of DMARC records suppress parent-domain discovery.
+        $ValidAnswers = @($Response.Answers | Where-Object { $_ -match '^v=DMARC1' })
+
+        if ($ValidAnswers.Length -eq 1) {
+            $Response = [PSCustomObject]@{
+                "Answers"    = @($ValidAnswers)
+                "Errors"     = $Response.Errors
+                "NXDomain"   = $Response.NXDomain
+                "LogEntries" = $Response.LogEntries
+            }
+        }
+        else {
+            $Response = [PSCustomObject]@{
+                "Answers"    = @()
+                "Errors"     = $Response.Errors
+                "NXDomain"   = $Response.NXDomain
+                "LogEntries" = $Response.LogEntries
+            }
+
             # RFC 9989 replaces Public Suffix List organizational-domain discovery with
             # a bounded DNS Tree Walk. Keep the author-domain query above, then walk
             # parent domains without exceeding eight total DNS queries.

--- a/PowerShell/ScubaGear/Modules/Providers/ExportEXOProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportEXOProvider.psm1
@@ -764,9 +764,12 @@ function Get-ScubaDmarcRecord {
             # RFC 9989 replaces Public Suffix List organizational-domain discovery with
             # a bounded DNS Tree Walk. Keep the author-domain query above, then walk
             # parent domains without exceeding eight total DNS queries.
-            $Labels = @($d.DomainName.Split(".") | Where-Object { $_ -ne "" })
+            $AuthorDomainLabels = @($d.DomainName.Split(".") | Where-Object { $_ -ne "" })
+            $Labels = @($AuthorDomainLabels)
             $Queries = 1
             $CandidateResponse = $null
+            $PolicyResponse = $null
+            $PolicyDomain = $null
 
             while ($Labels.Length -gt 1 -and $Queries -lt 8) {
                 if ($Labels.Length -ge 8) {
@@ -793,14 +796,38 @@ function Get-ScubaDmarcRecord {
                 $ValidAnswers = @($CandidateResponse.Answers | Where-Object { $_ -match '^v=DMARC1' })
 
                 if ($ValidAnswers.Length -eq 1) {
-                    $Response = [PSCustomObject]@{
+                    $ValidatedResponse = [PSCustomObject]@{
                         "Answers"    = @($ValidAnswers)
                         "Errors"     = $CandidateResponse.Errors
                         "NXDomain"   = $CandidateResponse.NXDomain
                         "LogEntries" = $CandidateResponse.LogEntries
                     }
 
-                    if ($ValidAnswers[0] -match 'psd=(n|y)\b') {
+                    if ($ValidAnswers[0] -match 'psd=y\b') {
+                        # The Organizational Domain is exactly one label below the PSD.
+                        # Prefer its record over the PSD record when one was discovered.
+                        $OrganizationalDomainStart = $AuthorDomainLabels.Length - $Labels.Length - 1
+                        $OrganizationalDomain = if ($OrganizationalDomainStart -ge 0) {
+                            $AuthorDomainLabels[$OrganizationalDomainStart..($AuthorDomainLabels.Length - 1)] -join "."
+                        }
+                        else {
+                            $null
+                        }
+
+                        $Response = if ($PolicyDomain -eq $OrganizationalDomain) {
+                            $PolicyResponse
+                        }
+                        else {
+                            $ValidatedResponse
+                        }
+                        break
+                    }
+
+                    $Response = $ValidatedResponse
+                    $PolicyResponse = $ValidatedResponse
+                    $PolicyDomain = $TreeWalkDomain
+
+                    if ($ValidAnswers[0] -match 'psd=n\b') {
                         break
                     }
                 }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/EXOProvider/Get-ScubaDmarcRecord.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/EXOProvider/Get-ScubaDmarcRecord.Tests.ps1
@@ -62,35 +62,71 @@ InModuleScope 'ExportEXOProvider' {
         }
 
         Context "When the DMARC record is unavailable at the full domain" {
-            BeforeAll {
+            BeforeEach {
+                $script:DmarcQueries = @()
+                $script:DmarcAnswerName = "_dmarc.example.com"
                 Mock -CommandName Invoke-RobustDnsTxt {
-                    Mock -CommandName Invoke-RobustDnsTxt {
-                        if ($Qname -eq "_dmarc.example.com") {
-                            @{
-                                "Answers" = @("v=DMARC1...");
-                                "Errors" = @();
-                                "NXDomain" = $false;
-                                "LogEntries" = @("some text")
-                            }
+                    $script:DmarcQueries += $Qname
+                    if ($Qname -eq $script:DmarcAnswerName) {
+                        @{
+                            "Answers" = @("v=DMARC1...");
+                            "Errors" = @();
+                            "NXDomain" = $false;
+                            "LogEntries" = @("some text")
                         }
-                        else {
-                            @{
-                                "Answers" = @();
-                                "Errors" = @();
-                                "NXDomain" = $false;
-                                "LogEntries" = @("Query returned NXDomain")
-                            }
+                    }
+                    else {
+                        @{
+                            "Answers" = @();
+                            "Errors" = @();
+                            "NXDomain" = $false;
+                            "LogEntries" = @("Query returned NXDomain")
                         }
                     }
                 }
             }
             It "Checks at the organization level" {
-                # There are two locations where DMARC records can be found. If it's not available at the
-                # full domain level, GetScubaDmarcRecord should try again at the organization domain level
+                # If no policy is available at the author domain, use the RFC 9989
+                # DNS Tree Walk to find the applicable policy.
                 $Response = Get-ScubaDmarcRecord -Domains @(@{"DomainName" = "a.b.example.com"}) `
                     -PreferredDnsResolvers @() -SkipDoH $false
-                Should -Invoke -CommandName Invoke-RobustDnsTxt -Exactly -Times 2
+                Should -Invoke -CommandName Invoke-RobustDnsTxt -Exactly -Times 4
                 $Response.rdata -Contains "v=DMARC1..." | Should -Be $true
+                $script:DmarcQueries | Should -Be @(
+                    "_dmarc.a.b.example.com",
+                    "_dmarc.b.example.com",
+                    "_dmarc.example.com",
+                    "_dmarc.com"
+                )
+            }
+
+            It "Checks the correct policy domain for a multi-label public suffix" {
+                $script:DmarcAnswerName = "_dmarc.example.fed.us"
+
+                $Response = Get-ScubaDmarcRecord -Domains @(@{"DomainName" = "subdomain.example.fed.us"}) `
+                    -PreferredDnsResolvers @() -SkipDoH $false
+                $Response.rdata -Contains "v=DMARC1..." | Should -Be $true
+                $script:DmarcQueries | Should -Contain "_dmarc.example.fed.us"
+            }
+
+            It "Limits RFC 9989 tree-walk lookups to eight total DNS queries" {
+                $script:DmarcAnswerName = "_dmarc.not-a-query.example"
+                $Response = Get-ScubaDmarcRecord -Domains @(
+                    @{"DomainName" = "a.b.c.d.e.f.g.h.i.j.mail.example.com"}
+                ) -PreferredDnsResolvers @() -SkipDoH $false
+
+                Should -Invoke -CommandName Invoke-RobustDnsTxt -Exactly -Times 8
+                $Response.rdata.Length | Should -Be 0
+                $script:DmarcQueries | Should -Be @(
+                    "_dmarc.a.b.c.d.e.f.g.h.i.j.mail.example.com",
+                    "_dmarc.g.h.i.j.mail.example.com",
+                    "_dmarc.h.i.j.mail.example.com",
+                    "_dmarc.i.j.mail.example.com",
+                    "_dmarc.j.mail.example.com",
+                    "_dmarc.mail.example.com",
+                    "_dmarc.example.com",
+                    "_dmarc.com"
+                )
             }
         }
     }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/EXOProvider/Get-ScubaDmarcRecord.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/EXOProvider/Get-ScubaDmarcRecord.Tests.ps1
@@ -220,6 +220,41 @@ InModuleScope 'ExportEXOProvider' {
                     "_dmarc.com"
                 )
             }
+
+            It "Discards a non-DMARC answer at the author domain and starts the tree walk" {
+                $script:DmarcAnswersByName["_dmarc.a.b.example.com"] = "some unrelated TXT record"
+                $script:DmarcAnswersByName["_dmarc.example.com"] = "v=DMARC1; p=reject;"
+
+                $Response = Get-ScubaDmarcRecord -Domains @(@{"DomainName" = "a.b.example.com"}) `
+                    -PreferredDnsResolvers @() -SkipDoH $false
+
+                $Response.rdata | Should -Be @("v=DMARC1; p=reject;")
+                $script:DmarcQueries | Should -Be @(
+                    "_dmarc.a.b.example.com",
+                    "_dmarc.b.example.com",
+                    "_dmarc.example.com",
+                    "_dmarc.com"
+                )
+            }
+
+            It "Discards multiple DMARC records at the author domain and starts the tree walk" {
+                $script:DmarcAnswersByName["_dmarc.a.b.example.com"] = @(
+                    "v=DMARC1; p=none;",
+                    "v=DMARC1; p=quarantine;"
+                )
+                $script:DmarcAnswersByName["_dmarc.example.com"] = "v=DMARC1; p=reject;"
+
+                $Response = Get-ScubaDmarcRecord -Domains @(@{"DomainName" = "a.b.example.com"}) `
+                    -PreferredDnsResolvers @() -SkipDoH $false
+
+                $Response.rdata | Should -Be @("v=DMARC1; p=reject;")
+                $script:DmarcQueries | Should -Be @(
+                    "_dmarc.a.b.example.com",
+                    "_dmarc.b.example.com",
+                    "_dmarc.example.com",
+                    "_dmarc.com"
+                )
+            }
         }
     }
 }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/EXOProvider/Get-ScubaDmarcRecord.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/EXOProvider/Get-ScubaDmarcRecord.Tests.ps1
@@ -129,6 +129,98 @@ InModuleScope 'ExportEXOProvider' {
                 )
             }
         }
+
+        Context "When the tree walk encounters ambiguous or boundary-marking records" {
+            BeforeEach {
+                $script:DmarcQueries = @()
+                $script:DmarcAnswersByName = @{}
+                Mock -CommandName Invoke-RobustDnsTxt {
+                    $script:DmarcQueries += $Qname
+                    if ($script:DmarcAnswersByName.ContainsKey($Qname)) {
+                        @{
+                            "Answers" = @($script:DmarcAnswersByName[$Qname]);
+                            "Errors" = @();
+                            "NXDomain" = $false;
+                            "LogEntries" = @("some text")
+                        }
+                    }
+                    else {
+                        @{
+                            "Answers" = @();
+                            "Errors" = @();
+                            "NXDomain" = $false;
+                            "LogEntries" = @("Query returned NXDomain")
+                        }
+                    }
+                }
+            }
+
+            It "Stops the walk early when a valid record carries psd=y" {
+                # RFC 9989 step 6: a psd tag marks the walk boundary explicitly.
+                $script:DmarcAnswersByName["_dmarc.b.example.com"] = "v=DMARC1; p=none; psd=y;"
+                $script:DmarcAnswersByName["_dmarc.example.com"] = "v=DMARC1; p=reject;"
+
+                $Response = Get-ScubaDmarcRecord -Domains @(@{"DomainName" = "a.b.example.com"}) `
+                    -PreferredDnsResolvers @() -SkipDoH $false
+
+                $Response.rdata | Should -Be @("v=DMARC1; p=none; psd=y;")
+                $script:DmarcQueries | Should -Be @(
+                    "_dmarc.a.b.example.com",
+                    "_dmarc.b.example.com"
+                )
+            }
+
+            It "Stops the walk early when a valid record carries psd=n" {
+                $script:DmarcAnswersByName["_dmarc.b.example.com"] = "v=DMARC1; p=none; psd=n;"
+                $script:DmarcAnswersByName["_dmarc.example.com"] = "v=DMARC1; p=reject;"
+
+                $Response = Get-ScubaDmarcRecord -Domains @(@{"DomainName" = "a.b.example.com"}) `
+                    -PreferredDnsResolvers @() -SkipDoH $false
+
+                $Response.rdata | Should -Be @("v=DMARC1; p=none; psd=n;")
+                $script:DmarcQueries | Should -Be @(
+                    "_dmarc.a.b.example.com",
+                    "_dmarc.b.example.com"
+                )
+            }
+
+            It "Discards a non-DMARC answer during the tree walk and keeps walking" {
+                # A TXT record at "_dmarc.<name>" that isn't itself a DMARC record
+                # (missing the v=DMARC1 tag) must not be treated as this target's
+                # policy - the walk should continue past it.
+                $script:DmarcAnswersByName["_dmarc.b.example.com"] = "some unrelated TXT record"
+                $script:DmarcAnswersByName["_dmarc.example.com"] = "v=DMARC1; p=reject;"
+
+                $Response = Get-ScubaDmarcRecord -Domains @(@{"DomainName" = "a.b.example.com"}) `
+                    -PreferredDnsResolvers @() -SkipDoH $false
+
+                $Response.rdata | Should -Be @("v=DMARC1; p=reject;")
+                $script:DmarcQueries | Should -Be @(
+                    "_dmarc.a.b.example.com",
+                    "_dmarc.b.example.com",
+                    "_dmarc.example.com",
+                    "_dmarc.com"
+                )
+            }
+
+            It "Treats multiple valid DMARC records at one target as unusable and keeps walking" {
+                # RFC 7489 6.6.3: more than one DMARC TXT record at a name is a
+                # discovery failure at that name, not a usable policy.
+                $script:DmarcAnswersByName["_dmarc.b.example.com"] = @("v=DMARC1; p=none;", "v=DMARC1; p=quarantine;")
+                $script:DmarcAnswersByName["_dmarc.example.com"] = "v=DMARC1; p=reject;"
+
+                $Response = Get-ScubaDmarcRecord -Domains @(@{"DomainName" = "a.b.example.com"}) `
+                    -PreferredDnsResolvers @() -SkipDoH $false
+
+                $Response.rdata | Should -Be @("v=DMARC1; p=reject;")
+                $script:DmarcQueries | Should -Be @(
+                    "_dmarc.a.b.example.com",
+                    "_dmarc.b.example.com",
+                    "_dmarc.example.com",
+                    "_dmarc.com"
+                )
+            }
+        }
     }
 }
 AfterAll {

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/EXOProvider/Get-ScubaDmarcRecord.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/EXOProvider/Get-ScubaDmarcRecord.Tests.ps1
@@ -170,6 +170,37 @@ InModuleScope 'ExportEXOProvider' {
                 )
             }
 
+            It "Prefers the Organizational Domain record over its PSD record" {
+                $script:DmarcAnswersByName["_dmarc.cisa.gov"] = "v=DMARC1; p=reject;"
+                $script:DmarcAnswersByName["_dmarc.gov"] = "v=DMARC1; p=reject; psd=y;"
+
+                $Response = Get-ScubaDmarcRecord -Domains @(@{"DomainName" = "example.cisa.gov"}) `
+                    -PreferredDnsResolvers @() -SkipDoH $false
+
+                $Response.rdata | Should -Be @("v=DMARC1; p=reject;")
+                $script:DmarcQueries | Should -Be @(
+                    "_dmarc.example.cisa.gov",
+                    "_dmarc.cisa.gov",
+                    "_dmarc.gov"
+                )
+            }
+
+            It "Uses the PSD record when the Organizational Domain has no record" {
+                $script:DmarcAnswersByName["_dmarc.b.c.gov"] = "v=DMARC1; p=none;"
+                $script:DmarcAnswersByName["_dmarc.gov"] = "v=DMARC1; p=reject; psd=y;"
+
+                $Response = Get-ScubaDmarcRecord -Domains @(@{"DomainName" = "a.b.c.gov"}) `
+                    -PreferredDnsResolvers @() -SkipDoH $false
+
+                $Response.rdata | Should -Be @("v=DMARC1; p=reject; psd=y;")
+                $script:DmarcQueries | Should -Be @(
+                    "_dmarc.a.b.c.gov",
+                    "_dmarc.b.c.gov",
+                    "_dmarc.c.gov",
+                    "_dmarc.gov"
+                )
+            }
+
             It "Stops the walk early when a valid record carries psd=n" {
                 $script:DmarcAnswersByName["_dmarc.b.example.com"] = "v=DMARC1; p=none; psd=n;"
                 $script:DmarcAnswersByName["_dmarc.example.com"] = "v=DMARC1; p=reject;"


### PR DESCRIPTION
## Intent

This PR updates `Get-ScubaDmarcRecord` so DMARC fallback discovery follows the bounded DNS Tree Walk described in RFC 9989 instead of assuming the applicable policy is always at the final two labels of the domain.

## Behavior being fixed
Proposed solution for https://github.com/cisagov/ScubaGear/issues/89.

The current fallback builds the policy domain as `labels[-2] + "." + labels[-1]`. That works for simple domains such as `sub.example.com` -> `example.com`, but it can miss the correct DMARC policy domain when the domain has a multi-label public suffix or otherwise needs parent-domain walking.

Example:

- Input author domain: `subdomain.example.fed.us`
- Current final-two-label fallback checks: `_dmarc.fed.us`
- Expected tree-walk behavior checks parent domains and can find: `_dmarc.example.fed.us`

## What changed

- Keep the existing author-domain lookup first.
- If no DMARC record is found there, walk parent domains using a bounded DNS Tree Walk.
- Limit total DNS TXT lookups to eight.
- Preserve the existing output shape and logging behavior.
- Add Pester tests for parent-domain discovery, multi-label public suffix behavior, and the eight-query limit.

## Reference

- RFC 9989 Section 4.10: https://www.rfc-editor.org/rfc/rfc9989.html#section-4.10

## Verification

```powershell
Import-Module Pester -RequiredVersion 5.7.1
Invoke-Pester -Path 'PowerShell\ScubaGear\Testing\Unit\PowerShell\Providers\EXOProvider\Get-ScubaDmarcRecord.Tests.ps1' -Output Detailed
```

Result: 12 tests passed, 0 failed.

