### PR TITLE
Fix dark mode default never applying in HTML reports

### DIFF
--- a/PowerShell/ScubaGear/Modules/CreateReport/scripts/IndividualReport.js
+++ b/PowerShell/ScubaGear/Modules/CreateReport/scripts/IndividualReport.js
@@ -1,7 +1,7 @@
 window.addEventListener('DOMContentLoaded', () => {
     const MAX_DNS_ENTRIES = 20;
 
-    const darkMode = getJsonData('dark-mode-flag') === "true";
+    const darkMode = getJsonData('dark-mode-flag') === true;
     const caps = getJsonData('cap-json');
     const riskyApps = getJsonData('risky-apps-json');
     const riskyThirdPartySPs = getJsonData('risky-third-party-sp-json');

--- a/PowerShell/ScubaGear/Modules/CreateReport/scripts/ParentReport.js
+++ b/PowerShell/ScubaGear/Modules/CreateReport/scripts/ParentReport.js
@@ -1,5 +1,5 @@
 window.addEventListener('DOMContentLoaded', () => {
-    const darkMode = getJsonData('dark-mode-flag') === "true";
+    const darkMode = getJsonData('dark-mode-flag') === true;
 
     applyScopeAttributes();
     mountDarkMode(darkMode, "Parent Report");


### PR DESCRIPTION
Fixes the report **DarkMode** default never taking effect.

## Root cause

`CreateReport.psm1` emits the default dark mode state as an **unquoted** boolean:

```powershell
"<script type='application/json' id='dark-mode-flag'> $($DarkMode.ToString().ToLower()) </script>"
```

so the script element contains ` true ` / ` false ` (not `"true"`). `getJsonData()` runs `JSON.parse(...)` on that, returning a JavaScript **boolean**. But `IndividualReport.js` and `ParentReport.js` compared it to the **string** `"true"`:

```js
const darkMode = getJsonData('dark-mode-flag') === "true";
```

`true === "true"` is always `false`, so generating a report with DarkMode enabled produced a report whose initial state was still light mode.

```
JSON.parse(" true ")            -> true      (boolean)
true === "true"  // old  -> false   (dark mode never applies)
true === true    // new  -> true
```

## Fix

Compare against the boolean `true` in both report scripts:

- `IndividualReport.js`
- `ParentReport.js`

Two-character change, one line each; no other behavior affected. (Separate from #2258 — that PR touches `Utils.js`/`CreateReport.psm1`, not these two files.)

## Testing

Verified the parse/compare behavior directly (`JSON.parse(" true ")` is the boolean `true`, so `=== "true"` is always false and `=== true` is correct). Happy to attach a before/after screenshot of a report generated with `-DarkMode` if useful.