### PR TITLE
fixed ScubaConfigApp migration issue if errors found

### DIFF
--- a/PowerShell/ScubaGear/Modules/ScubaConfigApp/ScubaConfigAppHelpers/ScubaConfigAppDynamicCardHelper.psm1
+++ b/PowerShell/ScubaGear/Modules/ScubaConfigApp/ScubaConfigAppHelpers/ScubaConfigAppDynamicCardHelper.psm1
@@ -1226,21 +1226,26 @@ Function New-FieldListCard {
     $removeButton.Visibility = "Collapsed"
 
     # Baseline Policy Viewer button
-    $baselinePolicyButton = New-Object System.Windows.Controls.Button
-    $baselinePolicyButton.Content = "View Baseline Policies"
-    $baselinePolicyButton.Name = ($PolicyId.replace('.', '_') + "_" + $CardName + "_BaselinePolicyButton")
-    $baselinePolicyButton.Style = $syncHash.Window.FindResource("PrimaryButton")
-    $baselinePolicyButton.Width = 140
-    $baselinePolicyButton.Height = 28
-    $baselinePolicyButton.Margin = "0,0,10,0"
-    $baselinePolicyButton.Background = [System.Windows.Media.Brushes]::DarkBlue
-    $baselinePolicyButton.Foreground = [System.Windows.Media.Brushes]::White
-    $baselinePolicyButton.BorderThickness = "0"
-    $baselinePolicyButton.FontWeight = "SemiBold"
-    $baselinePolicyButton.Cursor = [System.Windows.Input.Cursors]::Hand
+    # Skipped for Global Settings (-OutPolicyOnly): those cards are not tied to a
+    # baseline policy, so the baseline viewer has nothing to navigate to.
+    $baselinePolicyButton = $null
+    if (-not $OutPolicyOnly) {
+        $baselinePolicyButton = New-Object System.Windows.Controls.Button
+        $baselinePolicyButton.Content = "View Baseline Policies"
+        $baselinePolicyButton.Name = ($PolicyId.replace('.', '_') + "_" + $CardName + "_BaselinePolicyButton")
+        $baselinePolicyButton.Style = $syncHash.Window.FindResource("PrimaryButton")
+        $baselinePolicyButton.Width = 140
+        $baselinePolicyButton.Height = 28
+        $baselinePolicyButton.Margin = "0,0,10,0"
+        $baselinePolicyButton.Background = [System.Windows.Media.Brushes]::DarkBlue
+        $baselinePolicyButton.Foreground = [System.Windows.Media.Brushes]::White
+        $baselinePolicyButton.BorderThickness = "0"
+        $baselinePolicyButton.FontWeight = "SemiBold"
+        $baselinePolicyButton.Cursor = [System.Windows.Input.Cursors]::Hand
+    }
 
     [void]$buttonPanel.Children.Add($saveButton)
-    [void]$buttonPanel.Children.Add($baselinePolicyButton)
+    if ($baselinePolicyButton) { [void]$buttonPanel.Children.Add($baselinePolicyButton) }
     [void]$buttonPanel.Children.Add($removeButton)
 
     # Dismiss Review button — only shown on migration-pending cards
@@ -1503,7 +1508,7 @@ Function New-FieldListCard {
     Add-UIControlEventHandler -Control $saveButton
     Add-UIControlEventHandler -Control $removeButton
     <##>
-    Add-UIControlEventHandler -Control $baselinePolicyButton
+    if ($baselinePolicyButton) { Add-UIControlEventHandler -Control $baselinePolicyButton }
 
     # Dismiss Review button click handler — removes migrated data and clears pending state
     if ($dismissButton) {
@@ -1557,15 +1562,17 @@ Function New-FieldListCard {
     }
 
     # Create click event for baseline policy viewer button
-    $baselinePolicyButton.Add_Click({
-        try {
-            # Use the main baseline viewer function with navigation parameter via syncHash
-            & $syncHash.ShowBaselinePolicyViewer -NavigateToPolicyId $PolicyId
-        } catch {
-            Write-DebugOutput -Message "Error opening baseline policy viewer: $($_.Exception.Message)" -Source $MyInvocation.MyCommand -Level "Error"
-            $syncHash.ShowMessageBox.Invoke("Error opening baseline policies: $($_.Exception.Message)", "Error", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Error)
-        }
-    }.GetNewClosure())
+    if ($baselinePolicyButton) {
+        $baselinePolicyButton.Add_Click({
+            try {
+                # Use the main baseline viewer function with navigation parameter via syncHash
+                & $syncHash.ShowBaselinePolicyViewer -NavigateToPolicyId $PolicyId
+            } catch {
+                Write-DebugOutput -Message "Error opening baseline policy viewer: $($_.Exception.Message)" -Source $MyInvocation.MyCommand -Level "Error"
+                $syncHash.ShowMessageBox.Invoke("Error opening baseline policies: $($_.Exception.Message)", "Error", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Error)
+            }
+        }.GetNewClosure())
+    }
 
     # Create click event for save button
     $saveButton.Add_Click({

--- a/PowerShell/ScubaGear/Modules/ScubaConfigApp/ScubaConfigAppHelpers/ScubaConfigAppGraphHelper.psm1
+++ b/PowerShell/ScubaGear/Modules/ScubaConfigApp/ScubaConfigAppHelpers/ScubaConfigAppGraphHelper.psm1
@@ -110,10 +110,11 @@ Function Invoke-GraphQueryWithFilter {
         [string]$QueryType,
         $GraphConfig,
         [string]$FilterString,
+        [string]$SearchString,
         [int]$Top = 999
     )
 
-    Write-DebugOutput "Starting Graph query - Type: $QueryType, Filter: $FilterString, Top: $Top" -Source "Invoke-GraphQueryWithFilter" -Level "Debug"
+    Write-DebugOutput "Starting Graph query - Type: $QueryType, Filter: $FilterString, Search: $SearchString, Top: $Top" -Source "Invoke-GraphQueryWithFilter" -Level "Debug"
 
     # Create runspace
     $runspace = [runspacefactory]::CreateRunspace()
@@ -127,7 +128,7 @@ Function Invoke-GraphQueryWithFilter {
 
     # Add script block
     $scriptBlock = {
-        param($QueryType, $GraphConfig, $FilterString, $Top)
+        param($QueryType, $GraphConfig, $FilterString, $SearchString, $Top)
 
         try {
             # Get query configuration
@@ -157,8 +158,22 @@ Function Invoke-GraphQueryWithFilter {
                 $queryStringParts += "`$filter=$FilterString"
             }
 
+            # Add $search if provided (portal-style "contains" matching). This
+            # requires an advanced query: ConsistencyLevel eventual + $count=true.
+            $useAdvancedQuery = $false
+            if (![string]::IsNullOrWhiteSpace($SearchString)) {
+                $queryStringParts += "`$search=" + [uri]::EscapeDataString($SearchString)
+                $useAdvancedQuery = $true
+            }
+
             # Add top parameter
             $queryStringParts += "`$top=$Top"
+
+            # Advanced queries must request a count and use eventual consistency.
+            if ($useAdvancedQuery) {
+                $queryStringParts += "`$count=true"
+                $queryParams.Headers = @{ ConsistencyLevel = 'eventual' }
+            }
 
             # Combine query string
             if ($queryStringParts.Count -gt 0) {
@@ -191,7 +206,7 @@ Function Invoke-GraphQueryWithFilter {
     }
 
     # Add parameters and start execution
-    $powershell.AddScript($scriptBlock).AddParameter("QueryType", $QueryType).AddParameter("GraphConfig", $GraphConfig).AddParameter("FilterString", $FilterString).AddParameter("Top", $Top)
+    $powershell.AddScript($scriptBlock).AddParameter("QueryType", $QueryType).AddParameter("GraphConfig", $GraphConfig).AddParameter("FilterString", $FilterString).AddParameter("SearchString", $SearchString).AddParameter("Top", $Top)
     $asyncResult = $powershell.BeginInvoke()
 
     return @{
@@ -292,10 +307,20 @@ Function Show-GraphProgressWindow {
             Write-DebugOutput -Message "Unsupported graph entity type: $GraphEntityType" -Source $MyInvocation.MyCommand -Level "Error"
         }
 
-        # Build filter string
+        # Build the query. A full object id (GUID) is matched exactly; any other
+        # text uses Graph $search for portal-style "contains" matching on the
+        # configured property (e.g. displayName) instead of a prefix-only filter.
         $filterString = $null
+        $searchString = $null
         if (![string]::IsNullOrWhiteSpace($SearchTerm)) {
-            $filterString = "startswith($($config.FilterProperty),'$SearchTerm')"
+            $trimmedTerm = $SearchTerm.Trim()
+            $parsedGuid = [guid]::Empty
+            if ([guid]::TryParse($trimmedTerm, [ref]$parsedGuid)) {
+                $filterString = "id eq '$($parsedGuid.ToString())'"
+            } else {
+                $escapedTerm = $trimmedTerm -replace '"', ''
+                $searchString = '"{0}:{1}"' -f $config.FilterProperty, $escapedTerm
+            }
         }
 
         # Show progress window
@@ -327,11 +352,13 @@ Function Show-GraphProgressWindow {
         $progressWindow.Content = $progressPanel
 
         # Start async operation
-        Write-DebugOutput -Message "Starting async operation for graph query type: $($config.QueryType) with filter: $filterString" -Source $MyInvocation.MyCommand -Level "Verbose"
+        Write-DebugOutput -Message "Starting async operation for graph query type: $($config.QueryType) with filter: [$filterString] search: [$searchString]" -Source $MyInvocation.MyCommand -Level "Verbose"
         $asyncOp = Invoke-GraphQueryWithFilter `
                         -QueryType $config.QueryType `
                         -GraphConfig $syncHash.UIConfigs.graphQueries `
-                        -FilterString $filterString -Top $Top
+                        -FilterString $filterString `
+                        -SearchString $searchString `
+                        -Top $Top
 
         # Show progress window
         $progressWindow.Show()

--- a/PowerShell/ScubaGear/Modules/ScubaConfigApp/ScubaConfigAppHelpers/ScubaConfigAppImportHelper.psm1
+++ b/PowerShell/ScubaGear/Modules/ScubaConfigApp/ScubaConfigAppHelpers/ScubaConfigAppImportHelper.psm1
@@ -805,6 +805,8 @@ Function Invoke-PolicyMigration {
         if ($policiesToMigrate.Count -eq 0) { continue }
 
         foreach ($oldPolicyId in $policiesToMigrate) {
+            # Isolate each policy so a failure on one does not abort migration of the rest.
+            try {
             $entry = $migrationMap[$oldPolicyId]
 
             if (-not $entry.newPolicyId -or -not $entry.newProduct) {
@@ -846,6 +848,14 @@ Function Invoke-PolicyMigration {
                 Write-DebugOutput -Message "Migration skipped - target already configured: [$newProductKey][$newPolicyId]" -Source $MyInvocation.MyCommand -Level "Warning"
             }
             $productData.Remove($oldPolicyId)
+            }
+            catch {
+                # Leave the offending policy in place and keep migrating the others.
+                [void]$syncHash.MigrationLog.Add(
+                    "$pfxDropped exclusion [$productKey][$oldPolicyId] - migration error, left in place: $($_.Exception.Message)")
+                Write-DebugOutput -Message "Error migrating exclusion [$productKey][$oldPolicyId]; skipping this policy and continuing: $($_.Exception.Message)" -Source $MyInvocation.MyCommand -Level "Error"
+                continue
+            }
         }
 
         # Remove the old product key if it is now empty (e.g., an old Defender section)
@@ -872,6 +882,8 @@ Function Invoke-PolicyMigration {
         $policiesToMigrate = @($controlData.Keys) | Where-Object { $migrationMap.ContainsKey($_) }
 
         foreach ($oldPolicyId in $policiesToMigrate) {
+            # Isolate each policy so a failure on one does not abort migration of the rest.
+            try {
             $entry = $migrationMap[$oldPolicyId]
 
             if (-not $entry.newPolicyId) {
@@ -905,6 +917,14 @@ Function Invoke-PolicyMigration {
                 Write-DebugOutput -Message "Migration skipped - ${yamlValue} target exists: [$newPolicyId]" -Source $MyInvocation.MyCommand -Level "Warning"
             }
             $controlData.Remove($oldPolicyId)
+            }
+            catch {
+                # Leave the offending policy in place and keep migrating the others.
+                [void]$syncHash.MigrationLog.Add(
+                    "$pfxDropped $yamlValue [$oldPolicyId] - migration error, left in place: $($_.Exception.Message)")
+                Write-DebugOutput -Message "Error migrating ${yamlValue} [$oldPolicyId]; skipping this policy and continuing: $($_.Exception.Message)" -Source $MyInvocation.MyCommand -Level "Error"
+                continue
+            }
         }
     }
 

--- a/PowerShell/ScubaGear/Modules/ScubaConfigApp/ScubaConfigAppHelpers/ScubaConfigAppResultsHelper.psm1
+++ b/PowerShell/ScubaGear/Modules/ScubaConfigApp/ScubaConfigAppHelpers/ScubaConfigAppResultsHelper.psm1
@@ -419,7 +419,11 @@ Function New-ResultsReportTab {
 
     # Load content immediately instead of lazy loading
     try {
-        if (Test-Path $Report.JsonResultsPath) {
+        # Guard against an empty/missing JSON path - a report folder can match the
+        # folder-name pattern yet contain no ScubaResults JSON (e.g. an interrupted
+        # or partial run). Passing an empty string to Test-Path throws a parameter
+        # binding error, so check for content before probing the filesystem.
+        if (-not [string]::IsNullOrWhiteSpace($Report.JsonResultsPath) -and (Test-Path $Report.JsonResultsPath)) {
             $jsonContent = Get-Content $Report.JsonResultsPath -Raw
             $scubaData = $jsonContent | ConvertFrom-Json
 
@@ -435,7 +439,12 @@ Function New-ResultsReportTab {
                 $newTab.Content = $errorTab
             }
         } else {
-            $errorTab = New-ResultsNoDataTab -ReportPath $Report.ReportPath -Message "JSON file not found: $($Report.JsonResultsPath)"
+            $missingJsonMessage = if ([string]::IsNullOrWhiteSpace($Report.JsonResultsPath)) {
+                "No ScubaResults JSON file was found in this report folder:`n`n$($Report.ReportPath)`n`nThis folder may be from an interrupted or incomplete scan."
+            } else {
+                "JSON file not found: $($Report.JsonResultsPath)"
+            }
+            $errorTab = New-ResultsNoDataTab -ReportPath $Report.ReportPath -Message $missingJsonMessage
             $newTab.Content = $errorTab
         }
     } catch {


### PR DESCRIPTION
## 🗣 Description ##
Fixes the ScubaConfig auto-migration bug and includes three related reliability/UX fixes in the ScubaConfig app that were found while investigating it:
 - Config migration is now resilient: when an imported config is auto-migrated to newer policy IDs, a problem with one policy no longer stops the others from migrating.
 - Online group/user lookup actually finds things: the "Get Groups/Users" picker now matches by name substring or by Object ID, not just by the start of the name.
- Results tab no longer errors on empty report folders: a leftover/incomplete report folder no longer produces a Test-Path error on launch.
- Global Settings cards are cleaner. the "View Baseline Policies" button is removed from Global Settings (e.g., Preferred DNS), where it had nothing to show.

Resolves #2291 
## 💭 Motivation and context ##

**Auto-migration bug** : Legacy configs are auto-migrated to current policy IDs on import. All policies were migrated in one shared pass, so if a single policy hit an error the entire migration aborted and the remaining policies silently failed to migrate. Migration now processes each policy independently, a failure is logged and skipped, and every other policy still migrates. The failing entry is left in place rather than lost.

**Online search**: In online mode, the group/user picker only did a "starts-with" match on the display name. Searching by a word in the middle of a name (e.g., "break glass") or by a group's Object ID returned nothing, which was confusing. It now matches a pasted Object ID, and otherwise does a portal-style "contains" search on the name.

**Results tab error:** The Results tab auto-scans common output locations for report folders. When a matching folder had no results JSON in it (an interrupted or partial run), an empty path was handed to a file check, throwing an error on every launch. Empty/missing paths are now handled gracefully with a clear "no results file found" message.

**Global Settings button**: Global Settings entries aren't tied to a baseline policy, so the "View Baseline Policies" button only opened the viewer with nothing relevant to show. It's now hidden for Global Settings cards while remaining on all real policy cards.

## 🧪 Testing ##

Environment: Windows + PowerShell 5.1 or 7, ScubaGear built from this branch. Launch with `Start-SCuBAConfigApp -online` and connect Graph to a test tenant for the search test.

Sample yaml that would fail otherwise:
```yaml
# ScubaGear Configuration File - MIGRATION "SKIP ON ERROR" TEST
# Generated for verifying that one policy failing to migrate does NOT stop the others.

Organization: example.com
OrgName: DTO
OrgUnitName: LAB
Description: Migration skip-on-error test
ProductNames: ['aad','defender','exo']
M365Environment: commercial

#  Baseline Control: Exclusions
Aad:
  # Migrates fine: MS.AAD.3.2v1 -> MS.AAD.3.2v2
  MS.AAD.3.2v1:
    CapExclusions:
      Groups:
        - b2fbcd92-095e-4cc6-8bdd-0547399b97d1

Defender:
  # FAILS to migrate (target SecuritySuite is a string) -> skipped, left in place
  MS.DEFENDER.2.1v1:
    SensitiveUsers:
      - TestUser;testuser@example.com

#  Baseline Control: Annotations
AnnotatePolicy:
  # Migrates fine: MS.EXO.2.2v2 -> MS.EXO.2.2v3
  MS.EXO.2.2v2:
    Comment: "Testing migration resilience"
    RemediationDate: "2026-12-31"
    IncorrectResult: false

```

1. Migration resilience:
  - Import a legacy YAML config that uses old policy IDs subject to auto-migration (e.g., an MS.DEFENDER.2.1v1 exclusion config). 
  - Confirm all migratable policies appear in the migration review, and the debug log records any skipped policy instead of the import aborting.
 
2. Online group/user search
  - On a policy with a group exclusion field, click Get Groups.
  - Search a mid-name word (e.g., break glass); matching groups appear (previously returned nothing).
  - Paste a full group Object ID (GUID); the exact group is returned.
  - Search a name prefix still works as before.

4. Results tab guard
  - In your Documents (or configured OutPath), create an empty BaselineReports_<timestamp> folder with no ScubaResults*.json inside.
  - Launch the app / open the Results tab. Confirm $app.error has no Test-Path binding error and the folder shows a clean "no results JSON found" tab.
  - Confirm valid report folders still load and render normally.

5. Global Settings button
  - Go to Global Settings > Preferred DNS Resolvers, add an entry. Confirm the card shows only Save/Remove and no `View Baseline Policies` button.
  - Open a product policy card (e.g., an AAD exclusion) and confirm View Baseline Policies is still present and opens the baseline viewer

## 📷 Screenshots (if appropriate) ##

<img width="1582" height="1113" alt="image" src="https://github.com/user-attachments/assets/2a49a8fe-08d6-4601-b7c1-61e46101f618" />

<img width="1580" height="1115" alt="image" src="https://github.com/user-attachments/assets/08beb749-1eb3-4e46-92a0-87b38bb609d8" />

<img width="1211" height="700" alt="image" src="https://github.com/user-attachments/assets/de9b10de-01f8-481f-8f94-70cbba2a782f" />

<img width="827" height="909" alt="image" src="https://github.com/user-attachments/assets/e8bfa705-bba3-4c42-85c2-cc3404cb6623" />

<img width="1583" height="1118" alt="image" src="https://github.com/user-attachments/assets/74b80399-bce1-42a7-bb45-4e994a55f1e9" />


## ✅ Pre-approval checklist ##

- [ ] This PR has an informative and human-readable title.
- [ ] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] Changes are sized such that they do not touch excessive number of files.
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [ ] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] All relevant type-of-change labels added.
- [ ] All relevant project fields are set.
- [ ] All relevant repo and/or project documentation updated to reflect these changes.
- [ ] Unit tests added/updated to cover PowerShell and Rego changes.
- [ ] Functional tests added/updated to cover PowerShell and Rego changes.
- [ ] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

- [ ] PR passed smoke test check.
- [ ] PR/feature branch passes functional tests for relevant products, if applicable.
- [ ] Feature branch has been rebased against changes from parent branch, as needed.
- [ ] Resolved all merge conflicts on branch.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge checklist ##

- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
