### PR TITLE
Use WAM-compatible authentication modules

### DIFF
--- a/PowerShell/ScubaGear/Dependencies.ps1
+++ b/PowerShell/ScubaGear/Dependencies.ps1
@@ -15,7 +15,7 @@ param()
 
 try {
     $SupportModulesPath = Join-Path -Path $PSScriptRoot -ChildPath "Modules/Support/Support.psm1"
-    Import-Module -Name $SupportModulesPath
+    Import-Module -Name $SupportModulesPath -Force
 
     # Run version check and display its output
     $null = Test-ScubaGearVersion

--- a/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ExportAADProvider.psm1
@@ -1,4 +1,5 @@
 Import-Module -Name $PSScriptRoot/../Utility/Utility.psm1 -Function Invoke-GraphDirectly, ConvertFrom-GraphHashtable, Invoke-GraphBatchRequest
+Import-Module -Name $PSScriptRoot/../Utility/ScubaLogging.psm1 -Function Trace-ScubaFunction
 
 function Export-AADProvider {
     <#

--- a/PowerShell/ScubaGear/RequiredVersions.ps1
+++ b/PowerShell/ScubaGear/RequiredVersions.ps1
@@ -9,7 +9,7 @@ $ModuleList = @(
     },
     @{
         ModuleName = 'Microsoft.Graph.Authentication'
-        ModuleVersion = [version] '2.38.1'
+        ModuleVersion = [version] '2.30'
         MaximumVersion = [version] '2.38.1'
         Purpose = 'Microsoft Graph API authentication'
         IsPinned = "False"

--- a/PowerShell/ScubaGear/RequiredVersions.ps1
+++ b/PowerShell/ScubaGear/RequiredVersions.ps1
@@ -2,17 +2,17 @@
 $ModuleList = @(
     @{
         ModuleName = 'MicrosoftTeams'
-        ModuleVersion = [version] '4.9.3'
-        MaximumVersion = [version] '7.8.0'
+        ModuleVersion = [version] '7.9.0'
+        MaximumVersion = [version] '7.9.0'
         Purpose = 'Microsoft Teams configuration management'
         IsPinned = "False"
     },
     @{
         ModuleName = 'Microsoft.Graph.Authentication'
-        ModuleVersion = [version] '2.0.0'
-        MaximumVersion = [version] '2.25.0'
+        ModuleVersion = [version] '2.38.1'
+        MaximumVersion = [version] '2.38.1'
         Purpose = 'Microsoft Graph API authentication'
-        IsPinned = "True"
+        IsPinned = "False"
     },
     @{
         ModuleName = 'powershell-yaml'

--- a/docs/prerequisites/dependencies.md
+++ b/docs/prerequisites/dependencies.md
@@ -19,9 +19,9 @@ The following PowerShell modules are required for ScubaGear to function properly
 
 | Module Name                                   | Minimum Version | Maximum Version  | Purpose                                      |
 |:---------------------------------------------:|:---------------:|:----------------:|:---------------------------------------------|
-| MicrosoftTeams |           4.9.3 |            7.8.0 | Microsoft Teams configuration management |
+| MicrosoftTeams |           7.9.0 |            7.9.0 | Microsoft Teams configuration management |
 | ExchangeOnlineManagement |           3.2.0 |            3.9.2 | Exchange Online and Microsoft Defender management |
-| Microsoft.Graph.Authentication |           2.0.0 |           2.25.0 | Microsoft Graph API authentication |
+| Microsoft.Graph.Authentication |            2.30 |           2.38.1 | Microsoft Graph API authentication |
 | powershell-yaml |           0.4.2 |           0.4.12 | YAML file processing and configuration management |
 
 > **Note**: SharePoint and PowerPlatform data are now retrieved via REST API and no longer require Microsoft.Online.SharePoint.PowerShell or PnP.PowerShell modules.


### PR DESCRIPTION
## 🗣 Description

- Remove the use of embedded browser authentication.
- Require MicrosoftTeams 7.9.0 for WAM-compatible Teams authentication.
- Support Microsoft.Graph.Authentication versions 2.30 through 2.38.1 without pinning the dependency.
- Force the support module to reload current dependency metadata.
- Import `Trace-ScubaFunction` directly into the AAD provider so privileged-role and privileged-user collection can log correctly.
- Update the dependency documentation to match the supported versions.

## 💭 Motivation and context

The previous authentication module versions could invoke browser-based interactive authentication and retained stale dependency metadata in an existing PowerShell session. Updating the supported modules enables WAM authentication while preserving delegated and service-principal flows. The AAD provider import also ensures its logging helper is available in production module scope.

Closes #2305.

## 🧪 Testing

- Local focused Pester tests: 30 passed, 0 failed.
- [Functional tests passed](https://github.com/cisagov/ScubaGear/actions/runs/30563907774/job/90949980969).
- [Smoke tests passed](https://github.com/cisagov/ScubaGear/actions/runs/30563907774).
- Manually validated delegated AAD and Teams authentication against a GCC tenant using WAM.

## ✅ Pre-approval checklist

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] All relevant type-of-change labels added.
- [ ] All relevant project fields are set.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [ ] Unit tests added/updated to cover PowerShell and Rego changes.
- [ ] Functional tests added/updated to cover PowerShell and Rego changes.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist

- [x] PR passed smoke test check.
- [x] PR/feature branch passes functional tests for relevant products, if applicable.
- [ ] Feature branch has been rebased against changes from parent branch, as needed.

  Use `Update branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [ ] Resolved all merge conflicts on branch.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge checklist

- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.