### PR TITLE
Fix ScubaConfigValidator to detect anchors 

### DIFF
--- a/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfig.psm1
+++ b/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfig.psm1
@@ -223,6 +223,9 @@ class ScubaConfig {
         # The validator has already converted YAML to PowerShell objects safely
         $this.Configuration = $ValidationResult.ParsedContent
 
+        # Properties that solely host a YAML anchor definition
+        $this.AnchorDefinedProperties = $ValidationResult.AnchorDefinedProperties
+
         # IMPORTANT: Validate required fields BEFORE converting to hashtable
         # PSCustomObject preserves case-sensitive property names, hashtable doesn't
         # This ensures minRequired check validates exact property names from YAML
@@ -322,7 +325,7 @@ class ScubaConfig {
         # Phase 1: Perform JSON Schema validation (structure, types, constraints)
         # This validates against the formal schema definition including data types, patterns, and structural requirements
         # Schema validation catches fundamental issues like wrong data types, missing required fields, invalid formats
-        $SchemaValidation = [ScubaConfigValidator]::ValidateAgainstSchema($ConfigObject, $false)
+        $SchemaValidation = [ScubaConfigValidator]::ValidateAgainstSchema($ConfigObject, $false, $this.AnchorDefinedProperties)
 
         # Phase 2: Perform Scuba configuration rule validation (paths, content quality, cross-field validation)
         # This layer adds domain-specific validation beyond what JSON Schema can express
@@ -457,6 +460,7 @@ class ScubaConfig {
     # Clears configuration data from singleton instance. Used by ResetInstance() for clean state.
     hidden [void]ClearConfiguration(){
         $this.Configuration = $null
+        $this.AnchorDefinedProperties = @()
     }
 
     # Recursively converts PSCustomObject to hashtable for internal storage compatibility.
@@ -619,6 +623,11 @@ class ScubaConfig {
 
     # Internal configuration storage as hashtable
     hidden [hashtable]$Configuration
+
+    # Top-level property names (detected from the raw YAML text at load time) that solely
+    # host a YAML anchor definition, e.g. 'SensitiveUsers: &CommonSensitiveUsers'. Retained
+    # so deferred schema validation can exclude them from "unknown property" warnings.
+    hidden [array]$AnchorDefinedProperties = @()
 
     # Applies default values and processes special configuration properties (wildcards, path expansion).
     # This method ensures all required properties have values and handles special cases like path resolution.

--- a/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfigSchema.json
+++ b/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfigSchema.json
@@ -23,7 +23,9 @@
       "OPAExecutable",
       "Quiet",
       "SilenceBODWarnings",
-      "DarkMode"
+      "DarkMode",
+      "Verbose",
+      "Debug"
       ],
 
     "policyExclusionMappings": {

--- a/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfigValidator.psm1
+++ b/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfigValidator.psm1
@@ -220,6 +220,10 @@ class ScubaConfigValidator {
                     }
                     throw
                 }
+
+                # Note which keys carry a YAML anchor definition on their value
+                # (e.g. 'SensitiveUsers: &CommonSensitiveUsers').
+                $Result.AnchorDefinedProperties = [ScubaConfigValidator]::GetAnchorDefinedProperties($FileContent)
             }
             else {
                 # Parse JSON
@@ -236,7 +240,7 @@ class ScubaConfigValidator {
 
         # Phase 3: Schema validation (skip if deferred validation requested)
         if (-not $SkipScubaConfigRules) {
-            $SchemaValidation = [ScubaConfigValidator]::ValidateAgainstSchema($ParsedContent, $DebugMode)
+            $SchemaValidation = [ScubaConfigValidator]::ValidateAgainstSchema($ParsedContent, $DebugMode, $Result.AnchorDefinedProperties)
             $Result.ValidationErrors += $SchemaValidation.Errors
             $Result.Warnings += $SchemaValidation.Warnings
 
@@ -259,6 +263,14 @@ class ScubaConfigValidator {
 
     # Performs JSON Schema Draft-7 validation against configuration objects
     hidden static [PSCustomObject] ValidateAgainstSchema([object]$ConfigObject, [bool]$DebugMode) {
+        return [ScubaConfigValidator]::ValidateAgainstSchema($ConfigObject, $DebugMode, @())
+    }
+
+    # Performs JSON Schema Draft-7 validation against configuration objects.
+    # AnchorDefinedProperties lists top-level property names whose value carries a YAML
+    # anchor definition (e.g. 'SensitiveUsers: &CommonSensitiveUsers'), detected from the
+    # raw file text, so they can be excluded from "unknown property" warnings.
+    hidden static [PSCustomObject] ValidateAgainstSchema([object]$ConfigObject, [bool]$DebugMode, [array]$AnchorDefinedProperties) {
         $Validation = @{
             Errors = [System.Collections.ArrayList]::new()
             Warnings = [System.Collections.ArrayList]::new()
@@ -271,12 +283,36 @@ class ScubaConfigValidator {
         # This prevents default values from hiding missing required properties
 
         # Validate all properties against schema
-        [ScubaConfigValidator]::ValidateAllPropertiesAgainstSchema($ConfigObject, $Schema, $Validation)
+        [ScubaConfigValidator]::ValidateAllPropertiesAgainstSchema($ConfigObject, $Schema, $Validation, $AnchorDefinedProperties)
 
         # Validate product exclusions with metadata-driven checks
         [ScubaConfigValidator]::ValidateProductExclusions($ConfigObject, $Schema, $Validation)
 
         return [PSCustomObject]$Validation
+    }
+
+    # Scans raw YAML text for top-level (non-indented) keys whose value begins with an
+    # anchor definition (e.g. 'SensitiveUsers: &CommonSensitiveUsers'). YAML anchors can be
+    # attached to any node anywhere in a document, not just top-level keys; this method only
+    # looks at top-level keys because that's the only place a schema "unknown property"
+    # warning can be raised from. ConvertFrom-Yaml resolves anchors/aliases before the
+    # validator ever sees the parsed object, so by that point there is no way to tell
+    # whether a key's value happened to be anchored - this raw-text scan is the only place
+    # that information still exists, and is used purely as a heuristic to reduce false
+    # positives, not as proof that the key exists solely for reuse.
+    static [array] GetAnchorDefinedProperties([string]$YamlContent) {
+        $AnchorProperties = @()
+
+        if ([string]::IsNullOrWhiteSpace($YamlContent)) {
+            return $AnchorProperties
+        }
+
+        $AnchorKeyPattern = '(?m)^([A-Za-z_][A-Za-z0-9_]*)\s*:\s*&[A-Za-z0-9_]+'
+        foreach ($Match in [regex]::Matches($YamlContent, $AnchorKeyPattern)) {
+            $AnchorProperties += $Match.Groups[1].Value
+        }
+
+        return @($AnchorProperties | Select-Object -Unique)
     }
 
     # Performs Scuba configuration rule validation beyond basic schema compliance
@@ -473,6 +509,13 @@ class ScubaConfigValidator {
 
     # Dynamically validates all properties against their schema definitions
     static [void] ValidateAllPropertiesAgainstSchema([object]$ConfigObject, [object]$Schema, [hashtable]$Validation) {
+        [ScubaConfigValidator]::ValidateAllPropertiesAgainstSchema($ConfigObject, $Schema, $Validation, @())
+    }
+
+    # Dynamically validates all properties against their schema definitions.
+    # AnchorDefinedProperties lists top-level property names whose value carries a YAML
+    # anchor definition; these are excluded from "unknown property" warnings.
+    static [void] ValidateAllPropertiesAgainstSchema([object]$ConfigObject, [object]$Schema, [hashtable]$Validation, [array]$AnchorDefinedProperties) {
         if (-not $Schema.properties) {
             return
         }
@@ -588,10 +631,19 @@ class ScubaConfigValidator {
             }
 
             if (-not $PropertyExists) {
-                # Property not in schema - treat as warning (ScubaGear can still run with extra properties)
-                # Note: Root-level properties are case-insensitive in PowerShell, so typos may still work
-                # This warning means the property truly doesn't match any known configuration option
-                [void]$Validation.Warnings.Add("Unknown property '$PropertyName' is not defined in the schema. It will be ignored by ScubaGear.")
+                # If this unrecognized property's value carries a YAML anchor definition
+                # (e.g. 'SensitiveUsers: &CommonSensitiveUsers'), assume it's an ad hoc
+                # reuse block referenced elsewhere via an alias rather than a mistyped
+                # ScubaGear parameter, and don't flag it.
+                if ($AnchorDefinedProperties -and $PropertyName -in $AnchorDefinedProperties) {
+                    Write-Debug "Skipping unknown property warning for YAML anchor host property '$PropertyName'"
+                }
+                else {
+                    # Property not in schema - treat as warning (ScubaGear can still run with extra properties)
+                    # Note: Root-level properties are case-insensitive in PowerShell, so typos may still work
+                    # This warning means the property truly doesn't match any known configuration option
+                    [void]$Validation.Warnings.Add("Unknown property '$PropertyName' is not defined in the schema. It will be ignored by ScubaGear.")
+                }
             }
         }
     }
@@ -1539,12 +1591,18 @@ class ValidationResult {
     [array]$ValidationErrors
     [array]$Warnings
     [object]$ParsedContent
+    # Top-level property names whose sole purpose is to host a YAML anchor definition
+    # (e.g. 'SensitiveUsers: &CommonSensitiveUsers'), detected from the raw file text.
+    # These are user-defined reuse blocks, not ScubaGear configuration parameters, and
+    # are excluded from "unknown property" schema warnings.
+    [array]$AnchorDefinedProperties
 
     ValidationResult() {
         $this.IsValid = $true
         $this.ValidationErrors = @()
         $this.Warnings = @()
         $this.ParsedContent = $null
+        $this.AnchorDefinedProperties = @()
     }
 }
 

--- a/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfigValidator.psm1
+++ b/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfigValidator.psm1
@@ -307,7 +307,7 @@ class ScubaConfigValidator {
             return $AnchorProperties
         }
 
-        $AnchorKeyPattern = '(?m)^([A-Za-z_][A-Za-z0-9_]*)\s*:\s*&[A-Za-z0-9_]+'
+        $AnchorKeyPattern = '(?m)^([A-Za-z_][\w-]*)\s*:\s*&[\w-]+'
         foreach ($Match in [regex]::Matches($YamlContent, $AnchorKeyPattern)) {
             $AnchorProperties += $Match.Groups[1].Value
         }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfig.YamlAnchorAlias.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfig.YamlAnchorAlias.Tests.ps1
@@ -79,8 +79,15 @@ Describe "ScubaConfig YAML Anchor Definition Validation" {
         }
     }
 
+    BeforeEach {
+        $script:TempFile = $null
+    }
+
     AfterEach {
         [ScubaConfig]::ResetInstance()
+        if ($script:TempFile -and (Test-Path $script:TempFile)) {
+            Remove-Item -Path $script:TempFile -Force -ErrorAction SilentlyContinue
+        }
     }
 
     AfterAll {
@@ -101,14 +108,12 @@ M365Environment: commercial
 SensitiveUsers: &CommonSensitiveUsers
   - Example User;exampleuser@example.onmicrosoft.com
 "@
-            $TempFile = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), '.yaml')
-            $Yaml | Set-Content -Path $TempFile
+            $script:TempFile = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), '.yaml')
+            $Yaml | Set-Content -Path $script:TempFile
 
-            $Result = [ScubaConfig]::ValidateConfigFile($TempFile)
+            $Result = [ScubaConfig]::ValidateConfigFile($script:TempFile)
 
             $Result.Warnings | Where-Object { $_ -match "Unknown property 'SensitiveUsers'" } | Should -BeNullOrEmpty
-
-            Remove-Item -Path $TempFile -Force
         }
 
         It "Should NOT flag an unknown property warning regardless of the anchor host key's name" {
@@ -120,14 +125,12 @@ M365Environment: commercial
 CommonExclusions: &CommonExclusions
   - someone@example.onmicrosoft.com
 "@
-            $TempFile = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), '.yaml')
-            $Yaml | Set-Content -Path $TempFile
+            $script:TempFile = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), '.yaml')
+            $Yaml | Set-Content -Path $script:TempFile
 
