### PR TITLE
Fix MS.SECURITYSUITE.5.2v1 false Pass when a higher-priority retention policy is non-compliant

### DIFF
--- a/PowerShell/ScubaGear/Rego/SecuritySuiteConfig.rego
+++ b/PowerShell/ScubaGear/Rego/SecuritySuiteConfig.rego
@@ -842,6 +842,16 @@ AdvancedAuditingLicenses contains ServicePlan.ServicePlanId if {
     ServicePlan.ServicePlanName == "M365_ADVANCED_AUDITING"
 }
 
+# Enabled retention policies that supply a numeric Priority value. Per the
+# Microsoft Purview documentation, a lower numeric Priority value indicates a
+# higher precedence, so the smallest Priority value supersedes all others.
+# See issue #2374.
+EnabledPrioritizedRetentionPolicies contains Policy if {
+    some Policy in input.unified_audit_log_retention_policies
+    not Policy.Enabled == false
+    is_number(Policy.Priority)
+}
+
 # Save audit log retention policies that retain logs for at least 12 months
 # and are not disabled.
 CompliantRetentionPolicies contains {
@@ -860,10 +870,41 @@ CompliantRetentionPolicies contains {
 # Get-MgBetaSubscribedSku is intentionally omitted from the Commandlet list: when
 # the license data is unavailable the policy must report non-compliant rather
 # than a "command did not execute" dependency error.
+#
+# When at least one retention policy reports a numeric Priority value the
+# highest-priority (lowest numeric Priority value) policies must all be
+# duration-compliant. A lower-priority 12 month policy cannot mask a
+# higher-priority non-compliant policy; otherwise ScubaGear would produce a
+# false Pass. When several enabled policies tie on the smallest Priority
+# value, all of them must comply (fail closed): Purview does not define tie
+# semantics, and a complete rule selecting a single tied policy would abort
+# the whole evaluation with eval_conflict_error. See issue #2374.
 default AuditRetentionRequirementMet := false
 AuditRetentionRequirementMet if {
     count(AdvancedAuditingLicenses) > 0
     count(CompliantRetentionPolicies) >= 1
+    count(EnabledPrioritizedRetentionPolicies) == 0
+}
+
+AuditRetentionRequirementMet if {
+    count(AdvancedAuditingLicenses) > 0
+    count(EnabledPrioritizedRetentionPolicies) > 0
+    MinPriority := min({P.Priority | some P in EnabledPrioritizedRetentionPolicies})
+    every Policy in EnabledPrioritizedRetentionPolicies {
+        MinPriorityPolicyCompliant(Policy, MinPriority)
+    }
+}
+
+# A policy at the smallest Priority value must itself be duration-compliant;
+# policies at a lower precedence are ignored because they cannot mask a
+# higher-priority policy.
+MinPriorityPolicyCompliant(Policy, MinPriority) if {
+    Policy.Priority != MinPriority
+}
+
+MinPriorityPolicyCompliant(Policy, MinPriority) if {
+    Policy.Priority == MinPriority
+    Policy.RetentionDuration in CompliantRetentionDurations
 }
 
 tests contains {

--- a/PowerShell/ScubaGear/Rego/SecuritySuiteConfig.rego
+++ b/PowerShell/ScubaGear/Rego/SecuritySuiteConfig.rego
@@ -852,6 +852,19 @@ EnabledPrioritizedRetentionPolicies contains Policy if {
     is_number(Policy.Priority)
 }
 
+# Enabled retention policies without a usable numeric Priority value. When any
+# prioritized policy exists, these policies have unknown precedence relative to
+# it; silently dropping them from the evaluation could produce a false Pass,
+# so the mixed case must fail closed instead. Priority is read through
+# object.get because a bare `not is_number(Policy.Priority)` does not hold for
+# policies whose Priority key is absent. See issue #2374.
+EnabledUnprioritizedRetentionPolicies contains Policy if {
+    some Policy in input.unified_audit_log_retention_policies
+    not Policy.Enabled == false
+    Priority := object.get(Policy, "Priority", null)
+    not is_number(Priority)
+}
+
 # Save audit log retention policies that retain logs for at least 12 months
 # and are not disabled.
 CompliantRetentionPolicies contains {
@@ -878,7 +891,10 @@ CompliantRetentionPolicies contains {
 # false Pass. When several enabled policies tie on the smallest Priority
 # value, all of them must comply (fail closed): Purview does not define tie
 # semantics, and a complete rule selecting a single tied policy would abort
-# the whole evaluation with eval_conflict_error. See issue #2374.
+# the whole evaluation with eval_conflict_error. When enabled policies mix
+# numeric and missing Priority values, precedence is undefined and the rule
+# fails closed rather than silently excluding the unprioritized policies.
+# See issue #2374.
 default AuditRetentionRequirementMet := false
 AuditRetentionRequirementMet if {
     count(AdvancedAuditingLicenses) > 0
@@ -889,6 +905,7 @@ AuditRetentionRequirementMet if {
 AuditRetentionRequirementMet if {
     count(AdvancedAuditingLicenses) > 0
     count(EnabledPrioritizedRetentionPolicies) > 0
+    count(EnabledUnprioritizedRetentionPolicies) == 0
     MinPriority := min({P.Priority | some P in EnabledPrioritizedRetentionPolicies})
     every Policy in EnabledPrioritizedRetentionPolicies {
         MinPriorityPolicyCompliant(Policy, MinPriority)

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/SecuritySuite/SecuritySuiteBaseConfig.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/SecuritySuite/SecuritySuiteBaseConfig.rego
@@ -89,6 +89,26 @@ DisabledRetentionPolicy := {
     "Enabled": false
 }
 
+# Non-compliant: highest priority (Priority=1) policy keeps logs only 7 days.
+# Per the Microsoft Purview audit retention documentation, a lower numeric
+# Priority value indicates a higher precedence, so this policy supersedes
+# any other configured retention policy and therefore drives the result.
+HighPriorityNonCompliantRetentionPolicy := {
+    "Name": "7 day retention (highest priority)",
+    "RetentionDuration": "SevenDays",
+    "Enabled": true,
+    "Priority": 1
+}
+
+# Compliant: 12 month retention, but lower priority than
+# HighPriorityNonCompliantRetentionPolicy.
+LowerPriorityCompliantRetentionPolicy := {
+    "Name": "12 month retention (lower priority)",
+    "RetentionDuration": "TwelveMonths",
+    "Enabled": true,
+    "Priority": 2
+}
+
 # E5-level service plans, includes the advanced auditing plan required to
 # retain audit logs beyond 180 days (E5 / E5 Compliance / E5 eDiscovery and Audit)
 ServicePlansWithAdvancedAuditing := [

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/SecuritySuite/SecuritySuiteBaseConfig.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/SecuritySuite/SecuritySuiteBaseConfig.rego
@@ -109,6 +109,15 @@ LowerPriorityCompliantRetentionPolicy := {
     "Priority": 2
 }
 
+# Non-compliant: enabled policy without a usable numeric Priority value. Its
+# precedence relative to any prioritized policy is unknown, so mixing it with
+# a prioritized policy must fail closed instead of silently ignoring it.
+EnabledUnprioritizedRetentionPolicy := {
+    "Name": "7 day retention (no priority)",
+    "RetentionDuration": "SevenDays",
+    "Enabled": true
+}
+
 # E5-level service plans, includes the advanced auditing plan required to
 # retain audit logs beyond 180 days (E5 / E5 Compliance / E5 eDiscovery and Audit)
 ServicePlansWithAdvancedAuditing := [

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/SecuritySuite/SecuritySuiteConfig_05_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/SecuritySuite/SecuritySuiteConfig_05_test.rego
@@ -216,4 +216,30 @@ test_AuditLogRetention_TieOneNonCompliant if {
     ReportDetailString := concat(": ", [FAIL, RetentionLicenseNote])
     TestResult("MS.SECURITYSUITE.5.2v1", Output, ReportDetailString, false) == true
 }
+
+# Mixed priority data must fail closed: one duration-compliant policy with a
+# numeric Priority alongside an enabled policy whose Priority is missing. The
+# unprioritized policy's precedence is unknown, so it cannot silently vanish
+# from the decision even though the prioritized policy complies.
+test_AuditLogRetention_Incorrect_MixedPriorityDataFailsClosed if {
+    Output := securitysuite.tests with input.unified_audit_log_retention_policies as [LowerPriorityCompliantRetentionPolicy, EnabledUnprioritizedRetentionPolicy]
+        with input.service_plans as ServicePlansWithAdvancedAuditing
+
+    ReportDetailString := concat(": ", [FAIL, RetentionLicenseNote])
+    TestResult("MS.SECURITYSUITE.5.2v1", Output, ReportDetailString, false) == true
+}
+
+# Fail closed even when the unprioritized policy would itself be
+# duration-compliant: with mixed priority data the precedence cannot be
+# established, so the evaluation must not report a Pass.
+test_AuditLogRetention_Incorrect_MixedPriorityAllCompliantStillFailsClosed if {
+    UnprioritizedCompliant := json.patch(LowerPriorityCompliantRetentionPolicy, [
+        {"op": "remove", "path": "Priority"},
+    ])
+    Output := securitysuite.tests with input.unified_audit_log_retention_policies as [LowerPriorityCompliantRetentionPolicy, UnprioritizedCompliant]
+        with input.service_plans as ServicePlansWithAdvancedAuditing
+
+    ReportDetailString := concat(": ", [FAIL, RetentionLicenseNote])
+    TestResult("MS.SECURITYSUITE.5.2v1", Output, ReportDetailString, false) == true
+}
 #--

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/SecuritySuite/SecuritySuiteConfig_05_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/SecuritySuite/SecuritySuiteConfig_05_test.rego
@@ -154,4 +154,66 @@ test_AuditLogRetention_Incorrect_NoServicePlans if {
     ReportDetailString := concat(": ", [FAIL, RetentionLicenseNote])
     TestResult("MS.SECURITYSUITE.5.2v1", Output, ReportDetailString, false) == true
 }
+
+# A lower-priority compliant policy (12 months) must NOT override a higher-priority
+# non-compliant policy (7 days). Per Microsoft, lower numeric Priority means higher
+# precedence, so the 7 day policy wins and the tenant fails. See issue #2374.
+test_AuditLogRetention_Incorrect_HigherPriorityNonCompliant if {
+    Output := securitysuite.tests with input.unified_audit_log_retention_policies as [LowerPriorityCompliantRetentionPolicy, HighPriorityNonCompliantRetentionPolicy]
+        with input.service_plans as ServicePlansWithAdvancedAuditing
+
+    ReportDetailString := concat(": ", [FAIL, RetentionLicenseNote])
+    TestResult("MS.SECURITYSUITE.5.2v1", Output, ReportDetailString, false) == true
+}
+
+# Symmetric case: the non-compliant policy has the lower priority (Priority=2)
+# while the compliant 12 month policy has the higher priority (Priority=1).
+# Here the compliant policy wins and the tenant should pass.
+test_AuditLogRetention_Correct_HigherPriorityCompliant if {
+    HighPriorityCompliant := json.patch(LowerPriorityCompliantRetentionPolicy, [
+        {"op": "replace", "path": "Priority", "value": 1},
+    ])
+    LowPriorityNonCompliant := json.patch(HighPriorityNonCompliantRetentionPolicy, [
+        {"op": "replace", "path": "Priority", "value": 2},
+    ])
+    Output := securitysuite.tests with input.unified_audit_log_retention_policies as [LowPriorityNonCompliant, HighPriorityCompliant]
+        with input.service_plans as ServicePlansWithAdvancedAuditing
+
+    ReportDetailString := concat(": ", [PASS, RetentionLicenseNote])
+    TestResult("MS.SECURITYSUITE.5.2v1", Output, ReportDetailString, true) == true
+}
+
+# Tie on the smallest Priority value (two enabled policies, both Priority=1):
+# Purview does not define tie semantics, so the evaluation fails closed — all
+# highest-priority policies must comply for the tenant to pass.
+test_AuditLogRetention_TieBothCompliant if {
+    PolicyA := json.patch(LowerPriorityCompliantRetentionPolicy, [
+        {"op": "replace", "path": "Priority", "value": 1},
+    ])
+    PolicyB := json.patch(LowerPriorityCompliantRetentionPolicy, [
+        {"op": "replace", "path": "Name", "value": "Second compliant policy"},
+        {"op": "replace", "path": "Priority", "value": 1},
+    ])
+    Output := securitysuite.tests with input.unified_audit_log_retention_policies as [PolicyA, PolicyB]
+        with input.service_plans as ServicePlansWithAdvancedAuditing
+
+    ReportDetailString := concat(": ", [PASS, RetentionLicenseNote])
+    TestResult("MS.SECURITYSUITE.5.2v1", Output, ReportDetailString, true) == true
+}
+
+# A tie where one of the smallest-priority policies is non-compliant must fail:
+# a compliant policy at the same priority cannot mask the non-compliant one.
+test_AuditLogRetention_TieOneNonCompliant if {
+    TieNonCompliant := json.patch(HighPriorityNonCompliantRetentionPolicy, [
+        {"op": "replace", "path": "Priority", "value": 1},
+    ])
+    TieCompliant := json.patch(LowerPriorityCompliantRetentionPolicy, [
+        {"op": "replace", "path": "Priority", "value": 1},
+    ])
+    Output := securitysuite.tests with input.unified_audit_log_retention_policies as [TieNonCompliant, TieCompliant]
+        with input.service_plans as ServicePlansWithAdvancedAuditing
+
+    ReportDetailString := concat(": ", [FAIL, RetentionLicenseNote])
+    TestResult("MS.SECURITYSUITE.5.2v1", Output, ReportDetailString, false) == true
+}
 #--


### PR DESCRIPTION
### Summary

MS.SECURITYSUITE.5.2v1 previously reported Pass whenever any retention policy in the tenant kept logs for 12 months or longer, regardless of the policy Priority. Per the Microsoft Purview documentation, a lower numeric Priority means higher precedence, so a Priority=1 SevenDays policy should outrank a Priority=2 TwelveMonths policy. Tenants that configured a high-priority short retention policy alongside a lower-priority compliant policy were incorrectly reported as compliant (false Pass).

### Changes

- `PowerShell/ScubaGear/Rego/SecuritySuiteConfig.rego`: when at least one enabled retention policy reports a numeric Priority, the highest-priority (lowest Priority value) policies now drive the result — all of them must be duration-compliant. Tenants without Priority fields keep the existing duration-only behavior. When several enabled policies tie on the smallest Priority value, all of them must comply (fail closed): Purview does not define tie semantics, and a complete rule selecting a single tied policy would abort the whole evaluation with `eval_conflict_error`.
- `Testing/Unit/Rego/SecuritySuite/SecuritySuiteBaseConfig.rego`: add `HighPriorityNonCompliantRetentionPolicy` (7 days, Priority=1) and `LowerPriorityCompliantRetentionPolicy` (12 months, Priority=2) fixtures.
- `Testing/Unit/Rego/SecuritySuite/SecuritySuiteConfig_05_test.rego`: add `test_AuditLogRetention_Incorrect_HigherPriorityNonCompliant` (fails on main, passes after fix), a symmetric compliant case, and two Priority-tie cases (both-compliant passes, one-non-compliant fails).

### Verification

- `opa test` for the SecuritySuite suite: 198/198 pass on this branch (the new incorrect-priority test fails on `main`).
- `opa check --strict` passes.

Proposed solution for #2374