### PR TITLE
test: silence BOD warnings in test invocations

### DIFF
--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-Scuba.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-Scuba.Tests.ps1
@@ -70,6 +70,7 @@ InModuleScope Orchestrator {
                 $SplatParams = @{
                     M365Environment = 'commercial';
                     KeepIndividualJSON = $true;
+                    SilenceBODWarnings = $true;
                 }
             }
             It 'Do it quietly (Do not automatically show report)' {

--- a/Testing/Functional/Products/Products.Tests.ps1
+++ b/Testing/Functional/Products/Products.Tests.ps1
@@ -395,7 +395,7 @@ Describe "Policy Checks for <ProductName>" {
 
                 Set-Content -Path $TestConfigFilePath -Value ($ScubaConfig | ConvertTo-Yaml)
                 SetConditions -Conditions $Preconditions.ToArray()
-                Invoke-SCuBA -ConfigFilePath $TestConfigFilePath -Quiet -KeepIndividualJSON
+                Invoke-SCuBA -ConfigFilePath $TestConfigFilePath -Quiet -KeepIndividualJSON -SilenceBODWarnings
                 $ReportFolders = Get-ChildItem . -directory -Filter "M365BaselineConformance*" | Sort-Object -Property LastWriteTime -Descending
                 $script:OutputFolder = $ReportFolders[0].Name
 

--- a/Testing/Functional/SmokeTest/SmokeTest001.Tests.ps1
+++ b/Testing/Functional/SmokeTest/SmokeTest001.Tests.ps1
@@ -57,11 +57,11 @@ Describe "Smoke Test: Generate Output" {
     Context "Invoke Scuba for $Alias" {
         BeforeAll {
             if ($PSCmdlet.ParameterSetName -eq 'Manual'){
-                { Invoke-SCuBA -ProductNames "*" -M365Environment $M365Environment -Quiet -KeepIndividualJSON} |
+                { Invoke-SCuBA -ProductNames "*" -M365Environment $M365Environment -Quiet -KeepIndividualJSON -SilenceBODWarnings} |
                 Should -Not -Throw
             }
             else {
-                { Invoke-SCuBA -CertificateThumbprint $Thumbprint -AppID $AppId -Organization $Organization -ProductNames "*" -M365Environment $M365Environment -Quiet -KeepIndividualJSON} |
+                { Invoke-SCuBA -CertificateThumbprint $Thumbprint -AppID $AppId -Organization $Organization -ProductNames "*" -M365Environment $M365Environment -Quiet -KeepIndividualJSON -SilenceBODWarnings} |
                 Should -Not -Throw
             }
             $ReportFolders = Get-ChildItem . -directory -Filter "M365BaselineConformance*" | Sort-Object -Property LastWriteTime -Descending


### PR DESCRIPTION
## Summary
- add `-SilenceBODWarnings` to the remaining test `Invoke-SCuBA` entry points
- update the shared unit-test splat so product-path invocations stay quiet by default
- align the tests with issue #2214 and reduce noisy BOD warning output

Closes #2214

## Testing
- not run (test-only change)