### PR TITLE
Clarify MS.SHAREPOINT.1.3v1 note: domain/security-group restriction applies to new external users, not existing guests

### DIFF
--- a/PowerShell/ScubaGear/baselines/sharepoint.md
+++ b/PowerShell/ScubaGear/baselines/sharepoint.md
@@ -73,7 +73,7 @@ External sharing SHALL be restricted to approved external domains and/or users i
 <!--Policy: MS.SHAREPOINT.1.3v1; Criticality: SHALL -->
 - _Rationale:_ By limiting sharing to domains or approved security groups used for interagency collaboration purposes, administrators can help prevent sharing with unknown organizations and individuals.
 - _Last modified:_ March 2025
-- _Note:_ This policy is only applicable if the external sharing slider in the SharePoint admin center is not set to **Only people in your organization**.
+- _Note:_ This policy is only applicable if the external sharing slider in the SharePoint admin center is not set to **Only people in your organization**. The approved-domain and approved-security-group restrictions apply only when sharing with **new** external users; they do **not** apply to **existing guests**, who are already present in the directory and are treated as approved. Sharing with an existing guest succeeds regardless of these settings.
 - _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-3, AC-6(10)
 - _MITRE ATT&CK TTP Mapping:_
   - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)


### PR DESCRIPTION
Closes #2382.

## Summary
Clarifies the `_Note_` on **MS.SHAREPOINT.1.3v1**. The existing note only states the policy applies when the external-sharing slider is not set to *Only people in your organization*. It does not capture a second, important limitation: the **approved-domain** and **approved-security-group** restrictions are enforced when sharing with **new** external users, but they do **not** apply to **existing guests** already present in the directory. Existing guests are resolved as already-approved users, so sharing with them succeeds regardless of the domain/security-group allow lists.

## Why
Without this clarification, an assessor may over-credit the approved-domain/security-group restriction as protection against *all* external sharing, when in practice it only gates *new* external identities. This aligns the note with observed tenant behavior.

## Evidence
Verified across an external-sharing test matrix (Entra "who can invite" x SharePoint external-sharing slider x domain allow/deny): sharing with an **existing guest** succeeds even when the counterpart domain is outside the approved list, while **new** external users are subject to the domain/security-group check. Related discussion: #1687 and #2077.

## Change type
Documentation / baseline note clarification only. No Rego or logic change.

## Note
This replaces #2380 (opened from a personal fork). This PR comes from an in-repo branch so functional tests can run against it.
