### PR TITLE
Support role exclusions for MS.AAD.7.5v1

### DIFF
--- a/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfigSchema.json
+++ b/PowerShell/ScubaGear/Modules/ScubaConfig/ScubaConfigSchema.json
@@ -40,6 +40,7 @@
       "MS.AAD.3.8v1": ["CapExclusions"],
       "MS.AAD.3.9v1": ["CapExclusions"],
       "MS.AAD.7.4v1": ["RoleExclusions"],
+      "MS.AAD.7.5v1": ["RoleExclusions"],
       "MS.SECURITYSUITE.2.1v1": ["SensitiveUsers"],
       "MS.SECURITYSUITE.2.3v1": ["PartnerDomains"],
       "MS.EXO.1.1v2": ["AllowedForwardingDomains"]

--- a/PowerShell/ScubaGear/Rego/AADConfig.rego
+++ b/PowerShell/ScubaGear/Rego/AADConfig.rego
@@ -1314,12 +1314,29 @@ tests contains {
 # MS.AAD.7.5v1
 #--
 
-# Get all privileged roles that do not have a start date
+# Return true when a privileged role has at least one assignment outside PIM
+# that is not explicitly excluded by user or group object ID.
+RoleAssignedOutsidePim(PrivilegedRole, PolicyID) if {
+    OutsidePimPrincipals := {x.PrincipalId |
+        some x in PrivilegedRole.Assignments
+        is_null(x.StartDateTime)
+    }
+    AllowedPrivilegedRoleUsers := {y |
+        some y in input.scuba_config.Aad[PolicyID].RoleExclusions.Users
+        y != null
+    }
+    AllowedPrivilegedRoleGroups := {y |
+        some y in input.scuba_config.Aad[PolicyID].RoleExclusions.Groups
+        y != null
+    }
+
+    Count(OutsidePimPrincipals - (AllowedPrivilegedRoleUsers | AllowedPrivilegedRoleGroups)) > 0
+}
+
+# Get all privileged roles that have a non-excluded assignment outside PIM.
 RolesAssignedOutsidePim contains Role.DisplayName if {
     some Role in input.privileged_roles
-    NoStartAssignments := {is_null(X.StartDateTime) | some X in Role.Assignments}
-
-    Count(FilterArray(NoStartAssignments, true)) > 0
+    RoleAssignedOutsidePim(Role, "MS.AAD.7.5v1")
 }
 
 # If you have the correct license & no roles without start date, pass

--- a/PowerShell/ScubaGear/Sample-Config-Files/full_config.yaml
+++ b/PowerShell/ScubaGear/Sample-Config-Files/full_config.yaml
@@ -138,6 +138,9 @@ Aad:
       Groups:
         - 4a471183-d934-4fb4-b1b3-d9525e0e1b45 # Example Group 2
 
+  # Provisioning users to highly privileged roles SHALL NOT occur outside of a PAM system.
+  MS.AAD.7.5v1: *CommonRoleExclusions
+
 # ========================
 # EXCLUSIONS : EXO SAMPLE
 # ========================

--- a/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
+++ b/PowerShell/ScubaGear/Testing/Unit/Rego/AAD/AADConfig_07_test.rego
@@ -452,6 +452,49 @@ test_Assignments_Incorrect if {
     ReportDetailString := "1 role(s) assigned to users outside of PIM:<br/>Global Administrator"
     TestResult("MS.AAD.7.5v1", Output, ReportDetailString, false) == true
 }
+
+
+test_Assignments_UserExclusion_Correct if {
+    Roles := json.patch(PrivilegedRoles,
+                [{"op": "add", "path": "0/Assignments/0/StartDateTime", "value": null},
+                {"op": "remove", "path": "1"}])
+
+    Output := aad.tests with input.privileged_roles as Roles
+                        with input.service_plans as ServicePlans
+                        with input.scuba_config.Aad["MS.AAD.7.5v1"] as ScubaConfig
+                        with input.scuba_config.Aad["MS.AAD.7.5v1"].RoleExclusions.Users as ["ae71e61c-f465-4db6-8d26-5f3e52bdd800"]
+
+    ReportDetailString := "0 role(s) assigned to users outside of PIM"
+    TestResult("MS.AAD.7.5v1", Output, ReportDetailString, true) == true
+}
+
+test_Assignments_GroupExclusion_Correct if {
+    Roles := json.patch(PrivilegedRoles,
+                [{"op": "add", "path": "0/Assignments/0/StartDateTime", "value": null},
+                {"op": "remove", "path": "1"}])
+
+    Output := aad.tests with input.privileged_roles as Roles
+                        with input.service_plans as ServicePlans
+                        with input.scuba_config.Aad["MS.AAD.7.5v1"] as ScubaConfig
+                        with input.scuba_config.Aad["MS.AAD.7.5v1"].RoleExclusions.Groups as ["ae71e61c-f465-4db6-8d26-5f3e52bdd800"]
+
+    ReportDetailString := "0 role(s) assigned to users outside of PIM"
+    TestResult("MS.AAD.7.5v1", Output, ReportDetailString, true) == true
+}
+
+test_Assignments_UnrelatedExclusion_Incorrect if {
+    Roles := json.patch(PrivilegedRoles,
+                [{"op": "add", "path": "0/Assignments/0/StartDateTime", "value": null},
+                {"op": "remove", "path": "1"}])
+
+    Output := aad.tests with input.privileged_roles as Roles
+                        with input.service_plans as ServicePlans
+                        with input.scuba_config.Aad["MS.AAD.7.5v1"] as ScubaConfig
+                        with input.scuba_config.Aad["MS.AAD.7.5v1"].RoleExclusions.Users as ["7b36d094-0211-400b-aabd-3793e9a30fc6"]
+
+    ReportDetailString := "1 role(s) assigned to users outside of PIM:<br/>Global Administrator"
+    TestResult("MS.AAD.7.5v1", Output, ReportDetailString, false) == true
+}
 #--
 
 #

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -235,6 +235,12 @@ Aad:
         - "12345678-1234-1234-1234-123456789012"  # Emergency access account
       Groups:
         - "22222222-2222-2222-2222-222222222222"  # Service account group
+  MS.AAD.7.5v1:
+    RoleExclusions:
+      Users:
+        - "12345678-1234-1234-1234-123456789012"  # Emergency access account
+      Groups:
+        - "22222222-2222-2222-2222-222222222222"  # Service account group
 ```
 
 #### Conditional Access Policy Exclusions
@@ -286,6 +292,7 @@ In addition to defining exclusions for conditional access policies, the configur
 RoleExclusions are supported for the following policies:
 
 - MS.AAD.7.4v1
+- MS.AAD.7.5v1
 
 ### Security Suite Configuration
 


### PR DESCRIPTION
## Summary

Add `RoleExclusions` support to MS.AAD.7.5v1 so explicitly excluded users or groups are not reported as privileged-role assignments outside PIM.

- register `RoleExclusions` for MS.AAD.7.5v1 in the configuration schema
- filter outside-PIM assignments by user/group object ID
- document and demonstrate the new configuration
- add regression coverage for user, group, and unrelated exclusions

## Testing

- AAD Rego unit tests: 326/326 passing
- targeted MS.AAD.7.5v1 tests: 5/5 passing
- configuration schema JSON validation

Fixes #2393
