### PR TITLE
fix(logging): restore provider trace output after repeated runs

### DIFF
--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -2065,6 +2065,10 @@ function Remove-Resources {
         Remove-Module $Provider -ErrorAction "SilentlyContinue"
     }
 
+    # CommandTracker imports ScubaLogging functions into its module scope. It must
+    # be unloaded before the logging module is reloaded or providers keep stale
+    # function references on subsequent Invoke-SCuBA calls in the same session.
+    Remove-Module "CommandTracker" -ErrorAction "SilentlyContinue"
     Remove-Module "ScubaConfig" -ErrorAction "SilentlyContinue"
     Remove-Module "RunRego" -ErrorAction "SilentlyContinue"
     Remove-Module "CreateReport" -ErrorAction "SilentlyContinue"

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Remove-Resources.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Remove-Resources.Tests.ps1
@@ -6,6 +6,16 @@ Describe -Tag 'Orchestrator' -Name 'Remove-Resources' {
         It 'Removes all helper modules with no errors' {
             {Remove-Resources} | Should -Not -Throw
         }
+
+        It 'Removes CommandTracker so providers do not retain stale logging references' {
+            $CommandTrackerPath = Join-Path -Path $PSScriptRoot -ChildPath '../../../../Modules/Providers/ProviderHelpers/CommandTracker.psm1'
+            Import-Module $CommandTrackerPath -Force
+            Get-Module -Name 'CommandTracker' | Should -Not -BeNullOrEmpty
+
+            Remove-Resources
+
+            Get-Module -Name 'CommandTracker' | Should -BeNullOrEmpty
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #2350.

- Unload `CommandTracker` during `Remove-Resources` cleanup.
- Prevent provider modules from retaining stale `ScubaLogging` function references after a second `Invoke-SCuBA` call in the same PowerShell session.
- Add a regression test that verifies the helper module is removed during cleanup.

## Validation

- `git diff --check`
- Focused PowerShell verification passed: `CommandTracker` is loaded, `Remove-Resources` runs, and the helper is no longer loaded.
- The repository's Pester tests could not run locally because the machine has Pester 3.4.0 while this test suite uses Pester 5 operators; the existing test file fails at its pre-existing `Should -Not` assertions under Pester 3.4.0.
