### PR TITLE
Centralize Get-HttpResponseDetails into Utility.psm1

### DIFF
--- a/PowerShell/ScubaGear/Modules/Utility/Utility.psm1
+++ b/PowerShell/ScubaGear/Modules/Utility/Utility.psm1
@@ -786,69 +786,113 @@ function Invoke-ScubaRestMethod {
         $ErrorRecord = $_
         $WebResponse = $ErrorRecord.Exception.Response
 
-        $ErrorBuffer = [System.Text.StringBuilder]::new()
-        [void]$ErrorBuffer.AppendLine("Exception Type: $($ErrorRecord.Exception.GetType().FullName)")
-        [void]$ErrorBuffer.AppendLine("Message       : $($ErrorRecord.Exception.Message)")
-
         if ($null -eq $WebResponse) {
-            [void]$ErrorBuffer.AppendLine("No HTTP response object was returned.")
-            Write-Information $ErrorBuffer.ToString() -InformationAction Continue
+            Write-Information "No HTTP response object was returned.`nException Type: $($ErrorRecord.Exception.GetType().FullName)`nMessage       : $($ErrorRecord.Exception.Message)" -InformationAction Continue
             throw
         }
 
-        # PS 5.1 throws WebException -> HttpWebResponse. PS 7+ throws HttpResponseException -> HttpResponseMessage.
-        # Compare the type name as a string rather than "-is [System.Net.Http.HttpResponseMessage]" because that
-        # assembly isn't loaded by default on PS 5.1 Desktop, and the type-literal itself fails to resolve there.
-        if ($WebResponse.GetType().FullName -eq 'System.Net.Http.HttpResponseMessage') {
-            [void]$ErrorBuffer.AppendLine("Status Code   : $([int]$WebResponse.StatusCode)")
-            [void]$ErrorBuffer.AppendLine("Status Text   : $($WebResponse.ReasonPhrase)")
-            [void]$ErrorBuffer.AppendLine("")
-            [void]$ErrorBuffer.AppendLine("=== Response Headers ===")
-            foreach ($Header in $WebResponse.Headers) {
-                [void]$ErrorBuffer.AppendLine("$($Header.Key): $($Header.Value -join ', ')")
-            }
-            [void]$ErrorBuffer.AppendLine("")
-            [void]$ErrorBuffer.AppendLine("=== Raw Response Body ===")
-            # On PS 7+, Invoke-RestMethod already reads and disposes the response content internally,
-            # so re-reading $WebResponse.Content throws "Cannot access a disposed object." The body text
-            # (when PowerShell can parse it) is instead surfaced via ErrorRecord.ErrorDetails.Message.
-            $ResponseBody = $ErrorRecord.ErrorDetails.Message
-            [void]$ErrorBuffer.AppendLine($(if ([string]::IsNullOrWhiteSpace($ResponseBody)) { "Empty response body." } else { $ResponseBody }))
-        }
-        else {
-            [void]$ErrorBuffer.AppendLine("Status Code   : $([int]$WebResponse.StatusCode)")
-            [void]$ErrorBuffer.AppendLine("Status Text   : $($WebResponse.StatusDescription)")
-            [void]$ErrorBuffer.AppendLine("Content Type  : $($WebResponse.ContentType)")
-            [void]$ErrorBuffer.AppendLine("Content Length: $($WebResponse.ContentLength)")
-            [void]$ErrorBuffer.AppendLine("")
-            [void]$ErrorBuffer.AppendLine("=== Response Headers ===")
-            foreach ($HeaderName in $WebResponse.Headers.AllKeys) {
-                [void]$ErrorBuffer.AppendLine("${HeaderName}: $($WebResponse.Headers[$HeaderName])")
-            }
-            [void]$ErrorBuffer.AppendLine("")
-            [void]$ErrorBuffer.AppendLine("=== Raw Response Body ===")
-            $ResponseStream = $WebResponse.GetResponseStream()
-            if ($null -eq $ResponseStream) {
-                [void]$ErrorBuffer.AppendLine("No response stream in Error.Exception.Response object.")
-            }
-            else {
-                $Reader = New-Object System.IO.StreamReader($ResponseStream)
-                try {
-                    $ResponseBody = $Reader.ReadToEnd()
-                }
-                finally {
-                    $Reader.Dispose()
-                    $ResponseStream.Dispose()
-                }
-                [void]$ErrorBuffer.AppendLine($(if ([string]::IsNullOrWhiteSpace($ResponseBody)) { "Empty response body." } else { $ResponseBody }))
-            }
-        }
-
-        Write-Information $ErrorBuffer.ToString() -InformationAction Continue
+        $DetailedHttpMessage = Get-HttpResponseDetails -HttpResponseObject $WebResponse -ErrorDetailsMessage $ErrorRecord.ErrorDetails.Message
+        Write-Information $DetailedHttpMessage -InformationAction Continue
         throw
     }
 
     return $Response
