### PR TITLE
Surface nested aggregate exception details

### DIFF
--- a/PowerShell/ScubaGear/Modules/Connection/Connection.psm1
+++ b/PowerShell/ScubaGear/Modules/Connection/Connection.psm1
@@ -32,7 +32,7 @@ function Connect-Tenant {
    $ServicePrincipalParams
    )
    Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "ConnectHelpers.psm1")
-   Import-Module -Name $PSScriptRoot/../Utility/Utility.psm1 -Function Invoke-GraphDirectly, ConvertFrom-GraphHashtable
+   Import-Module -Name $PSScriptRoot/../Utility/Utility.psm1 -Function Invoke-GraphDirectly, ConvertFrom-GraphHashtable, Get-FullExceptionDetails
    Import-Module -Name $PSScriptRoot/../Utility/ScubaLogging.psm1 -Function Write-ScubaLog
    Import-Module -Name $PSScriptRoot/../Providers/ProviderHelpers/PowerPlatformRestHelper.psm1 -Function Get-PowerPlatformBaseUrl, Get-PowerPlatformScope
    Import-Module -Name $PSScriptRoot/../Providers/ProviderHelpers/SPORestHelper.psm1 -Function Get-SPOAdminUrl
@@ -395,18 +395,19 @@ function Connect-Tenant {
            }
        }
        catch {
+           $ExceptionDetails = Get-FullExceptionDetails -ErrorRecord $_
            $ErrorDetails = @{
                Product = $Product
-               ErrorMessage = $_.Exception.Message
+               ErrorMessage = $ExceptionDetails.Message
                ErrorType = $_.Exception.GetType().FullName
-               ScriptStackTrace = $_.ScriptStackTrace
+               ScriptStackTrace = $ExceptionDetails.StackTrace
                TargetObject = if ($_.TargetObject) { $_.TargetObject.ToString() } else { "N/A" }
            }
 
            # Log detailed error information for troubleshooting
            Write-ScubaLog -Message "Authentication failed for product: $Product" -Level "Error" -Source "ConnectTenant" -Data $ErrorDetails
 
-           Write-Warning "Error establishing a connection with $($Product): $($_.Exception.Message)`n$($_.ScriptStackTrace)"
+           Write-Warning "Error establishing a connection with $($Product): $($ExceptionDetails.Message)`n$($ExceptionDetails.StackTrace)"
            $ProdAuthFailed += $Product
            Write-Warning "$($Product) will be omitted from the output because of failed authentication"
        }

--- a/PowerShell/ScubaGear/Modules/Providers/ProviderHelpers/CommandTracker.psm1
+++ b/PowerShell/ScubaGear/Modules/Providers/ProviderHelpers/CommandTracker.psm1
@@ -5,7 +5,7 @@ Import-Module -Name $PSScriptRoot/AADHybridExchangeHelper.psm1 -Function Get-Leg
 Import-Module -Name $PSScriptRoot/EXORestHelper.psm1 -Function Invoke-EXORestMethod
 Import-Module -Name $PSScriptRoot/PowerPlatformRestHelper.psm1 -Function Get-PowerPlatformTenantSettingsRest, Get-PowerPlatformEnvironmentsRest, Get-PowerPlatformDlpPoliciesRest, Get-PowerPlatformTenantIsolationRest
 Import-Module -Name $PSScriptRoot/SPORestHelper.psm1 -Function Get-SPOTenantRest
-Import-Module -Name $PSScriptRoot/../../Utility/Utility.psm1 -Function Invoke-GraphDirectly, ConvertFrom-GraphHashtable
+Import-Module -Name $PSScriptRoot/../../Utility/Utility.psm1 -Function Invoke-GraphDirectly, ConvertFrom-GraphHashtable, Get-FullExceptionDetails
 Import-Module -Name $PSScriptRoot/AADAppManagementPolicyHelper.psm1 -Function Get-AppManagementPolicies
 Import-Module -Name $PSScriptRoot/../../Utility/ScubaLogging.psm1 -Function Write-ScubaLog, Trace-ScubaFunction
 
