### PR TITLE
Fix progress counts for single-product configurations

### DIFF
--- a/PowerShell/ScubaGear/Modules/Orchestrator.psm1
+++ b/PowerShell/ScubaGear/Modules/Orchestrator.psm1
@@ -1025,7 +1025,7 @@ function Invoke-RunRego {
             $ProdRegoFailed = @()
             $RegoOutput = @()
             $N = 0
-            $Len = $ScubaConfig.ProductNames.Length
+            $Len = @($ScubaConfig.ProductNames).Count
             foreach ($Product in $ScubaConfig.ProductNames) {
                 $BaselineName = $ArgToProd[$Product]
                 $N += 1
@@ -1566,7 +1566,7 @@ function Invoke-ReportCreation {
     process {
         try {
             $N = 0
-            $Len = $ScubaConfig.ProductNames.Length
+            $Len = @($ScubaConfig.ProductNames).Count
             $Fragment = @()
             $IndividualReportPath = Join-Path -Path $OutFolderPath -ChildPath $IndividualReportFolderName
             New-Item -Path $IndividualReportPath -ItemType "Directory" -ErrorAction "SilentlyContinue" | Out-Null

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-ReportCreation.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-ReportCreation.Tests.ps1
@@ -55,6 +55,22 @@ InModuleScope Orchestrator {
                 Should -Invoke -CommandName Invoke-Item -Exactly -Times 1 -ParameterFilter {-Not [string]::IsNullOrEmpty($Path) }
                 $ScubaConfig.ProductNames = @()
             }
+            It 'Reports progress for <Label>' -ForEach @(
+                @{ Label = 'a scalar product'; Products = 'aad'; Total = 1 }
+                @{ Label = 'a scalar security suite'; Products = 'securitysuite'; Total = 1 }
+                @{ Label = 'a single-element array'; Products = @('aad'); Total = 1 }
+                @{ Label = 'multiple products'; Products = @('aad', 'exo'); Total = 2 }
+            ) {
+                $ScubaConfig.ProductNames = $Products
+                Invoke-ReportCreation -ScubaConfig $ScubaConfig -TenantDetails $TenantDetails -ModuleVersion $ModuleVersion -OutFolderPath $OutFolderPath -DarkMode:$DarkMode -Quiet
+                Should -Invoke Write-Progress -Exactly -Times $Total
+                for ($Index = 1; $Index -le $Total; $Index++) {
+                    Should -Invoke Write-Progress -Exactly -Times 1 -ParameterFilter {
+                        $Status -like "*$Index of $Total *" -and
+                        $PercentComplete -eq ($Index * 100 / $Total)
+                    }
+                }
+            }
             It 'With -ProductNames "aad", should not throw' {
                 $ScubaConfig.ProductNames = @("aad")
                 { Invoke-ReportCreation -ScubaConfig $ScubaConfig -TenantDetails $TenantDetails -ModuleVersion $ModuleVersion -OutFolderPath $OutFolderPath -DarkMode:$DarkMode } | Should -Not -Throw

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-RunRego.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-RunRego.Tests.ps1
@@ -31,6 +31,22 @@ InModuleScope Orchestrator {
                 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'OutFolderPath')]
                 $OutFolderPath = "./"
             }
+            It 'Reports progress for <Label>' -ForEach @(
+                @{ Label = 'a scalar product'; Products = 'aad'; Total = 1 }
+                @{ Label = 'a scalar security suite'; Products = 'securitysuite'; Total = 1 }
+                @{ Label = 'a single-element array'; Products = @('aad'); Total = 1 }
+                @{ Label = 'multiple products'; Products = @('aad', 'exo'); Total = 2 }
+            ) {
+                $ScubaConfig.ProductNames = $Products
+                Invoke-RunRego -ScubaConfig $ScubaConfig -ParentPath $ParentPath -OutFolderPath $OutFolderPath
+                Should -Invoke Write-Progress -Exactly -Times $Total
+                for ($Index = 1; $Index -le $Total; $Index++) {
+                    Should -Invoke Write-Progress -Exactly -Times 1 -ParameterFilter {
+                        $Status -like "*$Index of $Total *" -and
+                        $PercentComplete -eq ($Index * 100 / $Total)
+                    }
+                }
+            }
             It 'With -ProductNames "aad", should not throw' {
                 $ScubaConfig.ProductNames = @("aad")
                 { Invoke-RunRego -ScubaConfig $ScubaConfig -ParentPath $ParentPath -OutFolderPath $OutFolderPath } | Should -Not -Throw


### PR DESCRIPTION
## 🗣 Description

Count products as a collection during Rego evaluation and report creation. A scalar `ProductNames = 'aad'` currently produces a total of three, while an array containing the same product produces one. Both stages now use the same `@(...).Count` pattern as provider execution.

## 💭 Motivation and context

Fixes #1893. The earlier provider-stage correction left the two later progress calculations using string `.Length`.

## 🧪 Testing

On macOS with PowerShell 7.6.6 and Pester 5.7.1:

```powershell
Import-Module ./PowerShell/ScubaGear/Modules/Utility/ScubaLogging.psm1
Invoke-Pester -Path ./PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-RunRego.Tests.ps1,./PowerShell/ScubaGear/Testing/Unit/PowerShell/Orchestrator/Invoke-ReportCreation.Tests.ps1 -Output Detailed
```

- 25 tests passed on this branch with the logging module loaded, and on current upstream plus the same patch. Before the implementation change, the four new scalar-product cases failed; the array cases passed.
- New assertions check the progress total and percentage for scalar Entra/security suite, a one-element array, and multiple products.
- Both changed test files pass PSScriptAnalyzer with the repository settings.
- PSScriptAnalyzer throws `Object reference not set to an instance of an object` on both the unchanged and modified Orchestrator module in this environment.
- `git diff --check` passed. Windows PowerShell 5.1 and tenant smoke/functional tests were not run; external operations are mocked in these unit tests.

The branch uses the fork's existing base because the available OAuth credential cannot upload intervening upstream workflow changes. It merges cleanly into current `main`; the resulting Git tree is identical to the upstream-plus-patch tree tested above. The PR diff contains only the three files for this fix.

## ✅ Pre-approval checklist

- [x] Informative title and correct parent branch.
- [x] Changes limited to one goal.
- [x] Contribution instructions and content style guide checked.
- [x] Related issue linked.
- [x] Unit tests added and passing.
- [ ] All automated checks passed (module analyzer limitation noted above).

## ✅ Pre-merge checklist

- [ ] Maintainer review and CI completed.
- [ ] Windows smoke/functional validation, if required.
