### PR TITLE
Add output and docs for defender to securitysuite transition

### DIFF
--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -1,6 +1,53 @@
 using module 'ScubaConfig\ScubaConfig.psm1'
 Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "Utility/ScubaLogging.psm1")
 
+function ConvertTo-ScubaProductNames {
+    <#
+    .SYNOPSIS
+    Normalizes a list of ScubaGear product names.
+    .DESCRIPTION
+    Centralizes ScubaGear product-name normalization so the value is handled identically
+    regardless of whether it originates from the -ProductNames parameter or an imported
+    configuration file. It:
+      1. Expands the '*' wildcard to the full list of supported products.
+      2. Substitutes the deprecated 'defender' alias with its replacement 'securitysuite'
+         (adding 'securitysuite' only if not already present).
+      3. Returns a sorted, de-duplicated array.
+    .PARAMETER ProductNames
+    The array of product names to normalize.
+    #>
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [AllowEmptyCollection()]
+        [string[]]
+        $ProductNames
+    )
+
+    if ($null -eq $ProductNames) {
+        return @()
+    }
+
+    # Expand the wildcard to all supported products
+    if ($ProductNames -contains '*') {
+        $ProductNames = "aad", "securitysuite", "exo", "powerplatform", "sharepoint", "teams", "powerbi"
+        Write-Debug "Setting ProductNames to all products because of wildcard"
+    }
+
+    # 'defender' is a deprecated alias for 'securitysuite'
+    if ($ProductNames -contains 'defender') {
+        if (-not ($ProductNames -contains 'securitysuite')) {
+            $ProductNames = @($ProductNames) + "securitysuite"
+        }
+        $ProductNames = @($ProductNames | Where-Object { $_ -ne "defender" })
+        Write-Debug "Substituting defender with securitysuite in ProductNames"
+    }
+
+    return @($ProductNames | Sort-Object -Unique)
+}
+
 function Invoke-SCuBA {
     <#
     .SYNOPSIS
@@ -315,20 +362,11 @@ function Invoke-SCuBA {
         # Initialize logging flag - actual initialization happens after output folder is created
         $Script:ScubaLoggingEnabled = $false
 
-        # Transform ProductNames into list of all products if it contains wildcard
-        if ($ProductNames.Contains('*')){
-            $ProductNames = $PSBoundParameters['ProductNames'] = "aad", "securitysuite", "exo", "powerplatform", "sharepoint", "teams", "powerbi"
-            Write-Debug "Setting ProductName to all products because of wildcard"
-        }
-
-        # defender is an alias for securitysuite, substitute securitysuite in for defender if specified
-        if ($ProductNames.Contains('defender')){
-            if (-not $ProductNames.Contains('securitysuite')) {
-                $ProductNames = $PSBoundParameters['ProductNames'] = $ProductNames + "securitysuite"
-            }
-            $ProductNames = $PSBoundParameters['ProductNames'] = @($ProductNames | Where-Object {$_ -ne "defender" })
-            Write-Debug "Substituting defender with securitysuite in ProductNames"
-        }
+        # ProductNames normalization (wildcard expansion and the deprecated 'defender' ->
+        # 'securitysuite' substitution) is centralized in ConvertTo-ScubaProductNames and
+        # applied once to the resolved $ScubaConfig.ProductNames below, after the command-line
+        # parameters and any configuration file have been merged. Handling it at that single
+        # convergence point ensures products from either source are normalized identically.
 
         # Default execution ParameterSet
         if ($PSCmdlet.ParameterSetName -eq 'Report'){
@@ -438,6 +476,14 @@ function Invoke-SCuBA {
             }
         }
 
+        # Normalize the fully-resolved product list once, after command-line parameters and
+        # any configuration file have been merged into $ScubaConfig. This is the single point
+        # where products from the -ProductNames parameter and from an imported config file
+        # converge, so normalizing here expands the '*' wildcard and substitutes the deprecated
+        # 'defender' alias with 'securitysuite' for both sources. It runs after
+        # ValidateConfiguration so the Defender deprecation warning is still emitted first.
+        $ScubaConfig.ProductNames = ConvertTo-ScubaProductNames -ProductNames $ScubaConfig.ProductNames
+
         if (-not $SilenceBODWarnings -and $null -eq $ScubaConfig.OrgName) {
             $Warning = "Config file option OrgName not provided. This option is required for BOD "
             $Warning += "submissions. See https://github.com/cisagov/ScubaGear/blob/main/docs/configuration/configuration.md#scuba-compliance-use for more details. "
@@ -480,7 +526,7 @@ function Invoke-SCuBA {
             $Script:ScubaLoggingEnabled = $true
             Write-ScubaLog -Message "ScubaGear logging initialized" -Level "Info" -Source "InvokeScuba" -Data @{
                 Version = $ModuleVersion
-                ProductNames = ($ProductNames -join ', ')
+                ProductNames = ($ScubaConfig.ProductNames -join ', ')
                 UserPassedEnvironment = $M365Environment
                 OutputFolder = $OutFolderPath
                 LogFolder = $ScubaLogFolder

--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -2674,7 +2674,7 @@ function Repair-ScubaGearJson {
     if ($ReturnObject.RepairedJson) {
         Write-Warning "The provider JSON file required automatic repair."
     }
-    
+
     $ProviderJsonObject = $ProviderSettingsObject.JsonObject
 
     .EXAMPLE
@@ -2732,7 +2732,7 @@ function Repair-ScubaGearJson {
         else {
             $ReturnObject.JsonString = $JsonInputString
         }
-       
+
         return $ReturnObject
     }
     catch {
@@ -2751,7 +2751,7 @@ function Repair-ScubaGearJson {
         else {
             Write-Warning "Repair-ScubaGearJson: ScubaGear detected an invalid JSON object"
         }
-        
+
         Write-Warning "Please report this to the ScubaGear team as a bug report either by GitHub or the Scuba mailbox."
         Write-Warning "Attempting to auto repair the JSON..."
 

--- a/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfigDefaults.json
+++ b/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfigDefaults.json
@@ -155,6 +155,11 @@
         "actionMessageRef": "default"
       },
       {
+        "name": "Defender migration warnings",
+        "pattern": "^Defender\\s+migration\\s+warning:",
+        "actionMessageRef": "defenderMigration"
+      },
+      {
         "name": "Other warnings",
         "pattern": "",
         "actionMessageRef": "default"
@@ -168,6 +173,11 @@
       ],
       "opaPath": [
         "Please install OPA using 'Install-OPAforSCuBA' or place the executable in one of the following locations above."
+      ],
+      "defenderMigration": [
+        "The Defender product has been renamed to 'securitysuite' and many Defender, Exchange Online, and Teams policies were migrated into the MS.SECURITYSUITE.* baseline.",
+        "Update your configuration file: replace 'defender' with 'securitysuite' in ProductNames and update migrated policy IDs to their new MS.SECURITYSUITE.* equivalents.",
+        "Refer to the documentation [docs\\configuration\\defender-to-securitysuite-transition.md] and the mapping file [mappings\\scuba-baseline-policy-migrations.csv] for the complete list of migrated policies."
       ]
     }
   }

--- a/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfigDefaults.json
+++ b/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfigDefaults.json
@@ -155,8 +155,8 @@
         "actionMessageRef": "default"
       },
       {
-        "name": "Defender migration warnings",
-        "pattern": "^Defender\\s+migration\\s+warning:",
+        "name": "Defender/Policy migration warnings",
+        "pattern": "^(Defender|Policy)\\s+migration\\s+warning:",
         "actionMessageRef": "defenderMigration"
       },
       {

--- a/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfigValidator.psm1
+++ b/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfigValidator.psm1
@@ -50,6 +50,7 @@ class ScubaConfigValidator {
         [ScubaConfigValidator]::_Cache['ModulePath'] = $ModulePath
         [ScubaConfigValidator]::LoadSchema()
         [ScubaConfigValidator]::LoadDefaults()
+        [ScubaConfigValidator]::LoadPolicyMigrations()
     }
 
     # Loads and caches JSON schema file for configuration validation
@@ -86,6 +87,50 @@ class ScubaConfigValidator {
         catch {
             throw "Failed to load defaults file: $($_.Exception.Message)"
         }
+    }
+
+    # Loads and caches the baseline policy migration mappings (Old ID -> New ID).
+    # These mappings drive the Defender-to-Security Suite transition warnings so that
+    # users configuring deprecated policy IDs are guided to the replacement policy IDs.
+    hidden static [void] LoadPolicyMigrations() {
+        $Migrations = @{}
+
+        $ModulePath = [ScubaConfigValidator]::_Cache['ModulePath']
+        # Module path is ...\Modules\ScubaConfig; the mappings live in ...\mappings
+        $MigrationsPath = Join-Path -Path $ModulePath -ChildPath "..\..\mappings\scuba-baseline-policy-migrations.csv"
+
+        if (Test-Path -LiteralPath $MigrationsPath) {
+            try {
+                $Rows = Import-Csv -LiteralPath $MigrationsPath -ErrorAction Stop
+                foreach ($Row in $Rows) {
+                    $OldId = ($Row.'Old ID').Trim()
+                    $NewId = ($Row.'New ID').Trim()
+                    if ($OldId) {
+                        $Migrations[$OldId.ToUpper()] = [PSCustomObject]@{
+                            OldId = $OldId
+                            NewId = $NewId
+                        }
+                    }
+                }
+            }
+            catch {
+                # Migration data is advisory only; never fail validation if it cannot be read
+                Write-Debug "Failed to load policy migrations file: $($_.Exception.Message)"
+            }
+        }
+        else {
+            Write-Debug "Policy migrations file not found: $MigrationsPath"
+        }
+
+        [ScubaConfigValidator]::_Cache['PolicyMigrations'] = $Migrations
+    }
+
+    # Returns cached policy migration mappings (keyed by upper-cased Old ID)
+    static [hashtable] GetPolicyMigrations() {
+        if (-not [ScubaConfigValidator]::_Cache.ContainsKey('PolicyMigrations')) {
+            [ScubaConfigValidator]::LoadPolicyMigrations()
+        }
+        return [ScubaConfigValidator]::_Cache['PolicyMigrations']
     }
 
     # Returns cached configuration defaults object
@@ -475,6 +520,9 @@ class ScubaConfigValidator {
         # Check for product exclusions on products that don't support them
         [ScubaConfigValidator]::ValidateUnsupportedProductExclusions($ConfigObject, $Validation)
 
+        # Warn when deprecated Defender product name or migrated Defender policy IDs are used
+        [ScubaConfigValidator]::ValidateDefenderMigration($ConfigObject, $Validation)
+
         return [PSCustomObject]$Validation
     }
 
@@ -505,6 +553,89 @@ class ScubaConfigValidator {
                 }
             }
         }
+    }
+
+    # Warns when a configuration still references the deprecated Defender product name
+    # or contains policy IDs that have migrated to the Security Suite baseline.
+    # The Defender product has been renamed to "securitysuite" and many of its policies
+    # (along with several EXO and Teams policies) were decoupled and migrated into the
+    # MS.SECURITYSUITE.* baseline. See mappings\scuba-baseline-policy-migrations.csv.
+    hidden static [void] ValidateDefenderMigration([object]$ConfigObject, [hashtable]$Validation) {
+        $DocRef = "See docs\configuration\defender-to-securitysuite-transition.md and mappings\scuba-baseline-policy-migrations.csv for the full list of migrated policies."
+
+        # 1. Deprecated 'defender' value in ProductNames
+        if ($ConfigObject.ProductNames) {
+            foreach ($Product in $ConfigObject.ProductNames) {
+                if ($Product -is [string] -and $Product.Trim().ToLower() -eq 'defender') {
+                    [void]$Validation.Warnings.Add("Defender migration warning: The product name 'defender' is deprecated and has been renamed to 'securitysuite'. ScubaGear will run 'securitysuite' in its place. Update ProductNames to use 'securitysuite'. $DocRef")
+                    break
+                }
+            }
+        }
+
+        # 2. Deprecated top-level 'Defender' product section (exclusions/config)
+        foreach ($PropertyName in $ConfigObject.PSObject.Properties.Name) {
+            if ($PropertyName -eq 'Defender') {
+                [void]$Validation.Warnings.Add("Defender migration warning: The 'Defender' configuration section is deprecated. Defender policies have been migrated to the Security Suite baseline; move applicable settings under the 'SecuritySuite' section. $DocRef")
+                break
+            }
+        }
+
+        # 3. Migrated policy IDs referenced anywhere in the configuration
+        $Migrations = [ScubaConfigValidator]::GetPolicyMigrations()
+        if ($Migrations -and $Migrations.Count -gt 0) {
+            $ReportedIds = @{}
+
+            foreach ($ConfigId in [ScubaConfigValidator]::GetConfiguredPolicyIds($ConfigObject)) {
+                $Key = $ConfigId.ToUpper()
+                if ($Migrations.ContainsKey($Key) -and -not $ReportedIds.ContainsKey($Key)) {
+                    $ReportedIds[$Key] = $true
+                    $NewId = $Migrations[$Key].NewId
+                    if ([string]::IsNullOrWhiteSpace($NewId) -or $NewId -eq 'None') {
+                        [void]$Validation.Warnings.Add("Defender migration warning: Policy ID '$ConfigId' has been removed and is no longer assessed by ScubaGear. Remove it from your configuration. $DocRef")
+                    }
+                    else {
+                        [void]$Validation.Warnings.Add("Defender migration warning: Policy ID '$ConfigId' has been migrated to '$NewId'. Update your configuration to use the new policy ID. $DocRef")
+                    }
+                }
+            }
+        }
+    }
+
+    # Collects all policy IDs referenced in a configuration object across product exclusion
+    # sections (e.g. Defender/SecuritySuite/Exo/Aad) and policy-type sections
+    # (AnnotatePolicy, OmitPolicy). Returns a flat array of policy ID strings.
+    hidden static [array] GetConfiguredPolicyIds([object]$ConfigObject) {
+        $PolicyIdPattern = '^MS\.[A-Za-z]+\.[0-9]+\.[0-9]+[Vv][0-9]+$'
+        $Ids = [System.Collections.ArrayList]::new()
+
+        if (-not $ConfigObject) {
+            return $Ids.ToArray()
+        }
+
+        foreach ($Property in $ConfigObject.PSObject.Properties) {
+            $Value = $Property.Value
+            if ($null -eq $Value) {
+                continue
+            }
+
+            # Top-level key that is itself a policy ID (defensive; not expected)
+            if ($Property.Name -match $PolicyIdPattern) {
+                [void]$Ids.Add($Property.Name)
+            }
+
+            # Nested keys (product exclusion sections, AnnotatePolicy, OmitPolicy)
+            if ($Value -is [System.Management.Automation.PSCustomObject] -or $Value -is [hashtable]) {
+                $NestedNames = if ($Value -is [hashtable]) { $Value.Keys } else { $Value.PSObject.Properties.Name }
+                foreach ($NestedName in $NestedNames) {
+                    if ($NestedName -match $PolicyIdPattern) {
+                        [void]$Ids.Add($NestedName)
+                    }
+                }
+            }
+        }
+
+        return $Ids.ToArray()
     }
 
     # Dynamically validates all properties against their schema definitions

--- a/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfigValidator.psm1
+++ b/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfigValidator.psm1
@@ -592,10 +592,10 @@ class ScubaConfigValidator {
                     $ReportedIds[$Key] = $true
                     $NewId = $Migrations[$Key].NewId
                     if ([string]::IsNullOrWhiteSpace($NewId) -or $NewId -eq 'None') {
-                        [void]$Validation.Warnings.Add("Defender migration warning: Policy ID '$ConfigId' has been removed and is no longer assessed by ScubaGear. Remove it from your configuration. $DocRef")
+                        [void]$Validation.Warnings.Add("Policy migration warning: Policy ID '$ConfigId' has been removed and is no longer assessed by ScubaGear. Remove it from your configuration. $DocRef")
                     }
                     else {
-                        [void]$Validation.Warnings.Add("Defender migration warning: Policy ID '$ConfigId' has been migrated to '$NewId'. Update your configuration to use the new policy ID. $DocRef")
+                        [void]$Validation.Warnings.Add("Policy migration warning: Policy ID '$ConfigId' has been migrated to '$NewId'. Update your configuration to use the new policy ID. $DocRef")
                     }
                 }
             }

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-ScubaConfig.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-ScubaConfig.Tests.ps1
@@ -233,7 +233,7 @@ InModuleScope Orchestrator {
             }
 
             It "Verify parameter, ProductNames, with wildcard CLI override"{
-                $script:TestSplat['ProductNames'] | Should -BeExactly @('aad', 'securitysuite', 'exo', 'powerplatform', 'sharepoint', 'teams', 'powerbi') -Because "got $($script:TestSplat['ProductNames'])"
+                $script:TestSplat['ProductNames'] | Should -BeExactly @('aad', 'exo', 'powerbi', 'powerplatform', 'securitysuite', 'sharepoint', 'teams') -Because "got $($script:TestSplat['ProductNames'])"
             }
         }
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -187,6 +187,9 @@ For each omitted policy, the config file allows you to indicate the following:
 
 Config files can include a top-level level key for a given product whose values are related to that specific product. For example, the `SecuritySuite` key contains configuration options specific to the Security Suite baseline. Currently, only Entra ID, Security Suite, and Exchange Online use this extra configuration.
 