-            $Result = [ScubaConfig]::ValidateConfigFile($TempFile)
+            $Result = [ScubaConfig]::ValidateConfigFile($script:TempFile)
 
             $Result.Warnings | Where-Object { $_ -match "Unknown property 'CommonExclusions'" } | Should -BeNullOrEmpty
-
-            Remove-Item -Path $TempFile -Force
         }
 
         It "Should still flag an unknown property warning for the same key name when it has no anchor" {
@@ -138,14 +141,12 @@ ProductNames:
 M365Environment: commercial
 SensitiveUsers: SomeGenericValue
 "@
-            $TempFile = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), '.yaml')
-            $Yaml | Set-Content -Path $TempFile
+            $script:TempFile = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), '.yaml')
+            $Yaml | Set-Content -Path $script:TempFile
 
-            $Result = [ScubaConfig]::ValidateConfigFile($TempFile)
+            $Result = [ScubaConfig]::ValidateConfigFile($script:TempFile)
 
             $Result.Warnings | Where-Object { $_ -match "Unknown property 'SensitiveUsers'" } | Should -Not -BeNullOrEmpty
-
-            Remove-Item -Path $TempFile -Force
         }
 
         It "Should still flag unrelated unknown properties that don't carry an anchor" {
@@ -158,15 +159,13 @@ SensitiveUsers: &CommonSensitiveUsers
   - Example User;exampleuser@example.onmicrosoft.com
 TotallyMadeUpProperty: SomeValue
 "@
-            $TempFile = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), '.yaml')
-            $Yaml | Set-Content -Path $TempFile
+            $script:TempFile = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), '.yaml')
+            $Yaml | Set-Content -Path $script:TempFile
 
