### PR TITLE
Resolve OPA paths to native filesystem locations

### DIFF
--- a/PowerShell/ScubaGear/Modules/RunRego/RunRego.psm1
+++ b/PowerShell/ScubaGear/Modules/RunRego/RunRego.psm1
@@ -48,9 +48,11 @@ function Invoke-Rego {
         throw "Rego file not found at: $RegoFile"
     }
 
-    # LiteralPath so input/output paths containing wildcard characters (e.g. []) resolve correctly.
-    $ResolvedInputFile = (Resolve-Path -LiteralPath $InputFile -ErrorAction Stop).Path
-    $ResolvedRegoFile = (Resolve-Path -LiteralPath $RegoFile -ErrorAction Stop).Path
+    # OPA is a native process: resolve relative paths and PSDrives to filesystem paths.
+    # LiteralPath also preserves wildcard characters (e.g. []) in folder names.
+    $Cmd = (Resolve-Path -LiteralPath $Cmd -ErrorAction Stop).ProviderPath
+    $ResolvedInputFile = (Resolve-Path -LiteralPath $InputFile -ErrorAction Stop).ProviderPath
+    $ResolvedRegoFile = (Resolve-Path -LiteralPath $RegoFile -ErrorAction Stop).ProviderPath
 
     $RegoFileObject = Get-Item -LiteralPath $ResolvedRegoFile -ErrorAction Stop
     if ($null -eq $RegoFileObject) {
@@ -61,7 +63,7 @@ function Invoke-Rego {
     if (-not (Test-Path -LiteralPath $ScubaUtils -PathType Container)) {
         throw "Rego Utils directory not found at: $ScubaUtils"
     }
-    $ResolvedScubaUtils = (Resolve-Path -LiteralPath $ScubaUtils -ErrorAction Stop).Path
+    $ResolvedScubaUtils = (Resolve-Path -LiteralPath $ScubaUtils -ErrorAction Stop).ProviderPath
 
     $CmdArgs = @("eval", "data.$PackageName.tests", "-i", $ResolvedInputFile, "-d", $ResolvedRegoFile, "-d", $ResolvedScubaUtils, "-f", "values")
 

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/RunRego/Run-Rego.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/RunRego/Run-Rego.Tests.ps1
@@ -11,6 +11,8 @@ InModuleScope 'RunRego' {
     ){
         BeforeAll {
             Mock -ModuleName RunRego Invoke-ExternalCmd {return 0}
+            $OpaName = if ($Env:OS -eq "Windows_NT") { "opa_windows_amd64.exe" } else { "opa" }
+            Set-Content -LiteralPath (Join-Path $TestDrive $OpaName) -Value "test stub"
             [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'RegoParams')]
             $RegoParams = @{
                 'InputFile' = Join-Path -Path $PSScriptRoot -ChildPath "./RunRegoStubs/ProviderSettingsExport.json";
@@ -20,7 +22,7 @@ InModuleScope 'RunRego' {
             $RegoParams += @{
                 'RegoFile'    = Join-Path -Path $PSScriptRoot -ChildPath "../../../../Rego/$($Arg)Config.rego";
                 'PackageName' = $Product;
-                'OPAPath'   = Join-Path -Path $env:USERPROFILE -ChildPath ".scubagear/Tools";
+                'OPAPath'   = $TestDrive;
             }
             Mock -CommandName Test-Path {$true}
             Invoke-Rego @RegoParams | Should -Not -Be $null
@@ -38,6 +40,8 @@ InModuleScope 'RunRego' {
     Describe -Tag 'RunRego' -Name 'Invoke-Rego wildcard path handling' {
         BeforeAll {
             Mock -ModuleName RunRego Invoke-ExternalCmd { return 0 }
+            $OpaName = if ($Env:OS -eq "Windows_NT") { "opa_windows_amd64.exe" } else { "opa" }
+            Set-Content -LiteralPath (Join-Path $TestDrive $OpaName) -Value "test stub"
             Mock -CommandName Test-Path { $true }
         }
         It 'Passes an InputFile path containing square brackets ([]) to OPA literally' {
@@ -50,7 +54,7 @@ InModuleScope 'RunRego' {
                 'InputFile'   = $BracketInput
                 'RegoFile'    = Join-Path -Path $PSScriptRoot -ChildPath '../../../../Rego/AADConfig.rego'
                 'PackageName' = 'aad'
-                'OPAPath'     = Join-Path -Path $env:USERPROFILE -ChildPath '.scubagear/Tools'
+                'OPAPath'     = $TestDrive
             }
             { Invoke-Rego @RegoParams } | Should -Not -Throw
             # The resolved bracketed input path must appear in the OPA arguments (regex-escaped brackets)
@@ -63,4 +67,53 @@ InModuleScope 'RunRego' {
 
 AfterAll {
     Remove-Module RunRego -ErrorAction SilentlyContinue
+}
+InModuleScope 'RunRego' {
+    Describe -Tag 'RunRego' -Name 'Invoke-Rego native filesystem paths' {
+        BeforeAll {
+            $NativeDirectory = Join-Path $TestDrive 'cached reports [test]'
+            New-Item -ItemType Directory -Path $NativeDirectory | Out-Null
+            New-Item -ItemType Directory -Path (Join-Path $NativeDirectory 'Utils') | Out-Null
+            Set-Content -LiteralPath (Join-Path $NativeDirectory 'input.json') -Value '{}'
+            Set-Content -LiteralPath (Join-Path $NativeDirectory 'test.rego') -Value 'package test'
+            $NativeOpaName = if ($Env:OS -eq 'Windows_NT') { 'opa_windows_amd64.exe' } else { 'opa' }
+            Set-Content -LiteralPath (Join-Path $NativeDirectory $NativeOpaName) -Value 'test stub'
+            New-PSDrive -Name ScubaCache -PSProvider FileSystem -Root $NativeDirectory | Out-Null
+        }
+        AfterAll {
+            Remove-PSDrive -Name ScubaCache
+        }
+        BeforeEach {
+            Mock Invoke-ExternalCmd { '[[{"result":true}]]' }
+        }
+        It 'Resolves a relative executable against the PowerShell working directory' {
+            Push-Location -LiteralPath $NativeDirectory
+            try {
+                Invoke-Rego -OPAPath '.' -InputFile './input.json' -RegoFile './test.rego' -PackageName test
+                Should -Invoke Invoke-ExternalCmd -Times 1 -Exactly -ParameterFilter {
+                    $LiteralPath -eq (Join-Path $NativeDirectory $NativeOpaName)
+                }
+            }
+            finally { Pop-Location }
+        }
+        It 'Converts PSDrive paths into native paths for OPA and all input files' {
+            Invoke-Rego -OPAPath 'ScubaCache:/' -InputFile 'ScubaCache:/input.json' -RegoFile 'ScubaCache:/test.rego' -PackageName test
+            Should -Invoke Invoke-ExternalCmd -Times 1 -Exactly -ParameterFilter {
+                $LiteralPath -eq (Join-Path $NativeDirectory $NativeOpaName) -and
+                $PassThruArgs[3] -eq (Join-Path $NativeDirectory 'input.json') -and
+                $PassThruArgs[5] -eq (Join-Path $NativeDirectory 'test.rego') -and
+                $PassThruArgs[7] -eq (Join-Path $NativeDirectory 'Utils')
+            }
+        }
+        It 'Resolves the current-directory fallback on a PSDrive' {
+            Push-Location ScubaCache:/
+            try {
+                Invoke-Rego -OPAPath (Join-Path $TestDrive 'missing') -InputFile './input.json' -RegoFile './test.rego' -PackageName test
+                Should -Invoke Invoke-ExternalCmd -Times 1 -Exactly -ParameterFilter {
+                    $LiteralPath -eq (Join-Path $NativeDirectory $NativeOpaName)
+                }
+            }
+            finally { Pop-Location }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Resolve the OPA executable, input JSON, Rego policy and Utils directory to native filesystem paths. This preserves literal paths while handling relative OPA locations and FileSystem PSDrives.

Fixes #2398. Related to #2337; its original Windows physical-drive scenario still needs confirmation.

## Testing

- RunRego Pester suite: **16 passed**, including three new cases that fail before the fix.
- Real OPA 1.19.1 execution: relative executable, PSDrive-qualified executable and current-directory fallback all pass.
- PSScriptAnalyzer: no warnings or errors in either changed file.
- Tested on macOS PowerShell. Windows PowerShell 5.1 was not available locally.