+> [!IMPORTANT]
+> The `defender` product has been renamed to `securitysuite`, and many Defender, Exchange Online, and Teams policies have been migrated into the Security Suite baseline. If you have an existing configuration file that references `defender` or migrated policy IDs, see [Transitioning from Defender to the Security Suite Baseline](defender-to-securitysuite-transition.md).
+
 Under a product key, there can be policy keys that provide configuration values unique to the product. In the Security Suite configuration, for example, there is the `MS.SECURITYSUITE.2.1v1` key.
 
 ### Entra ID Configuration

--- a/docs/configuration/defender-to-securitysuite-transition.md
+++ b/docs/configuration/defender-to-securitysuite-transition.md
@@ -125,10 +125,10 @@ Re-run ScubaGear (or the configuration validator) against your updated file to c
 
 When ScubaGear loads a configuration file, the built-in configuration validator checks for deprecated Defender usage and prints warnings to the console. You will see a `Defender migration warning` for each of the following situations:
 
-- **Deprecated product name** — `ProductNames` still contains `defender`. ScubaGear runs `securitysuite` in its place and recommends updating the configuration.
-- **Deprecated `Defender` section** — the configuration still contains a top-level `Defender:` section. Move the settings under `SecuritySuite:`.
-- **Migrated policy ID** — a policy ID referenced in the configuration (in an exclusion, annotation, or omission) has been migrated. The warning names the new `MS.SECURITYSUITE.*` policy ID to use.
-- **Removed policy ID** — a policy ID referenced in the configuration has been removed and should be deleted.
+- **Deprecated product name** - `ProductNames` still contains `defender`. ScubaGear runs `securitysuite` in its place and recommends updating the configuration.
+- **Deprecated `Defender` section** - the configuration still contains a top-level `Defender:` section. Move the settings under `SecuritySuite:`.
+- **Migrated policy ID** - a policy ID referenced in the configuration (in an exclusion, annotation, or omission) has been migrated. The warning names the new `MS.SECURITYSUITE.*` policy ID to use.
+- **Removed policy ID** - a policy ID referenced in the configuration has been removed and should be deleted.
 
 Example console output:
 