-            $Result = [ScubaConfig]::ValidateConfigFile($TempFile)
+            $Result = [ScubaConfig]::ValidateConfigFile($script:TempFile)
 
             $Result.Warnings | Where-Object { $_ -match "Unknown property 'SensitiveUsers'" } | Should -BeNullOrEmpty
             $Result.Warnings | Where-Object { $_ -match "Unknown property 'TotallyMadeUpProperty'" } | Should -Not -BeNullOrEmpty
-
-            Remove-Item -Path $TempFile -Force
         }
     }
 }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfig.YamlAnchorAlias.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/ScubaConfig/ScubaConfig.YamlAnchorAlias.Tests.ps1
@@ -1,0 +1,172 @@
+using module '..\..\..\..\Modules\ScubaConfig\ScubaConfig.psm1'
+
+Describe "ScubaConfig YAML Anchor Definition Validation" {
+    BeforeAll {
+        # Initialize the system
+        [ScubaConfig]::InitializeValidator()
+
+        # Create a dummy OPA executable for testing (required for configuration validation)
+        $IsLinuxOS = (Test-Path variable:IsLinux) -and $IsLinux
+        $IsMacOSOS = (Test-Path variable:IsMacOS) -and $IsMacOS
+
+        if ($IsLinuxOS) {
+            $script:DummyOPAName = "opa_linux_amd64"
+        }
+        elseif ($IsMacOSOS) {
+            $script:DummyOPAName = "opa_darwin_amd64"
+        }
+        else {
+            $script:DummyOPAName = "opa_windows_amd64.exe"
+        }
+        $script:DummyOPAPath = Join-Path -Path $PSScriptRoot -ChildPath "..\..\..\..\..\..\$script:DummyOPAName"
+        $script:DummyOPACreatedByTests = $false
+        if (-not (Test-Path $script:DummyOPAPath)) {
+            New-Item -Path $script:DummyOPAPath -ItemType File -Force | Out-Null
+            $script:DummyOPACreatedByTests = $true
+        }
+
+        # Mock ConvertFrom-Yaml to avoid dependency on the powershell-yaml module in CI.
+        # This mock does NOT resolve YAML anchors/aliases (that's ConvertFrom-Yaml's job in
+        # production, not something the validator needs to reimplement) - it just needs to
+        # produce a parsed object containing the same top-level keys as the raw file text,
+        # since anchor detection reads the raw text directly rather than the parsed object.
+        function global:ConvertFrom-Yaml {
+            [CmdletBinding()]
+            param([Parameter(ValueFromPipeline)]$YamlString)
+
+            process {
+                if (-not $YamlString) { return @{} }
+
+                $result = @{}
+                $lines = $YamlString -split "`n" | Where-Object { $_.Trim() -and -not $_.Trim().StartsWith('#') }
+                $currentKey = $null
+                $arrayMode = $false
+
+                foreach ($line in $lines) {
+                    $trimmed = $line.Trim()
+
+                    if ($trimmed.StartsWith('- ')) {
+                        if ($arrayMode -and $currentKey) {
+                            $result[$currentKey] += @($trimmed.Substring(2).Trim())
+                        }
+                    }
+                    elseif ($trimmed -match '^([^:]+):\s*(.*)$') {
+                        $key = $matches[1].Trim()
+                        $value = $matches[2].Trim()
+
+                        if ($value -eq '') {
+                            $result[$key] = @()
+                            $currentKey = $key
+                            $arrayMode = $true
+                        }
+                        else {
+                            if ($value -eq 'true' -or $value -eq 'True') {
+                                $result[$key] = $true
+                            }
+                            elseif ($value -eq 'false' -or $value -eq 'False') {
+                                $result[$key] = $false
+                            }
+                            else {
+                                $result[$key] = $value
+                            }
+                            $arrayMode = $false
+                        }
+                    }
+                }
+
+                return $result
+            }
+        }
+    }
+
+    AfterEach {
+        [ScubaConfig]::ResetInstance()
+    }
+
+    AfterAll {
+        [ScubaConfig]::ResetInstance()
+
+        if ($script:DummyOPACreatedByTests -and (Test-Path $script:DummyOPAPath)) {
+            Remove-Item -Path $script:DummyOPAPath -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    Context "Top-level keys that host a YAML anchor definition" {
+        It "Should NOT flag an unknown property warning for a root key whose value carries an anchor" {
+            $Yaml = @"
+OrgName: TestOrg
+ProductNames:
+  - aad
+M365Environment: commercial
+SensitiveUsers: &CommonSensitiveUsers
+  - Example User;exampleuser@example.onmicrosoft.com
+"@
+            $TempFile = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), '.yaml')
+            $Yaml | Set-Content -Path $TempFile
+
+            $Result = [ScubaConfig]::ValidateConfigFile($TempFile)
+
+            $Result.Warnings | Where-Object { $_ -match "Unknown property 'SensitiveUsers'" } | Should -BeNullOrEmpty
+
+            Remove-Item -Path $TempFile -Force
+        }
+
+        It "Should NOT flag an unknown property warning regardless of the anchor host key's name" {
+            $Yaml = @"
+OrgName: TestOrg
+ProductNames:
+  - aad
+M365Environment: commercial
+CommonExclusions: &CommonExclusions
+  - someone@example.onmicrosoft.com
+"@
+            $TempFile = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), '.yaml')
+            $Yaml | Set-Content -Path $TempFile
+
+            $Result = [ScubaConfig]::ValidateConfigFile($TempFile)
+
+            $Result.Warnings | Where-Object { $_ -match "Unknown property 'CommonExclusions'" } | Should -BeNullOrEmpty
+
+            Remove-Item -Path $TempFile -Force
+        }
+
+        It "Should still flag an unknown property warning for the same key name when it has no anchor" {
+            $Yaml = @"
+OrgName: TestOrg
+ProductNames:
+  - aad
+M365Environment: commercial
+SensitiveUsers: SomeGenericValue
+"@
+            $TempFile = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), '.yaml')
+            $Yaml | Set-Content -Path $TempFile
+
+            $Result = [ScubaConfig]::ValidateConfigFile($TempFile)
+
+            $Result.Warnings | Where-Object { $_ -match "Unknown property 'SensitiveUsers'" } | Should -Not -BeNullOrEmpty
+
+            Remove-Item -Path $TempFile -Force
+        }
+
+        It "Should still flag unrelated unknown properties that don't carry an anchor" {
+            $Yaml = @"
+OrgName: TestOrg
+ProductNames:
+  - aad
+M365Environment: commercial
+SensitiveUsers: &CommonSensitiveUsers
+  - Example User;exampleuser@example.onmicrosoft.com
+TotallyMadeUpProperty: SomeValue
+"@
+            $TempFile = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), '.yaml')
+            $Yaml | Set-Content -Path $TempFile
+
+            $Result = [ScubaConfig]::ValidateConfigFile($TempFile)
+
+            $Result.Warnings | Where-Object { $_ -match "Unknown property 'SensitiveUsers'" } | Should -BeNullOrEmpty
+            $Result.Warnings | Where-Object { $_ -match "Unknown property 'TotallyMadeUpProperty'" } | Should -Not -BeNullOrEmpty
+
+            Remove-Item -Path $TempFile -Force
+        }
+    }
+}


