### PR TITLE
functional test fix: update .net unresolved path

### DIFF
--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -503,6 +503,8 @@ function Invoke-SCuBA {
         $OutFolderPath = $ScubaConfig.OutPath
         $FolderName = "$($ScubaConfig.OutFolderName)_$($FormattedTimeStamp)"
         $OutFolderPath = Join-Path -Path $OutFolderPath -ChildPath $FolderName -ErrorAction 'Stop'
+        # .NET file APIs resolve relative paths against the process cwd, not $PWD; absolutize first.
+        $OutFolderPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($OutFolderPath)
         # New-Item has no -LiteralPath; use .NET so output paths with wildcard chars (e.g. []) are created literally.
         [System.IO.Directory]::CreateDirectory($OutFolderPath) | Out-Null
 
@@ -1633,6 +1635,8 @@ function Invoke-ReportCreation {
             $Len = $ScubaConfig.ProductNames.Length
             $Fragment = @()
             $IndividualReportPath = Join-Path -Path $OutFolderPath -ChildPath $IndividualReportFolderName
+            # .NET file APIs resolve relative paths against the process cwd, not $PWD; absolutize first.
+            $IndividualReportPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($IndividualReportPath)
             # New-Item has no -LiteralPath; use .NET so paths with wildcard chars (e.g. []) are created literally.
             [System.IO.Directory]::CreateDirectory($IndividualReportPath) | Out-Null
 
@@ -2339,6 +2343,8 @@ function Invoke-SCuBACached {
             # Create outpath if $Outpath does not exist
             if(-not (Test-Path -LiteralPath $OutPath -PathType "container"))
             {
+                # .NET file APIs resolve relative paths against the process cwd, not $PWD; absolutize first.
+                $OutPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($OutPath)
                 # New-Item has no -LiteralPath; use .NET so paths with wildcard chars (e.g. []) are created literally.
                 [System.IO.Directory]::CreateDirectory($OutPath) | Out-Null
             }

--- a/PowerShell/ScubaGear/Modules/Utility/ScubaLogging.psm1
+++ b/PowerShell/ScubaGear/Modules/Utility/ScubaLogging.psm1
@@ -93,6 +93,8 @@ function Initialize-ScubaLogging {
         if ($LogPath) {
             # Create the log directory if it doesn't exist
             if (!(Test-Path -LiteralPath $LogPath)) {
+                # .NET file APIs resolve relative paths against the process cwd, not $PWD; absolutize first.
+                $LogPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($LogPath)
                 # New-Item has no -LiteralPath; use .NET so paths with wildcard chars (e.g. []) are created literally.
                 [System.IO.Directory]::CreateDirectory($LogPath) | Out-Null
             }


### PR DESCRIPTION

## 🗣 Description ##

Fixes the failing Functional Tests. ScubaGear was creating its output/log folders using a .NET call that measures relative paths from a different "current folder" than the rest of the code uses. In runner those two folders don't match, so ScubaGear created the results folder in one spot but then looked for it in another causing it to fail. The fix makes the path fully absolute before creating the folder, so both agree.

## 💭 Motivation and context ##

Introduced by #2236. Only shows up in the Functional Tests environment, which is why unit tests and PR checks passed but the scheduled run failed.

## 🧪 Testing ##

- Run the affected unit tests: ensure all pass 
- Trigger the Functional Tests against this branch: ensure all pass.

## ✅ Pre-approval checklist ##


- [ ] This PR has an informative and human-readable title.
- [ ] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] Changes are sized such that they do not touch excessive number of files.
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] These code changes follow the ScubaGear [content style guide](https://github.com/cisagov/ScubaGear/blob/main/CONTENTSTYLEGUIDE.md).
- [ ] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] All relevant type-of-change labels added.
- [ ] All relevant project fields are set.
- [ ] All relevant repo and/or project documentation updated to reflect these changes.
- [ ] Unit tests added/updated to cover PowerShell and Rego changes.
- [ ] Functional tests added/updated to cover PowerShell and Rego changes.
- [ ] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Pre-merge checklist ##

- [ ] PR passed smoke test check.
- [ ] PR/feature branch passes functional tests for relevant products, if applicable.
- [ ] Feature branch has been rebased against changes from parent branch, as needed.

  Use `Update branch` button below or use [this](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request) reference to rebase from the command line.
- [ ] Resolved all merge conflicts on branch.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge checklist ##

- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