--- a/docs/configuration/defender-to-securitysuite-transition.md
+++ b/docs/configuration/defender-to-securitysuite-transition.md
@@ -1,0 +1,153 @@
+# Transitioning from Defender to the Security Suite Baseline
+
+Recent versions of ScubaGear consolidate the Microsoft Defender baseline (and several Exchange Online and Microsoft Teams policies) into a new **Security Suite** baseline. As part of this change:
+
+- The **`defender`** product has been **renamed to `securitysuite`**.
+- Many `MS.DEFENDER.*`, `MS.EXO.*`, and `MS.TEAMS.*` policies were **decoupled and migrated** into new `MS.SECURITYSUITE.*` policies. Some old policies map to a single combined Security Suite policy, some were split across several new policies, and a few were removed entirely.
+
+If you have existing configuration files that reference `defender` or any of the migrated policy IDs, you must update them to use the Security Suite product name and the new policy IDs.
+
+> [!TIP]
+> The easiest way to build or update a configuration file is with the **[Configuration UI](scubaconfigapp.md)** (`Start-ScubaConfigApp`). The UI validates policy IDs and product names for you and helps avoid manual mistakes.
+
+## The policy migration mapping file
+
+The authoritative list of what changed is the migration mapping file included in the repository:
+
+[`PowerShell/ScubaGear/mappings/scuba-baseline-policy-migrations.csv`](../../PowerShell/ScubaGear/mappings/scuba-baseline-policy-migrations.csv)
+
+Each row describes how an old policy maps to the Security Suite baseline:
+
+| Column | Description |
+| --- | --- |
+| `Old ID` | The deprecated policy ID (for example, `MS.DEFENDER.1.1v1` or `MS.EXO.9.1v2`). |
+| `Old Description` | The text of the deprecated policy. |
+| `New ID` | The replacement policy ID (for example, `MS.SECURITYSUITE.1.1v1`). A value of `None` means the policy was removed and is no longer assessed. A range (for example, `MS.SECURITYSUITE.1.1v1 - MS.SECURITYSUITE.1.4v1`) means the old policy was split across several new policies. |
+| `Shall or Should` | Whether the policy is a `SHALL` or `SHOULD`. |
+| `Removal Rationale` | Why the policy changed or was removed (`N/A` when it simply moved). |
+
+Refer to this file whenever you need to find the new ID for a specific old policy.
+
+### High-level summary of the migration
+
+- **`MS.DEFENDER.*` policies** are now covered by `MS.SECURITYSUITE.*` policies (preset/EOP protection, impersonation protection, safe attachments, DLP, alerts, and audit logging).
+- **`MS.EXO.8` – `MS.EXO.17` policies** (DLP, attachment filtering, malware scanning, impersonation, anti-spam, safe links, alerts, and audit logging) were moved into the Security Suite baseline.
+- **`MS.TEAMS.6` – `MS.TEAMS.8` policies** (DLP and malware scanning for Teams) were moved into the Security Suite baseline.
+- A small number of `SHOULD` policies that could not be assessed by ScubaGear were **removed** (`New ID` = `None`).
+
+## Steps to update a YAML configuration file
+
+Follow these steps to migrate an existing configuration file. The same steps apply to JSON configuration files.
+
+### 1. Update `ProductNames`
+
+Replace `defender` with `securitysuite`.
+
+**Before:**
+
+```yaml
+ProductNames:
+  - aad
+  - defender
+  - exo
+```
+
+**After:**
+
+```yaml
+ProductNames:
+  - aad
+  - securitysuite
+  - exo
+```
+
+> [!NOTE]
+> For backwards compatibility, if you run ScubaGear with `defender` in `ProductNames`, ScubaGear will automatically substitute `securitysuite` and emit a warning. Updating the configuration file removes the warning and reflects the current product name.
+
+### 2. Rename the product exclusion section
+
+If your configuration file has a top-level `Defender:` section for exclusions, rename it to `SecuritySuite:` and update the policy IDs inside it (see step 3).
+
+**Before:**
+
+```yaml
+Defender:
+  MS.DEFENDER.2.1v1:
+    SensitiveUsers:
+      - jdoe@example.com
+```
+
+**After:**
+
+```yaml
+SecuritySuite:
+  MS.SECURITYSUITE.2.1v1:
+    SensitiveUsers:
+      - jdoe@example.com
+```
+
+### 3. Update migrated policy IDs in exclusions, annotations, and omissions
+
+Look up each old policy ID in [`scuba-baseline-policy-migrations.csv`](../../PowerShell/ScubaGear/mappings/scuba-baseline-policy-migrations.csv) and replace it with the corresponding `New ID` under `AnnotatePolicy`, `OmitPolicy`, and any product exclusion section.
+
+**Before:**
+
+```yaml
+OmitPolicy:
+  MS.DEFENDER.2.1v1:
+    Rationale: "We use a third-party phishing protection solution instead of Defender."
+  MS.EXO.9.1v2:
+    Rationale: "Handled by our third-party mail gateway."
+```
+
+**After:**
+
+```yaml
+OmitPolicy:
+  MS.SECURITYSUITE.2.1v1:
+    Rationale: "We use a third-party phishing protection solution instead of Defender."
+  MS.SECURITYSUITE.1.1v1:
+    Rationale: "Handled by our third-party mail gateway."
+```
+
+> [!IMPORTANT]
+> Some old policies were split into a **range** of new policies (for example, `MS.DEFENDER.1.1v1` maps to `MS.SECURITYSUITE.1.1v1 - MS.SECURITYSUITE.1.4v1`). Review the range and choose the specific new policy ID(s) that apply to your exclusion, annotation, or omission.
+
+### 4. Remove any policies marked as removed
+
+If the `New ID` for an old policy is `None`, the policy has been removed and is no longer assessed by ScubaGear. Delete any exclusions, annotations, or omissions that reference it.
+
+### 5. Validate the updated configuration
+
+Re-run ScubaGear (or the configuration validator) against your updated file to confirm there are no remaining Defender migration warnings. See [Validator warnings](#validator-warnings) below.
+
+## Validator warnings
+
+When ScubaGear loads a configuration file, the built-in configuration validator checks for deprecated Defender usage and prints warnings to the console. You will see a `Defender migration warning` for each of the following situations:
+
+- **Deprecated product name** — `ProductNames` still contains `defender`. ScubaGear runs `securitysuite` in its place and recommends updating the configuration.
+- **Deprecated `Defender` section** — the configuration still contains a top-level `Defender:` section. Move the settings under `SecuritySuite:`.
+- **Migrated policy ID** — a policy ID referenced in the configuration (in an exclusion, annotation, or omission) has been migrated. The warning names the new `MS.SECURITYSUITE.*` policy ID to use.
+- **Removed policy ID** — a policy ID referenced in the configuration has been removed and should be deleted.
+
+Example console output:
+
+```text
+WARNING: Configuration validation found 2 warnings:
+  Defender migration warning: The product name 'defender' is deprecated and has been renamed to 'securitysuite'. ScubaGear will run 'securitysuite' in its place. Update ProductNames to use 'securitysuite'. See docs\configuration\defender-to-securitysuite-transition.md and mappings\scuba-baseline-policy-migrations.csv for the full list of migrated policies.
+  Defender migration warning: Policy ID 'MS.DEFENDER.2.1v1' has been migrated to 'MS.SECURITYSUITE.2.1v1'. Update your configuration to use the new policy ID. See docs\configuration\defender-to-securitysuite-transition.md and mappings\scuba-baseline-policy-migrations.csv for the full list of migrated policies.
+
+--- RECOMMENDED ACTION ---
+  - The Defender product has been renamed to 'securitysuite' and many Defender, Exchange Online, and Teams policies were migrated into the MS.SECURITYSUITE.* baseline.
+  - Update your configuration file: replace 'defender' with 'securitysuite' in ProductNames and update migrated policy IDs to their new MS.SECURITYSUITE.* equivalents.
+  - Refer to the documentation [docs\configuration\defender-to-securitysuite-transition.md] and the mapping file [mappings\scuba-baseline-policy-migrations.csv] for the complete list of migrated policies.
+```
+
+These warnings do not stop ScubaGear from running, but resolving them ensures your configuration reflects the current baseline and that your exclusions, annotations, and omissions are applied to the correct policies.
+
+## Related documentation
+
+- [ScubaGear Configuration File](configuration.md)
+- [Configuration UI](scubaconfigapp.md)
+- [Parameters](parameters.md)
+- [Security Suite baseline](../../PowerShell/ScubaGear/baselines/securitysuite.md)

--- a/docs/configuration/defender-to-securitysuite-transition.md
+++ b/docs/configuration/defender-to-securitysuite-transition.md
@@ -123,10 +123,15 @@ Re-run ScubaGear (or the configuration validator) against your updated file to c
 
 ## Validator warnings
 
-When ScubaGear loads a configuration file, the built-in configuration validator checks for deprecated Defender usage and prints warnings to the console. You will see a `Defender migration warning` for each of the following situations:
+When ScubaGear loads a configuration file, the built-in configuration validator checks for deprecated Defender usage and prints warnings to the console. The validator uses two prefixes:
+
+`Defender migration warning:` for Defender-wide deprecations:
 
 - **Deprecated product name** - `ProductNames` still contains `defender`. ScubaGear runs `securitysuite` in its place and recommends updating the configuration.
 - **Deprecated `Defender` section** - the configuration still contains a top-level `Defender:` section. Move the settings under `SecuritySuite:`.
+
+`Policy migration warning:` for individual policy IDs referenced in the configuration:
+
 - **Migrated policy ID** - a policy ID referenced in the configuration (in an exclusion, annotation, or omission) has been migrated. The warning names the new `MS.SECURITYSUITE.*` policy ID to use.
 - **Removed policy ID** - a policy ID referenced in the configuration has been removed and should be deleted.
 
@@ -135,7 +140,7 @@ Example console output:
 ```text
 WARNING: Configuration validation found 2 warnings:
   Defender migration warning: The product name 'defender' is deprecated and has been renamed to 'securitysuite'. ScubaGear will run 'securitysuite' in its place. Update ProductNames to use 'securitysuite'. See docs\configuration\defender-to-securitysuite-transition.md and mappings\scuba-baseline-policy-migrations.csv for the full list of migrated policies.
-  Defender migration warning: Policy ID 'MS.DEFENDER.2.1v1' has been migrated to 'MS.SECURITYSUITE.2.1v1'. Update your configuration to use the new policy ID. See docs\configuration\defender-to-securitysuite-transition.md and mappings\scuba-baseline-policy-migrations.csv for the full list of migrated policies.
+  Policy migration warning: Policy ID 'MS.DEFENDER.2.1v1' has been migrated to 'MS.SECURITYSUITE.2.1v1'. Update your configuration to use the new policy ID. See docs\configuration\defender-to-securitysuite-transition.md and mappings\scuba-baseline-policy-migrations.csv for the full list of migrated policies.
 
 --- RECOMMENDED ACTION ---
   - The Defender product has been renamed to 'securitysuite' and many Defender, Exchange Online, and Teams policies were migrated into the MS.SECURITYSUITE.* baseline.


### PR DESCRIPTION
# Add output and docs for Defender-to-SecuritySuite transition #

## 🗣 Description ##

Adds user-facing guidance and configuration validation to help users migrate from the deprecated `defender` product to the renamed `securitysuite` baseline.

- **New transition guide**: `docs/configuration/defender-to-securitysuite-transition.md` explaining the rename, the migrated policy IDs, and the recommended actions.
- **Orchestrator updates** (`Orchestrator.psm1`): accounts for `securitysuite` in both `Invoke-SCuBA -ProductNames` and `-ConfigFilePath` code paths, and emits a RECOMMENDED ACTION block when a legacy Defender config is detected.
- **Config validation** (`ScubaConfigValidator.psm1`): new `ValidateDefenderMigration` logic that warns when a config:
  - lists the deprecated `defender` value in `ProductNames`,
  - contains the deprecated top-level `Defender` section, or
  - references a policy ID that has been migrated (looked up in `mappings\scuba-baseline-policy-migrations.csv`).
- **Generic migration label**: the per-policy-ID migration message now uses a product-neutral `Policy migration warning:` prefix instead of `Defender migration warning:`, since the migration mapping also includes `AAD`/`EXO` version bumps (e.g. `MS.AAD.3.2v1` → `MS.AAD.3.2v2`) that are not Defender policies. The two genuinely Defender-specific warnings (deprecated `defender` product name and deprecated `Defender` config section) keep their Defender-specific wording.
- Supporting additions to `ScubaConfigDefaults.json` and `configuration.md`.

## 💭 Motivation and context ##

The Defender product was renamed to `securitysuite` and many Defender, Exchange Online, and Teams policies were migrated into the `MS.SECURITYSUITE.*` baseline. Existing configuration files referencing `defender` or old policy IDs previously ran with no guidance, or surfaced confusing warnings (an `AAD` policy migration was mislabeled as a "Defender migration warning"). This change gives users clear, accurate warnings and documentation on how to update their configs.

Closes #2262

## 🧪 Testing ##

Ran `Invoke-SCuBA -ConfigFilePath` against ternant config files containing legacy references and confirmed:

- A config with `defender` in `ProductNames` + an `OmitPolicy` for `MS.DEFENDER.1.1v1` produces the Defender rename warning, the policy-ID migration warning (`MS.DEFENDER.1.1v1` → `MS.SECURITYSUITE.1.4v1`), and the RECOMMENDED ACTION block.
- A config referencing `MS.AAD.3.2v1` and `MS.EXO.2.2v2` now reports `Policy migration warning:` (not `Defender migration warning:`) pointing to `MS.AAD.3.2v2` and `MS.EXO.2.2v3`.
- A clean/updated config produces no migration warnings.

Reviewers can reproduce by running `Invoke-SCuBA -ConfigFilePath <legacy.yaml>` and inspecting the `Configuration validation found X warnings` output, or by running the ScubaConfig unit tests under `Testing/Unit/PowerShell/ScubaConfig/`.

## 📷 Screenshots (if appropriate) ##

Running config with defender:
<img width="1913" height="686" alt="image" src="https://github.com/user-attachments/assets/6cd636bb-2f57-4bb1-940a-37d0488d9bdb" />

Running config with securitysuite
<img width="1896" height="379" alt="image" src="https://github.com/user-attachments/assets/94894d7f-15f7-4e53-a19f-6514050c9a52" />

Running `Invoke-Scuba` with defender (no config)
<img width="1907" height="172" alt="image" src="https://github.com/user-attachments/assets/ba06e26b-2cca-445b-a9a5-80357e5b3e69" />


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels added.
- [x] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [x] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] PR passed smoke test check.
- [ ] PR/feature branch passes functional tests for relevant products, if applicable.
- [ ] Feature branch has been rebased against changes from parent branch, as needed.

  Use `Update branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [ ] Resolved all merge conflicts on branch.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the PR assignee to complete. -->
- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