### PR DESCRIPTION
## 🗣 Description ##

When a config file uses a YAML anchor (`&`) to define a reusable value under a top-level key, the validator was flagging that key as an unknown property, even though it's not a real config setting - it's just a place to park the anchor so it can be referenced elsewhere in the file with an alias (`*`).

The validator now checks the raw YAML text for any top-level key whose value starts with an anchor, and skips the unknown-property warning for those keys. It doesn't care what the key is named or what the anchor is used for - it's a general check, not tied to any specific field.

Alias resolution itself isn't touched here - `ConvertFrom-Yaml` already handles that correctly. This is only to fix the validator's unknown-property warning.

## 💭 Motivation and context ##

Resolves #2204. 
Anchors are a normal YAML feature for avoiding repetition, but using them meant an extra, misleading warning on every load.

## 🧪 Testing ##

- Added unit tests covering: an anchor key gets skipped, a differently named anchor key also gets skipped (confirms it's not hardcoded to one field name), the same key without an anchor still warns, and unrelated unknown properties
  still warn.
- Full ScubaConfig test suite passes, no warnings or regressions.
- Verified against a real config file with several anchors/aliases.

Here is a sample yaml file (or use your own yaml with anchors)
```yaml
# ScubaGear Sample Configuration File - YAML Anchors & Aliases (Full Example)
#
# Demonstrates three distinct anchor/alias patterns:
#   1. List anchor reused across independent product sections (SensitiveUsers, AllowedForwardingDomains).
#   2. Scalar anchor reused as ONE item inside several different-sized lists (BreakGlassAccountsGroup).
#   3. Whole-mapping anchor reused directly on a real schema property's value (AnnotatePolicy),
#      no throwaway top-level key needed since the first usage IS a valid property.

OrgName: Department of Example
OrgUnitName: Subdepartment of Example
Description: |
  Full sample demonstrating multiple YAML anchor/alias reuse patterns.

ProductNames:
  - aad
  - securitysuite
  - exo

M365Environment: commercial

# --- Pattern 1: list anchors (throwaway top-level keys) ---

CommonSensitiveUsersList: &CommonSensitiveUsers
  - Jane Doe;jane.doe@example.onmicrosoft.com

CommonAllowedForwardingDomainsList: &AllowedForwardingDomains
  - partner.example.com

# --- Pattern 2: scalar anchor, reused as a single list item alongside other unique items ---

BreakGlassAccountsGroup: &BreakGlassAccountsGroup 00000000-0000-0000-0000-000000000001

Aad:
  MS.AAD.1.1v1:
    CapExclusions:
      Groups:
        - *BreakGlassAccountsGroup
  MS.AAD.2.1v1:
    CapExclusions:
      Groups:
        - *BreakGlassAccountsGroup
        - 11111111-1111-1111-1111-111111111111

SecuritySuite:
  MS.SECURITYSUITE.2.1v1:
    SensitiveUsers: *CommonSensitiveUsers

Exo:
  MS.EXO.1.1v2:
    AllowedForwardingDomains: *AllowedForwardingDomains

# --- Pattern 3: whole-mapping anchor directly on a real property (no throwaway key needed) ---

AnnotatePolicy:
  MS.AAD.3.1v1: &CommonAnnotation
    Comment: 'Reused annotation, see MS.SECURITYSUITE.1.2v1 for the same note'
    RemediationDate: "2027-12-31"
    IncorrectResult: false
  MS.SECURITYSUITE.1.2v1: *CommonAnnotation
```

Verify the anchors aren't removed and the values are added to each alias:

```powershell
using module '.\PowerShell\ScubaGear\Modules\ScubaConfig\ScubaConfig.psm1'

# Full resolved config (defaults applied, aliases already expanded)
[ScubaConfig]::ResetInstance()
$config = [ScubaConfig]::GetInstance()
$config.LoadConfig(''<path>.yaml')
$config.Configuration | ConvertTo-Json -Depth 10
```
Test ScubaGear against the yaml

```powershell
Invoke-SCuBA -ConfigFilePath <path>.yaml
```

There should be no warnings for unknown properties against the Anchors

## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] Changes are sized such that they do not touch excessive number of files.
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [ ] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] All relevant type-of-change labels added.
- [ ] All relevant project fields are set.
- [ ] All relevant repo and/or project documentation updated to reflect these changes.
- [ ] Unit tests added/updated to cover PowerShell and Rego changes.
- [ ] Functional tests added/updated to cover PowerShell and Rego changes.
- [ ] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] PR passed smoke test check.
- [ ] PR/feature branch passes functional tests for relevant products, if applicable.
- [ ] Feature branch has been rebased against changes from parent branch, as needed.

  Use `Update branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [ ] Resolved all merge conflicts on branch.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the PR assignee to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