@@ -75,15 +75,16 @@ class CommandTracker {
             $this.SuccessfulCommands += $TrackedCommand
         }
         catch {
+            $ExceptionDetails = Get-FullExceptionDetails -ErrorRecord $_
             if (-not $SuppressWarning) {
-                Write-Warning "Error running $($Command): $($_.Exception.Message)`n$($_.ScriptStackTrace)"
+                Write-Warning "Error running $($Command): $($ExceptionDetails.Message)`n$($ExceptionDetails.StackTrace)"
             }
 
             # We set the log level to Info here because Write-ScubaLog will track Warning or Error as a terminating error.
             Write-ScubaLog -Message "Error running command" -Level "Info" -Source "TryCommand" -Data @{
                 Command = $Command
-                Error   = $_.Exception.Message
-                StackTrace = $_.ScriptStackTrace
+                Error   = $ExceptionDetails.Message
+                StackTrace = $ExceptionDetails.StackTrace
             }
 
             $this.UnSuccessfulCommands += $TrackedCommand

--- a/PowerShell/ScubaGear/Modules/Utility/Utility.psm1
+++ b/PowerShell/ScubaGear/Modules/Utility/Utility.psm1
@@ -1,4 +1,54 @@
 
+function Get-FullExceptionDetails {
+    <#
+    .Description
+    Returns the full message and script stack trace for an error record.
+    Aggregate exception messages include the messages from all nested
+    exceptions.
+    .Functionality
+    Internal
+    .Parameter ErrorRecord
+    The error record to inspect.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [System.Management.Automation.ErrorRecord]
+        $ErrorRecord
+    )
+    process {
+        $Exception = $ErrorRecord.Exception
+        $Messages = @($Exception.Message)
+
+        if ($Exception -is [System.AggregateException]) {
+            $NestedExceptions = [System.Collections.Queue]::new()
+            foreach ($InnerException in $Exception.InnerExceptions) {
+                $NestedExceptions.Enqueue($InnerException)
+            }
+
+            while ($NestedExceptions.Count -gt 0) {
+                $NestedException = $NestedExceptions.Dequeue()
+                $Messages += $NestedException.Message
+
+                if ($NestedException -is [System.AggregateException]) {
+                    foreach ($InnerException in $NestedException.InnerExceptions) {
+                        $NestedExceptions.Enqueue($InnerException)
+                    }
+                }
+                elseif ($null -ne $NestedException.InnerException) {
+                    $NestedExceptions.Enqueue($NestedException.InnerException)
+                }
+            }
+        }
+
+        [PSCustomObject]@{
+            Message    = $Messages -join "`n"
+            StackTrace = $ErrorRecord.ScriptStackTrace
+        }
+    }
+}
+
 function Set-Utf8NoBom {
     <#
     .Description
@@ -782,6 +832,7 @@ function Invoke-ScubaRestMethod {
 }
 
 Export-ModuleMember -Function @(
+    'Get-FullExceptionDetails',
     'Get-Utf8NoBom',
     'Set-Utf8NoBom',
     'Invoke-GraphDirectly',

--- a/PowerShell/ScubaGear/Modules/Utility/Utility.psm1
+++ b/PowerShell/ScubaGear/Modules/Utility/Utility.psm1
@@ -1,4 +1,54 @@
 
+function Get-FullExceptionDetails {
+    <#
+    .Description
+    Returns the full message and script stack trace for an error record.
+    Aggregate exception messages include the messages from all nested
+    exceptions.
+    .Functionality
+    Internal
+    .Parameter ErrorRecord
+    The error record to inspect.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [System.Management.Automation.ErrorRecord]
+        $ErrorRecord
+    )
+    process {
+        $Exception = $ErrorRecord.Exception
+        $Messages = @($Exception.Message)
+
+        if ($Exception -is [System.AggregateException]) {
+            $NestedExceptions = [System.Collections.Queue]::new()
+            foreach ($InnerException in $Exception.InnerExceptions) {
+                $NestedExceptions.Enqueue($InnerException)
+            }
+
+            while ($NestedExceptions.Count -gt 0) {
+                $NestedException = $NestedExceptions.Dequeue()
+                $Messages += $NestedException.Message
+
+                if ($NestedException -is [System.AggregateException]) {
+                    foreach ($InnerException in $NestedException.InnerExceptions) {
+                        $NestedExceptions.Enqueue($InnerException)
+                    }
+                }
+                elseif ($null -ne $NestedException.InnerException) {
+                    $NestedExceptions.Enqueue($NestedException.InnerException)
+                }
+            }
+        }
+
+        [PSCustomObject]@{
+            Message    = $Messages -join "`n"
+            StackTrace = $ErrorRecord.ScriptStackTrace
+        }
+    }
+}
+
 function Set-Utf8NoBom {
     <#
     .Description
@@ -783,6 +833,7 @@ function Invoke-ScubaRestMethod {
 }
 
 Export-ModuleMember -Function @(
+    'Get-FullExceptionDetails',
     'Get-Utf8NoBom',
     'Set-Utf8NoBom',
     'Invoke-GraphDirectly',

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Connection/Connect-Tenant.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Connection/Connect-Tenant.Tests.ps1
@@ -77,6 +77,26 @@ InModuleScope Connection {
 
         }
     }
+
+    Describe -Tag 'Connection' -Name 'Connect-Tenant exception handling' {
+        BeforeAll {
+            function Connect-MicrosoftTeams {throw 'this will be mocked'}
+            Mock Connect-MicrosoftTeams -MockWith {
+                $InnerException = [System.InvalidOperationException]::new('Application does not exist in the tenant')
+                throw [System.AggregateException]::new('One or more errors occurred.', $InnerException)
+            }
+            Mock Write-Progress {}
+        }
+
+        It 'Reports the underlying aggregate exception' {
+            $Output = Connect-Tenant -ProductNames teams -M365Environment commercial 3>&1
+            $Warnings = @($Output | Where-Object { $_ -is [System.Management.Automation.WarningRecord] })
+            $ConnectionWarningLines = $Warnings[0].Message -split '\r?\n'
+
+            $Warnings.Count | Should -Be 2
+            $ConnectionWarningLines | Should -Contain 'Application does not exist in the tenant'
+        }
+    }
 }
 AfterAll {
     Remove-Module Connection -ErrorAction SilentlyContinue

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/CommandTracker.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Providers/CommandTracker.Tests.ps1
@@ -1,0 +1,29 @@
+$CommandTrackerPath = '../../../../Modules/Providers/ProviderHelpers/CommandTracker.psm1'
+Import-Module (Join-Path -Path $PSScriptRoot -ChildPath $CommandTrackerPath) -Function 'Get-CommandTracker' -Force
+
+InModuleScope CommandTracker {
+    Describe -Tag 'Providers' -Name 'CommandTracker exception handling' {
+        BeforeAll {
+            $AggregateFailurePath = Join-Path -Path $TestDrive -ChildPath 'Invoke-AggregateFailure.ps1'
+            @'
+$InnerException = [System.InvalidOperationException]::new('Provider returned invalid response')
+throw [System.AggregateException]::new('One or more errors occurred.', $InnerException)
+'@ | Set-Content -LiteralPath $AggregateFailurePath
+        }
+
+        It 'Reports the underlying aggregate exception' {
+            $Tracker = Get-CommandTracker
+            $Output = & { $Tracker.TryCommand($AggregateFailurePath, @{}, $false) } 3>&1
+            $Warnings = @($Output | Where-Object { $_ -is [System.Management.Automation.WarningRecord] })
+            $WarningLines = $Warnings[0].Message -split '\r?\n'
+
+            $Warnings.Count | Should -Be 1
+            $WarningLines | Should -Contain 'Provider returned invalid response'
+            $Tracker.GetUnSuccessfulCommands() | Should -Contain $AggregateFailurePath
+        }
+    }
+}
+
+AfterAll {
+    Remove-Module CommandTracker -ErrorAction SilentlyContinue
+}

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/Get-FullExceptionDetails.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/Get-FullExceptionDetails.Tests.ps1
@@ -1,0 +1,48 @@
+$UtilityPath = '../../../../Modules/Utility/Utility.psm1'
+Import-Module (Join-Path -Path $PSScriptRoot -ChildPath $UtilityPath) -Function 'Get-FullExceptionDetails' -Force
+
+InModuleScope Utility {
+    Describe -Tag 'Utility' -Name 'Get-FullExceptionDetails' {
+        It 'Returns the original details for a non-aggregate exception' {
+            try {
+                throw [System.InvalidOperationException]::new('Authentication failed')
+            }
+            catch {
+                $Details = Get-FullExceptionDetails -ErrorRecord $_
+            }
+
+            $Details.Message | Should -Be 'Authentication failed'
+            $Details.StackTrace | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Returns every nested aggregate exception message on a separate line' {
+            $FirstException = [System.InvalidOperationException]::new('Application does not exist in the tenant')
+            $NestedException = [System.Exception]::new(
+                'Provider request failed',
+                [System.ArgumentException]::new('Provider returned invalid data')
+            )
+            $AggregateException = [System.AggregateException]::new(
+                'One or more errors occurred.',
+                [System.Exception[]]@($FirstException, $NestedException)
+            )
+
+            try {
+                throw $AggregateException
+            }
+            catch {
+                $Details = Get-FullExceptionDetails -ErrorRecord $_
+            }
+
+            $MessageLines = $Details.Message -split '\r?\n'
+            $MessageLines[0] | Should -Match '^One or more errors occurred\.'
+            $MessageLines | Should -Contain 'Application does not exist in the tenant'
+            $MessageLines | Should -Contain 'Provider request failed'
+            $MessageLines | Should -Contain 'Provider returned invalid data'
+            $Details.StackTrace | Should -Not -BeNullOrEmpty
+        }
+    }
+}
+
+AfterAll {
+    Remove-Module Utility -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## 🗣 Description

- Add `Get-FullExceptionDetails` as a shared utility for preserving every nested `AggregateException` message and the script stack trace.
- Use the shared details in `Connect-Tenant` and `CommandTracker.TryCommand` warnings and structured log data.
- Add regression coverage for Teams authentication, provider commands, non-aggregate exceptions, multiple aggregate branches, and nested inner exceptions.

## 💭 Motivation and context

### Problem

The affected catch blocks only read the top-level `Exception.Message`. When an asynchronous cmdlet throws an `AggregateException`, the actionable provider or authentication error can remain nested, leaving users with a generic diagnostic such as `One or more errors occurred`.

### Root cause

Neither catch block traversed the aggregate exception tree before formatting its console warning or log data.

### Solution

The new utility collects the top-level message, walks all aggregate branches and nested inner exceptions in deterministic breadth-first order, and returns that message set with the existing script stack trace. Non-aggregate exception formatting remains unchanged. The connection and provider paths now share this implementation instead of duplicating exception traversal.

Resolves #2112.

## 🧪 Testing

Environment: macOS 26.6 (arm64), PowerShell 7.6.4, Pester 5.7.1, PSScriptAnalyzer 1.25.0.

- [Fork CI Pipeline](https://github.com/rksharma-owg/ScubaGear/actions/runs/30586001294): passed on commit `93a2f470`; all seven jobs succeeded, including YAML lint, PowerShell lint, Markdown syntax, Gitleaks, Checkov, OPA/Regal, and Windows PowerShell Pester.
- Windows PowerShell Pester: 1,055 passed, 0 failed, 0 skipped, 0 inconclusive, 0 not run.
- Focused and module-order regression set: 65 passed, 0 failed, 0 skipped.
- Changed-file PSScriptAnalyzer: 0 findings.
- Repository-wide PSScriptAnalyzer: 195 files; 0 errors, 0 warnings, 8 pre-existing informational findings.
- `git diff --check`: passed.
- Manual reproduction: the nested Teams authentication message is now emitted as its own warning line while preserving the aggregate summary and stack trace.

The unmodified baseline full suite on this macOS host produced 757 passed and 281 platform-only failures (Windows drive/UNC paths, `Resolve-DnsName`, Windows principals/XAML, and local OPA/tool paths). The repository's Windows CI completed the full suite successfully. The checks attached directly to this first-time contributor PR remain behind GitHub's maintainer-approval gate.

## Risk

- Compatibility and control-flow risk are low: command success/failure handling and return values are unchanged.
- Aggregate failures will expose more vendor-provided diagnostic text in the existing console and log channels. Existing log redaction remains in place.
- No dependencies, external calls, telemetry, or persistent data formats are added.

## ✅ Pre-approval checklist

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (`main`) for merge.
- [x] Changes are limited to a single goal.
- [x] Changes are sized such that they do not touch an excessive number of files.
- [x] No future TODOs are introduced.
- [x] These code changes follow the ScubaGear content style guide.
- [x] The related issue is linked with a closing keyword.
- [x] Unit tests cover the PowerShell changes.
- [x] All automated checks passed.

## ✅ Pre-merge checklist

- [ ] PR passed smoke test check.
- [ ] Feature branch passes functional tests for relevant products, if applicable.
- [ ] Feature branch has been rebased against changes from the parent branch, as needed.
- [ ] Resolved all merge conflicts on branch.
- [ ] Squash all commits into one PR-level commit using the **Squash and merge** button.

## ✅ Post-merge checklist

- [ ] Feature branch deleted after merge.
- [ ] Close issues resolved by this PR if the closing keyword did not activate.
- [ ] Verified that all checks pass on the parent branch after merge.
