### PR TITLE
Fix Entra report table anchors

### DIFF
--- a/PowerShell/ScubaGear/Modules/CreateReport/scripts/AADTableFunctions.js
+++ b/PowerShell/ScubaGear/Modules/CreateReport/scripts/AADTableFunctions.js
@@ -305,6 +305,7 @@ const buildExpandableTable = (data, tableType, severityScoreWeights) => {
         const isSortable = tableType === "riskyApps" || tableType === "riskyThirdPartySPs";
         const colNames = metadata.columns;
         const section = document.createElement("section");
+        section.id = tableType;
         section.className = metadata.wrapperClass;
         document.querySelector("main").appendChild(section);
 

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/CreateReport/New-Report.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/CreateReport/New-Report.Tests.ps1
@@ -67,6 +67,8 @@ InModuleScope CreateReport {
                 $ReportContent = Get-Content -Path $ReportPath -Raw
                 $ReportContent | Should -Match '<h2>Users with Privileged Roles</h2>'
                 $ReportContent | Should -Match 'id="privileged-users"'
+                $ReportContent | Should -Match "href='#caps'"
+                $ReportContent | Should -Match 'section\.id = tableType;'
 
                 $PrivilegedUsersTable = [regex]::Match($ReportContent, 'id="privileged-users".*?</table>', 'Singleline').Value
                 $DataRows = [regex]::Matches($PrivilegedUsersTable, '<tr>.*?</tr>', 'Singleline') | Select-Object -Skip 1


### PR DESCRIPTION
## Description

Add IDs to the dynamically generated Entra ID report table sections using their table type. This creates anchor targets for the Conditional Access Policies, risky applications, and risky third-party service principal tables.

Add regression assertions covering the CAP link and generated section-anchor logic.

## Motivation and context

The Entra ID report contains links such as `href="#caps"`, but the dynamically generated table section did not have the corresponding `id`. As a result, selecting the link did not navigate to the table.

Setting each section ID from `tableType` creates the expected `caps`, `riskyApps`, and `riskyThirdPartySPs` anchor targets.

Fixes #1911.

## Testing

- `node --check PowerShell/ScubaGear/Modules/CreateReport/scripts/AADTableFunctions.js` - passed.
- `Invoke-Pester -Path PowerShell/ScubaGear/Testing/Unit/PowerShell/CreateReport/New-Report.Tests.ps1` - 6 passed, 0 failed.
- `. ./utils/workflow/Invoke-PSSA.ps1; Invoke-PSSA -DebuggingMode $false -RepoPath "."` - 0 errors, 0 warnings, 11 informational findings.
- `git diff --check upstream/main...HEAD` - passed.
- `git rev-list --left-right --count upstream/main...HEAD` - 0 behind, 1 ahead.

The repository-wide PowerShell suite was also attempted under Linux with Pester 6: 725 tests passed and 280 failed in unrelated Windows-, Pester 5-, OPA-, or writable-filesystem-dependent areas. The focused report suite passes; the authoritative Windows suite is left to GitHub Actions.

## Pre-approval checklist

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (`main`) for merge.
- [x] Changes are limited to a single goal.
- [x] Changes are limited to two relevant files.
- [x] No future TODOs were introduced.
- [x] These code changes follow the ScubaGear content style guide.
- [x] The related issue is linked using a closing keyword.
- [x] Unit tests were updated to cover the report-generation change.
- [ ] All automated checks have passed.

## Pre-merge checklist

- [ ] PR passed smoke-test checks.
- [x] Feature branch has been rebased against the current parent branch.
- [x] No merge conflicts remain.
- [ ] Squash all commits into one PR-level commit using the `Squash and merge` button.

## Post-merge checklist

- [ ] Feature branch deleted after merge.
- [ ] Confirm issue closure.
- [ ] Verify checks pass on the parent branch after merge.