+}
+
+function Get-HttpResponseDetails {
+    <#
+    .SYNOPSIS
+        Formats an HTTP response object into a human-readable diagnostic string.
+
+    .DESCRIPTION
+        Handles the three response object shapes ScubaGear's REST callers actually encounter:
+        the WebResponseObject Invoke-WebRequest returns directly on success, System.Net.HttpWebResponse
+        (PS 5.1 exception .Response), and System.Net.Http.HttpResponseMessage (PS 7+ exception .Response).
+
+    .PARAMETER HttpResponseObject
+        The response object to format (either a direct Invoke-WebRequest return value, or an
+        exception's .Response property).
+
+    .PARAMETER ErrorDetailsMessage
+        Only used for HttpResponseMessage: PS 7+ disposes the response content stream by the time
+        the catch block runs, so the body (when parseable) has to come from the caller's
+        $ErrorRecord.ErrorDetails.Message instead.
+
+    .FUNCTIONALITY
+        Internal
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        $HttpResponseObject,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ErrorDetailsMessage
+    )
+
+    $StringBuffer = [System.Text.StringBuilder]::new()
+    [void]$StringBuffer.AppendLine("`nResponse Type : $($HttpResponseObject.GetType().FullName)")
+
+    if ($HttpResponseObject -is [Microsoft.PowerShell.Commands.WebResponseObject]) {
+        # Direct return value of Invoke-WebRequest (e.g. HTTP 202/3xx) - Content is already a string.
+        [void]$StringBuffer.AppendLine("Status Code   : $([int]$HttpResponseObject.StatusCode)")
+        [void]$StringBuffer.AppendLine("Status Text   : $($HttpResponseObject.StatusDescription)")
+        [void]$StringBuffer.AppendLine("")
+        [void]$StringBuffer.AppendLine("=== Response Headers ===")
+        foreach ($HeaderName in $HttpResponseObject.Headers.Keys) {
+            [void]$StringBuffer.AppendLine("${HeaderName}: $($HttpResponseObject.Headers[$HeaderName])")
+        }
+        [void]$StringBuffer.AppendLine("")
+        [void]$StringBuffer.AppendLine("=== Raw Response Body ===")
+        [void]$StringBuffer.AppendLine($(if ([string]::IsNullOrWhiteSpace($HttpResponseObject.Content)) { "Empty response body." } else { $HttpResponseObject.Content }))
+    }
+    elseif ($HttpResponseObject.GetType().FullName -eq 'System.Net.Http.HttpResponseMessage') {
+        # PowerShell 7+ HttpResponseException.Response
+        [void]$StringBuffer.AppendLine("Status Code   : $([int]$HttpResponseObject.StatusCode)")
+        [void]$StringBuffer.AppendLine("Status Text   : $($HttpResponseObject.ReasonPhrase)")
+        [void]$StringBuffer.AppendLine("")
+        [void]$StringBuffer.AppendLine("=== Response Headers ===")
+        foreach ($Header in $HttpResponseObject.Headers) {
+            [void]$StringBuffer.AppendLine("$($Header.Key): $($Header.Value -join ', ')")
+        }
+        [void]$StringBuffer.AppendLine("")
+        [void]$StringBuffer.AppendLine("=== Raw Response Body ===")
+        # On PS 7+, Invoke-RestMethod already reads and disposes the response content internally,
+        # so re-reading .Content throws "Cannot access a disposed object." The body text (when
+        # PowerShell can parse it) is instead surfaced via ErrorRecord.ErrorDetails.Message.
+        [void]$StringBuffer.AppendLine($(if ([string]::IsNullOrWhiteSpace($ErrorDetailsMessage)) { "Empty response body." } else { $ErrorDetailsMessage }))
+    }
+    else {
+        # PowerShell 5.1 WebException.Response (System.Net.HttpWebResponse)
+        [void]$StringBuffer.AppendLine("Status Code   : $([int]$HttpResponseObject.StatusCode)")
+        [void]$StringBuffer.AppendLine("Status Text   : $($HttpResponseObject.StatusDescription)")
+        [void]$StringBuffer.AppendLine("Content Type  : $($HttpResponseObject.ContentType)")
+        [void]$StringBuffer.AppendLine("Content Length: $($HttpResponseObject.ContentLength)")
+        [void]$StringBuffer.AppendLine("")
+        [void]$StringBuffer.AppendLine("=== Response Headers ===")
+        foreach ($HeaderName in $HttpResponseObject.Headers.AllKeys) {
+            [void]$StringBuffer.AppendLine("${HeaderName}: $($HttpResponseObject.Headers[$HeaderName])")
+        }
+        [void]$StringBuffer.AppendLine("")
+        [void]$StringBuffer.AppendLine("=== Raw Response Body ===")
+        $HttpResponseStream = $HttpResponseObject.GetResponseStream()
+        if ($null -eq $HttpResponseStream) {
+            [void]$StringBuffer.AppendLine("No response stream in Error.Exception.Response object.")
+        }
+        else {
+            $HttpResponseReader = New-Object System.IO.StreamReader($HttpResponseStream)
+            try {
+                $ResponseBody = $HttpResponseReader.ReadToEnd()
+            }
+            finally {
+                $HttpResponseReader.Dispose()
+                $HttpResponseStream.Dispose()
+            }
+            [void]$StringBuffer.AppendLine($(if ([string]::IsNullOrWhiteSpace($ResponseBody)) { "Empty response body." } else { $ResponseBody }))
+        }
+    }
+
+    return $StringBuffer.ToString()
 }
 
 Export-ModuleMember -Function @(
@@ -857,5 +901,6 @@ Export-ModuleMember -Function @(
     'Invoke-GraphDirectly',
     'ConvertFrom-GraphHashtable',
     'Invoke-GraphBatchRequest',
-    'Invoke-ScubaRestMethod'
+    'Invoke-ScubaRestMethod',
+    'Get-HttpResponseDetails'
 )

--- a/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/Get-HttpResponseDetails.Tests.ps1
+++ b/PowerShell/ScubaGear/Testing/Unit/PowerShell/Utility/Get-HttpResponseDetails.Tests.ps1
@@ -1,0 +1,112 @@
+$UtilityPath = '../../../../Modules/Utility/Utility.psm1'
+Import-Module (Join-Path -Path $PSScriptRoot -ChildPath $UtilityPath) -Function 'Get-HttpResponseDetails' -Force
+
+InModuleScope Utility {
+    Describe -Tag 'Utility' -Name 'Get-HttpResponseDetails' {
+        Context 'HttpResponseMessage (PowerShell 7+ exception .Response shape)' {
+            BeforeAll {
+                # Not loaded by default on PS 5.1 Desktop; must be loaded explicitly before the type can be constructed.
+                Add-Type -AssemblyName System.Net.Http
+            }
+
+            It 'Formats status, headers and body from the ErrorDetailsMessage parameter' {
+                $Response = [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::Unauthorized)
+                $Response.ReasonPhrase = 'Unauthorized'
+                $Response.Headers.Add('X-Test-Header', 'test-value')
+
+                $Details = Get-HttpResponseDetails -HttpResponseObject $Response -ErrorDetailsMessage '{"message":"Bad credentials"}'
+
+                $Details | Should -Match 'Response Type : System\.Net\.Http\.HttpResponseMessage'
+                $Details | Should -Match 'Status Code   : 401'
+                $Details | Should -Match 'Status Text   : Unauthorized'
+                $Details | Should -Match 'X-Test-Header: test-value'
+                $Details | Should -Match '\{"message":"Bad credentials"\}'
+            }
+
+            It 'Reports an empty body when ErrorDetailsMessage is not supplied' {
+                $Response = [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::InternalServerError)
+                $Response.ReasonPhrase = 'Internal Server Error'
+
+                $Details = Get-HttpResponseDetails -HttpResponseObject $Response
+
+                $Details | Should -Match 'Empty response body\.'
+            }
+        }
+
+        Context 'HttpWebResponse (PowerShell 5.1 exception .Response shape)' {
+            BeforeAll {
+                # HttpWebResponse has no public constructor, so we duck-type a fake with the same members
+                # Get-HttpResponseDetails actually reads. It falls into this branch by not matching the other two.
+                function New-FakeHttpWebResponse {
+                    param(
+                        [int] $StatusCode = 404,
+                        [string] $StatusDescription = 'Not Found',
+                        [string] $Body = '{"message":"Not Found"}',
+                        [switch] $NoStream
+                    )
+
+                    $BodyBytes = [System.Text.Encoding]::UTF8.GetBytes($Body)
+                    $FakeHeaders = [System.Net.WebHeaderCollection]::new()
+                    $FakeHeaders.Add('X-Fake-Header', 'fake-value')
+
+                    $Fake = [PSCustomObject]@{
+                        StatusCode        = $StatusCode
+                        StatusDescription = $StatusDescription
+                        ContentType       = 'application/json'
+                        ContentLength     = $BodyBytes.Length
+                        Headers           = $FakeHeaders
+                        FakeStream        = if ($NoStream) { $null } else { [System.IO.MemoryStream]::new($BodyBytes) }
+                    }
+                    $Fake | Add-Member -MemberType ScriptMethod -Name GetResponseStream -Value { return $this.FakeStream }
+                    return $Fake
+                }
+            }
+
+            It 'Formats status, headers and body from the response stream' {
+                $Response = New-FakeHttpWebResponse -StatusCode 404 -StatusDescription 'Not Found' -Body '{"message":"Not Found"}'
+
+                $Details = Get-HttpResponseDetails -HttpResponseObject $Response
+
+                $Details | Should -Match 'Status Code   : 404'
+                $Details | Should -Match 'Status Text   : Not Found'
+                $Details | Should -Match 'Content Type  : application/json'
+                $Details | Should -Match 'X-Fake-Header: fake-value'
+                $Details | Should -Match '\{"message":"Not Found"\}'
+            }
+
+            It 'Reports no response stream when GetResponseStream returns null' {
+                $Response = New-FakeHttpWebResponse -NoStream
+
+                $Details = Get-HttpResponseDetails -HttpResponseObject $Response
+
+                $Details | Should -Match 'No response stream in Error\.Exception\.Response object\.'
+            }
+
+            It 'Reports an empty body when the response stream has no content' {
+                $Response = New-FakeHttpWebResponse -Body ''
+
+                $Details = Get-HttpResponseDetails -HttpResponseObject $Response
+
+                $Details | Should -Match 'Empty response body\.'
+            }
+        }
+
+        Context 'WebResponseObject (direct Invoke-WebRequest success return value)' -Tag 'Network' {
+            It 'Formats status, headers and body from a live HTTP response' {
+                # WebResponseObject has no accessible constructor, and its assembly isn't even resolvable
+                # until Invoke-WebRequest has been called at least once - a real request is the only reliable way to get one.
+                $Response = Invoke-WebRequest -Uri 'https://www.githubstatus.com' -UseBasicParsing -ErrorAction Stop
+
+                $Details = Get-HttpResponseDetails -HttpResponseObject $Response
+
+                $Details | Should -Match 'Response Type : Microsoft\.PowerShell\.Commands\.'
+                $Details | Should -Match 'Status Code   : 200'
+                $Details | Should -Not -Match 'Empty response body\.'
+            }
+        }
+    }
+}
+
+AfterAll {
+    Remove-Module Utility -ErrorAction SilentlyContinue
+}

--- a/Testing/Functional/Products/FunctionalTestUtils.ps1
+++ b/Testing/Functional/Products/FunctionalTestUtils.ps1
@@ -1,5 +1,5 @@
 $UtilityModulePath = Join-Path -Path $PSScriptRoot -ChildPath "../../../PowerShell/ScubaGear/Modules/Utility/Utility.psm1" -Resolve
-Import-Module $UtilityModulePath -Function Get-Utf8NoBom, Set-Utf8NoBom
+Import-Module $UtilityModulePath -Function Get-Utf8NoBom, Set-Utf8NoBom, Get-HttpResponseDetails
 
 function Get-FunctionalTestHeaderValue {
   param(
@@ -47,80 +47,6 @@ function Get-FunctionalTestHeaderValue {
   # }
 
   # return [string]$Property.Value
-}
-
-# This function will parse an HTTP response object returned from a call to Invoke-WebRequest and return a nicely formatted string with
-#   the status code, headers and response body to aid in troubleshooting.
-# Handles three distinct shapes: the WebResponseObject Invoke-WebRequest returns directly on success,
-#   System.Net.HttpWebResponse (PS 5.1 exception .Response), and System.Net.Http.HttpResponseMessage (PS 7+ exception .Response).
-function Get-HttpResponseDetails {
-  param(
-    [Parameter(Mandatory = $true)] $HttpResponseObject,
-    # Only used for HttpResponseMessage: PS 7+ disposes the content stream by the time we get here,
-    # so the body (when parseable) has to come from the caller's $ErrorRecord.ErrorDetails.Message instead.
-    [string] $ErrorDetailsMessage
-  )
-
-  $StringBuffer = [System.Text.StringBuilder]::new()
-  [void]$StringBuffer.AppendLine("`nResponse Type : $($HttpResponseObject.GetType().FullName)")
-
-  if ($HttpResponseObject -is [Microsoft.PowerShell.Commands.WebResponseObject]) {
-    # Direct return value of Invoke-WebRequest (e.g. HTTP 202/3xx) - Content is already a string.
-    [void]$StringBuffer.AppendLine("Status Code   : $([int]$HttpResponseObject.StatusCode)")
-    [void]$StringBuffer.AppendLine("Status Text   : $($HttpResponseObject.StatusDescription)")
-    [void]$StringBuffer.AppendLine("")
-    [void]$StringBuffer.AppendLine("=== Response Headers ===")
-    foreach ($HeaderName in $HttpResponseObject.Headers.Keys) {
-      [void]$StringBuffer.AppendLine("${HeaderName}: $($HttpResponseObject.Headers[$HeaderName])")
-    }
-    [void]$StringBuffer.AppendLine("")
-    [void]$StringBuffer.AppendLine("=== Raw Response Body ===")
-    [void]$StringBuffer.AppendLine($(if ([string]::IsNullOrWhiteSpace($HttpResponseObject.Content)) { "Empty response body." } else { $HttpResponseObject.Content }))
-  }
-  elseif ($HttpResponseObject.GetType().FullName -eq 'System.Net.Http.HttpResponseMessage') {
-    # PowerShell 7+ HttpResponseException.Response
-    [void]$StringBuffer.AppendLine("Status Code   : $([int]$HttpResponseObject.StatusCode)")
-    [void]$StringBuffer.AppendLine("Status Text   : $($HttpResponseObject.ReasonPhrase)")
-    [void]$StringBuffer.AppendLine("")
-    [void]$StringBuffer.AppendLine("=== Response Headers ===")
-    foreach ($Header in $HttpResponseObject.Headers) {
-      [void]$StringBuffer.AppendLine("$($Header.Key): $($Header.Value -join ', ')")
-    }
-    [void]$StringBuffer.AppendLine("")
-    [void]$StringBuffer.AppendLine("=== Raw Response Body ===")
-    [void]$StringBuffer.AppendLine($(if ([string]::IsNullOrWhiteSpace($ErrorDetailsMessage)) { "Empty response body." } else { $ErrorDetailsMessage }))
-  }
-  else {
-    # PowerShell 5.1 WebException.Response (System.Net.HttpWebResponse)
-    [void]$StringBuffer.AppendLine("Status Code   : $([int]$HttpResponseObject.StatusCode)")
-    [void]$StringBuffer.AppendLine("Status Text   : $($HttpResponseObject.StatusDescription)")
-    [void]$StringBuffer.AppendLine("Content Type  : $($HttpResponseObject.ContentType)")
-    [void]$StringBuffer.AppendLine("Content Length: $($HttpResponseObject.ContentLength)")
-    [void]$StringBuffer.AppendLine("")
-    [void]$StringBuffer.AppendLine("=== Response Headers ===")
-    foreach ($HeaderName in $HttpResponseObject.Headers.AllKeys) {
-      [void]$StringBuffer.AppendLine("${HeaderName}: $($HttpResponseObject.Headers[$HeaderName])")
-    }
-    [void]$StringBuffer.AppendLine("")
-    [void]$StringBuffer.AppendLine("=== Raw Response Body ===")
-    $HttpResponseStream = $HttpResponseObject.GetResponseStream()
-    if ($null -eq $HttpResponseStream) {
-      [void]$StringBuffer.AppendLine("No response stream in Error.Exception.Response object.")
-    }
-    else {
-      $HttpResponseReader = New-Object System.IO.StreamReader($HttpResponseStream)
-      try {
-        $ResponseBody = $HttpResponseReader.ReadToEnd()
-      }
-      finally {
-        $HttpResponseReader.Dispose()
-        $HttpResponseStream.Dispose()
-      }
-      [void]$StringBuffer.AppendLine($(if ([string]::IsNullOrWhiteSpace($ResponseBody)) { "Empty response body." } else { $ResponseBody }))
-    }
-  }
-
-  return $StringBuffer.ToString()
 }
 
 function Resolve-FunctionalTestPollingUri {


### PR DESCRIPTION
## 🗣 Description

Extracts the HTTP response error-formatting logic (previously named
Get-HttpResponseDetails) out of Invoke-ScubaRestMethod's inline catch
block in PowerShell/ScubaGear/Modules/Utility/Utility.psm1 and makes it
its own exported function in the same file. Invoke-ScubaRestMethod now
calls this function instead of duplicating the logic inline.

Testing/Functional/Products/FunctionalTestUtils.ps1 no longer defines
its own copy of Get-HttpResponseDetails - it now imports the one from
Utility.psm1 instead. No changes were needed in Products.Tests.ps1,
since FunctionalTestUtils.ps1 already imports Utility.psm1 directly at
the top of the file.

## 💭 Motivation and context

Closes #2402

PR #2342 fixed Get-HttpResponseDetails to correctly handle PowerShell
5.1 vs PowerShell 7 response object shapes (System.Net.HttpWebResponse
vs System.Net.Http.HttpResponseMessage), plus a case where PS 7 disposes
the response content stream before the error handler can read it. That
fix had to be applied twice, because the same logic existed as two
separate, independently-maintained copies - once inline in
Invoke-ScubaRestMethod, and once as a standalone function in
FunctionalTestUtils.ps1.

Utility.psm1 is already the natural home for this: every REST-based
provider helper (EXO, PowerPlatform, SecuritySuite, SharePoint, Teams)
already imports Invoke-ScubaRestMethod from there, so centralizing the
error-formatting logic in the same module means any future fix only
needs to happen once and automatically covers all current and future
REST-based providers, plus the functional test tooling.

## 🧪 Testing

Verified against real HTTP requests (a 401 response with a real JSON
body from the GitHub API) on both Windows PowerShell 5.1 and PowerShell
7.4 - identical, correct output to before the extraction on both
runtimes, with the original exception type and .Response property still
preserved for the caller.

Added a new unit test file, Get-HttpResponseDetails.Tests.ps1, covering
all three response shapes the function handles: HttpResponseMessage
(PS7), HttpWebResponse (PS 5.1, via a duck-typed fake since that type
has no public constructor), and WebResponseObject (via a real
lightweight request, since that type's assembly isn't resolvable
without a prior real Invoke-WebRequest call). All 6 tests pass on both
PowerShell 5.1 and PowerShell 7.4.

Ran the full relevant existing test surface after the change: 105/105
passing across Get-Utf8NoBom.Tests.ps1, Set-Utf8NoBom.Tests.ps1,
Invoke-FunctionalTestRestRequest.Tests.ps1 (confirms Pester's Mock still
works correctly against the now-imported function instead of a locally
defined one), and the EXO/PowerPlatform/SecuritySuite/SharePoint/Teams
provider test suites.

## ✅ Pre-approval checklist

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] These code changes follow the ScubaGear content style guide.
- [x] Related issues these changes resolve are linked preferably via closing keywords.
- [ ] All relevant type-of-change labels added.
- [ ] All relevant project fields are set.
- [ ] All relevant repo and/or project documentation updated to reflect these changes.
- [x] Unit tests added/updated to cover PowerShell and Rego changes.
- [ ] Functional tests added/updated to cover PowerShell and Rego changes.
- [ ] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.
