### PR TITLE
Remove report generation when a custom OPAPath is configured

### DIFF
--- a/PowerShell/ScubaGear/Modules/Utility/ScubaLogging.psm1
+++ b/PowerShell/ScubaGear/Modules/Utility/ScubaLogging.psm1
@@ -748,6 +748,25 @@ function Write-ScubaRunDetails {
 
         # 5. OPA Executable Information
         Write-ScubaLog -Message "Collecting OPA executable information..." -Level "Debug" -Source "RunDetails"
+
+        # Pre-resolve whether a custom OPAPath was supplied AND actually contains an OPA binary.
+        # When it does, the absence of OPA in the DEFAULT ~/.scubagear/Tools location is expected and
+        # benign, so the default-location check below logs it at Info instead of Warning. A benign
+        # Warning here would otherwise set $Script:ScubaHasErrors and trip the automatic error-report
+        # generator, producing a false "Errors detected!" report on an otherwise successful run.
+        # Note: Test-Path is case-insensitive on Windows, so a custom OPAPath that differs only in
+        # letter case from the actual folder still resolves correctly here.
+        $customOpaResolves = $false
+        if ($ConfiguredOPAPath) {
+            if (Test-Path $ConfiguredOPAPath -PathType Leaf) {
+                $customOpaResolves = $true
+            }
+            elseif ((Test-Path $ConfiguredOPAPath -PathType Container) -and
+                    (Get-ChildItem -Path $ConfiguredOPAPath -Filter 'opa*' -ErrorAction SilentlyContinue)) {
+                $customOpaResolves = $true
+            }
+        }
+
         try {
             $scubaDefaultPath = Join-Path -Path $env:USERPROFILE -ChildPath '.scubagear'
             $scubaTools = Join-Path -Path $scubaDefaultPath -ChildPath 'Tools'
@@ -779,11 +798,23 @@ function Write-ScubaRunDetails {
                     }
                 }
                 else {
-                    Write-ScubaLog -Message "No OPA executable found in $scubaTools" -Level "Warning" -Source "RunDetails"
+                    if ($customOpaResolves) {
+                        # Benign: OPA lives at the configured custom OPAPath, not the default location.
+                        Write-ScubaLog -Message "No OPA executable found in default location $scubaTools; a custom OPAPath is configured and will be used instead." -Level "Info" -Source "RunDetails"
+                    }
+                    else {
+                        Write-ScubaLog -Message "No OPA executable found in $scubaTools" -Level "Warning" -Source "RunDetails"
+                    }
                 }
             }
             else {
-                Write-ScubaLog -Message "ScubaGear Tools directory not found: $scubaTools" -Level "Warning" -Source "RunDetails"
+                if ($customOpaResolves) {
+                    # Benign: OPA lives at the configured custom OPAPath, so the default Tools folder is not required.
+                    Write-ScubaLog -Message "ScubaGear Tools directory not found: $scubaTools; a custom OPAPath is configured and will be used instead." -Level "Info" -Source "RunDetails"
+                }
+                else {
+                    Write-ScubaLog -Message "ScubaGear Tools directory not found: $scubaTools" -Level "Warning" -Source "RunDetails"
+                }
             }
         }
         catch {

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/ScubaLogging.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/ScubaLogging.Tests.ps1
@@ -501,6 +501,51 @@ InModuleScope ScubaLogging {
                 $logContent | Should -Not -Match "OPA Executable at configured path"
                 $logContent | Should -Not -Match "OPA Executable NOT found at configured path"
             }
+
+            It "Should log default-location OPA absence as Info (not Warning) and not flag errors when a valid custom OPAPath is configured" {
+                # Point the default location at an EMPTY Tools folder so the default-location check misses.
+                $fakeProfile = Join-Path $script:TestLogPath "profile-$(Get-Date -Format 'fffffff')"
+                New-Item -ItemType Directory (Join-Path $fakeProfile ".scubagear\Tools") -Force | Out-Null
+                $originalUserProfile = $env:USERPROFILE
+                $env:USERPROFILE = $fakeProfile
+
+                # Provide a valid custom OPAPath (directory containing an opa binary).
+                $customOpaDir = Join-Path $script:TestLogPath "customopa-$(Get-Date -Format 'fffffff')"
+                New-Item -ItemType Directory $customOpaDir -Force | Out-Null
+                Set-Content (Join-Path $customOpaDir "opa_windows_amd64.exe") "fake" -Encoding UTF8
+
+                $Script:ScubaHasErrors = $false
+                try {
+                    Write-ScubaRunDetails -ConfiguredOPAPath $customOpaDir
+                }
+                finally {
+                    $env:USERPROFILE = $originalUserProfile
+                }
+
+                $logContent = Get-Content $Script:ScubaLogPath -Raw
+                # The default-location miss must be Info, not a Warning that would trip the auto error report.
+                $logContent | Should -Match "\[Info\s*\].*RunDetails.*No OPA executable found in default location"
+                $logContent | Should -Not -Match "\[Warning\s*\].*RunDetails.*No OPA executable found in"
+                $Script:ScubaHasErrors | Should -Be $false
+            }
+
+            It "Should log default-location OPA absence as Warning when no valid custom OPAPath is configured" {
+                # Empty default Tools folder and NO configured path -> genuine warning expected.
+                $fakeProfile = Join-Path $script:TestLogPath "profile-$(Get-Date -Format 'fffffff')"
+                New-Item -ItemType Directory (Join-Path $fakeProfile ".scubagear\Tools") -Force | Out-Null
+                $originalUserProfile = $env:USERPROFILE
+                $env:USERPROFILE = $fakeProfile
+
+                try {
+                    Write-ScubaRunDetails
+                }
+                finally {
+                    $env:USERPROFILE = $originalUserProfile
+                }
+
+                $logContent = Get-Content $Script:ScubaLogPath -Raw
+                $logContent | Should -Match "\[Warning\s*\].*RunDetails.*No OPA executable found in"
+            }
         }
 
         Context "Write-ScubaRunDetails - Network Connectivity Uses Port 443" {

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/ScubaLogging.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/ScubaLogging.Tests.ps1
@@ -452,7 +452,7 @@ InModuleScope ScubaLogging {
                 $fakeOpa = Join-Path $script:TestLogPath "opa_windows_amd64.exe"
                 Set-Content $fakeOpa "fake" -Encoding UTF8
 
-                Write-ScubaRunDetails -ConfiguredOPAPath $fakeOpa
+                Write-ScubaRunDetails -ConfiguredOPAPath $fakeOpa -TestNetworkConnectivity:$false
 
                 $logContent = Get-Content $Script:ScubaLogPath -Raw
                 $logContent | Should -Match "OPA Executable at configured path"
@@ -464,7 +464,7 @@ InModuleScope ScubaLogging {
                 New-Item -ItemType Directory $opaDir -Force | Out-Null
                 Set-Content (Join-Path $opaDir "opa_windows_amd64.exe") "fake" -Encoding UTF8
 
-                Write-ScubaRunDetails -ConfiguredOPAPath $opaDir
+                Write-ScubaRunDetails -ConfiguredOPAPath $opaDir -TestNetworkConnectivity:$false
 
                 $logContent = Get-Content $Script:ScubaLogPath -Raw
                 $logContent | Should -Match "OPA Executable at configured path"
@@ -475,7 +475,7 @@ InModuleScope ScubaLogging {
                 $emptyDir = Join-Path $script:TestLogPath "emptydir-$(Get-Date -Format 'fff')"
                 New-Item -ItemType Directory $emptyDir -Force | Out-Null
 
-                Write-ScubaRunDetails -ConfiguredOPAPath $emptyDir
+                Write-ScubaRunDetails -ConfiguredOPAPath $emptyDir -TestNetworkConnectivity:$false
 
                 $logContent = Get-Content $Script:ScubaLogPath -Raw
                 $logContent | Should -Match "OPA Executable NOT found at configured path"
@@ -486,7 +486,7 @@ InModuleScope ScubaLogging {
             It "Should log Warning 'OPA Executable NOT found at configured path' when path does not exist" {
                 $nonExistent = Join-Path $script:TestLogPath "doesnotexist\opa.exe"
 
-                Write-ScubaRunDetails -ConfiguredOPAPath $nonExistent
+                Write-ScubaRunDetails -ConfiguredOPAPath $nonExistent -TestNetworkConnectivity:$false
 
                 $logContent = Get-Content $Script:ScubaLogPath -Raw
                 $logContent | Should -Match "OPA Executable NOT found at configured path"
@@ -495,7 +495,7 @@ InModuleScope ScubaLogging {
             }
 
             It "Should skip ConfiguredOPAPath check when parameter is not provided" {
-                Write-ScubaRunDetails
+                Write-ScubaRunDetails -TestNetworkConnectivity:$false
 
                 $logContent = Get-Content $Script:ScubaLogPath -Raw
                 $logContent | Should -Not -Match "OPA Executable at configured path"
@@ -516,7 +516,7 @@ InModuleScope ScubaLogging {
 
                 $Script:ScubaHasErrors = $false
                 try {
-                    Write-ScubaRunDetails -ConfiguredOPAPath $customOpaDir
+                    Write-ScubaRunDetails -ConfiguredOPAPath $customOpaDir -TestNetworkConnectivity:$false
                 }
                 finally {
                     $env:USERPROFILE = $originalUserProfile
@@ -537,7 +537,7 @@ InModuleScope ScubaLogging {
                 $env:USERPROFILE = $fakeProfile
 
                 try {
-                    Write-ScubaRunDetails
+                    Write-ScubaRunDetails -TestNetworkConnectivity:$false
                 }
                 finally {
                     $env:USERPROFILE = $originalUserProfile


### PR DESCRIPTION
## 🗣 Description ##

`Write-ScubaRunDetails` collects diagnostic run details, including whether an OPA executable exists in the default `~/.scubagear/Tools` location. Previously, when a user supplied a custom `OPAPath`, the absence of OPA in the *default* location was still logged at `Warning` and trips the automatic error-report generator, an otherwise successful run produced a false "Errors detected" report.

This change pre-resolves whether a custom `OPAPath` was supplied **and** actually contains an OPA binary. When it does, the missing default-location OPA is logged at `Info` instead of `Warning`, so the run is no longer incorrectly flagged as having
errors. When no valid custom `OPAPath` is configured, the genuine `Warning` behavior is preserved.

## 💭 Motivation and context ##

Running ScubaGear with a custom OPA path (e.g. OPA moved to `C:\ScubaOPA`) completed the scan successfully but the log reported a `Warning` for the missing default-location OPA, which in turn generated a error report. This was misleading as nothing had actually failed. 

Closes #2071

## 🧪 Testing ##

Added/updated unit tests in `ScubaLogging.Tests.ps1`:

- New: default-location OPA absence is logged as `Info` (not `Warning`) and `$Script:ScubaHasErrors` remains `$false` when a valid custom `OPAPath` (directory containing an OPA binary) is configured. 
- Updated to network check `-TestNetworkConnectivity:$false` to speed up tests.

Manual verification:
1. Move OPA to `C:\ScubaOPA`, or custom path, and run `Invoke-SCuBA` with that custom `OPAPath`.
2. Create a yaml and specify the `OPAPath` and run `Invoke-SCuBA -ConfigFilePath "<path to customer opa yaml>"`
3. Remove OPA from default or specify wrong path, this should still stop scubagear from running:
4. No false error report should be generated if OPA does exist and correct path.

## 📷 Screenshots (if appropriate) ##

No existing OPA found:
<img width="1159" height="245" alt="image" src="https://github.com/user-attachments/assets/dcb1763b-b097-41d7-b654-2b1064f06a9b" />

## ✅ Pre-approval checklist ##

- [ ] This PR has an informative and human-readable title.
- [ ] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] Changes are sized such that they do not touch excessive number of files.
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [ ] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] All relevant type-of-change labels added.
- [ ] All relevant project fields are set.
- [ ] All relevant repo and/or project documentation updated to reflect these changes.
- [ ] Unit tests added/updated to cover PowerShell and Rego changes.
- [ ] Functional tests added/updated to cover PowerShell and Rego changes.
- [ ] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

- [ ] PR passed smoke test check.
- [ ] PR/feature branch passes functional tests for relevant products, if applicable.
- [ ] Feature branch has been rebased against changes from parent branch, as needed.
- [ ] Resolved all merge conflicts on branch.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge checklist ##

- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
